### PR TITLE
Fix broken GSWA IRI

### DIFF
--- a/vocabularies/Geoscience-units-of-measurement.ttl
+++ b/vocabularies/Geoscience-units-of-measurement.ttl
@@ -453,7 +453,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:altLabel
         "MBTU_Ml"@en ,
         "kBTU/ML"@en ;
-    skos:definition "A measure of oil quality or energy density defined as the energy in 1000 BTU (British Thermal Units; 1 055 000 J) per million litres."@en ;
+    skos:definition "A measure of oil quality or energy density defined as the energy in 1000 BTU (British Thermal Units; 1 055 000 J) per million litres."@en ;
     skos:inScheme cs: ;
     skos:notation "MBTU/Ml"^^xsd:token ;
     skos:prefLabel "thousand British thermal units per megalitre"@en ;
@@ -518,7 +518,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         "l_50 kg"@en ;
     skos:definition "A proportional concentration ratio typically used for cement mixtures. The number of litres of water added to 50 kg of additive(s)."@en ;
     skos:inScheme cs: ;
-    skos:notation "l/50 kg"^^xsd:token ;
+    skos:notation "l/50 kg"^^xsd:token ;
     skos:prefLabel "litres per 50 kg sack"@en ;
     skos:topConceptOf cs: ;
     schema:citation "http://linked.data.gov.au/def/geou/L-PER-50SACK"^^xsd:anyURI ;
@@ -543,10 +543,10 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <http://linked.data.gov.au/def/geou/LB_F-PER-100FT2>
     a skos:Concept ;
     rdfs:isDefinedBy <http://linked.data.gov.au/def/geou> ;
-    skos:altLabel "lbf_100 ft²"@en ;
-    skos:definition "Pounds force per 100 square feet (lbf/100 ft²) is a British (imperial) and US pressure unit. The number of pounds force applied to an area of 100 ft²."@en ;
+    skos:altLabel "lbf_100 ft²"@en ;
+    skos:definition "Pounds force per 100 square feet (lbf/100 ft²) is a British (imperial) and US pressure unit. The number of pounds force applied to an area of 100 ft²."@en ;
     skos:inScheme cs: ;
-    skos:notation "lbf/100 ft²"^^xsd:token ;
+    skos:notation "lbf/100 ft²"^^xsd:token ;
     skos:prefLabel "pounds force per 100 square feet"@en ;
     skos:topConceptOf cs: ;
     schema:citation "http://linked.data.gov.au/def/geou/LB_F-PER-100FT2"^^xsd:anyURI ;
@@ -570,10 +570,10 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <http://linked.data.gov.au/def/geou/LB_M-PER-100FT2>
     a skos:Concept ;
     rdfs:isDefinedBy <http://linked.data.gov.au/def/geou> ;
-    skos:altLabel "lb_100 ft²"@en ;
-    skos:definition "Pounds per 100 square feet (lb/100 ft²) is a British (imperial) and US pressure unit. The force equivalent to the number of pounds mass under standard gravity conditions applied to an area of 100 ft²."@en ;
+    skos:altLabel "lb_100 ft²"@en ;
+    skos:definition "Pounds per 100 square feet (lb/100 ft²) is a British (imperial) and US pressure unit. The force equivalent to the number of pounds mass under standard gravity conditions applied to an area of 100 ft²."@en ;
     skos:inScheme cs: ;
-    skos:notation "lb/100 ft²"^^xsd:token ;
+    skos:notation "lb/100 ft²"^^xsd:token ;
     skos:prefLabel "pounds per 100 square feet"@en ;
     skos:topConceptOf cs: ;
     schema:citation "http://linked.data.gov.au/def/geou/LB_M-PER-100FT2"^^xsd:anyURI ;
@@ -585,9 +585,9 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:altLabel
         "lb/50kg"@en ,
         "lb_50 kg"@en ;
-    skos:definition "A proportional concentration ratio typically used for cement mixtures. The number of pounds of water added to 50 kg of additive(s)."@en ;
+    skos:definition "A proportional concentration ratio typically used for cement mixtures. The number of pounds of water added to 50 kg of additive(s)."@en ;
     skos:inScheme cs: ;
-    skos:notation "lb/50 kg"^^xsd:token ;
+    skos:notation "lb/50 kg"^^xsd:token ;
     skos:prefLabel "pounds per 50 kg sack"@en ;
     skos:topConceptOf cs: ;
     schema:citation "http://linked.data.gov.au/def/geou/LB_M-PER-50SAC"^^xsd:anyURI ;
@@ -697,7 +697,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:altLabel
         "MMBTU/ML"@en ,
         "MMBTU_Ml"@en ;
-    skos:definition "A measure of oil quality or energy density defined as the energy in 1 000 000 British thermal units (BTU) (1 055 000 000 J) per million litres."@en ;
+    skos:definition "A measure of oil quality or energy density defined as the energy in 1 000 000 British thermal units (BTU) (1 055 000 000 J) per million litres."@en ;
     skos:inScheme cs: ;
     skos:notation "MMBTU/Ml"^^xsd:token ;
     skos:prefLabel "million British thermal units per megalitre"@en ;
@@ -775,7 +775,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <http://linked.data.gov.au/def/geou/MilliD>
     a skos:Concept ;
     rdfs:isDefinedBy <http://linked.data.gov.au/def/geou> ;
-    skos:definition "A measure of permeability. A medium with a permeability of 1 millidarcy (mD) permits a flow of 0.001 cm³/s of a fluid with viscosity 1 cP (1 mPa·s) under a pressure gradient of 1 atm/cm acting across an area of 1 cm²."@en ;
+    skos:definition "A measure of permeability. A medium with a permeability of 1 millidarcy (mD) permits a flow of 0.001 cm³/s of a fluid with viscosity 1 cP (1 mPa·s) under a pressure gradient of 1 atm/cm acting across an area of 1 cm²."@en ;
     skos:inScheme cs: ;
     skos:notation "md"^^xsd:token ;
     skos:prefLabel "millidarcy"@en ;
@@ -1011,7 +1011,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         "MOA"@en ,
         "minute arc"@en ,
         "minute of arc"@en ;
-    skos:definition "A minute of arc, arcminute, or minute arc (MOA), is a unit of angular measurement equal to one sixtieth (1/60) of one degree (circle/21 600), or π/10 800 radians. In turn, a second of arc or arcsecond is one sixtieth (1/60) of one minute of arc. Since one degree is defined as one three hundred and sixtieth (1/360) of a rotation, one minute of arc is 1/21 600 of a rotation. Prime (') is the symbol for the arcminute."@en ;
+    skos:definition "A minute of arc, arcminute, or minute arc (MOA), is a unit of angular measurement equal to one sixtieth (1/60) of one degree (circle/21 600), or π/10 800 radians. In turn, a second of arc or arcsecond is one sixtieth (1/60) of one minute of arc. Since one degree is defined as one three hundred and sixtieth (1/360) of a rotation, one minute of arc is 1/21 600 of a rotation. Prime (') is the symbol for the arcminute."@en ;
     skos:inScheme cs: ;
     skos:notation "'"^^<https://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
     skos:prefLabel "arcminute"@en ;
@@ -1025,7 +1025,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:altLabel
         "ARCSEC"@en ,
         "second of arc"@en ;
-    skos:definition "Arcsecond is a unit of angular measure, also called the second of arc, equal to 1/60 arcminute. One arcsecond is a very small angle: there are 1 296 000 in a circle. The International System of Units (SI) recommends double prime (ʺ) as the symbol for the arcsecond. The symbol has become common in astronomy, where very small angles are stated in milliarcseconds (mas)."@en ;
+    skos:definition "Arcsecond is a unit of angular measure, also called the second of arc, equal to 1/60 arcminute. One arcsecond is a very small angle: there are 1 296 000 in a circle. The International System of Units (SI) recommends double prime (ʺ) as the symbol for the arcsecond. The symbol has become common in astronomy, where very small angles are stated in milliarcseconds (mas)."@en ;
     skos:inScheme cs: ;
     skos:notation "\""^^<https://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
     skos:prefLabel "arcsecond"@en ;
@@ -1036,7 +1036,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <http://qudt.org/vocab/unit/ATM>
     a skos:Concept ;
     rdfs:isDefinedBy <http://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
-    skos:definition "The standard atmosphere (atm) is an international reference pressure defined as 101.325 kPa and formerly used as unit of pressure. For practical purposes it has been replaced by the bar which is 100 kPa. The difference of about 1% is not significant for many applications, and is within the error range of common pressure gauges."@en ;
+    skos:definition "The standard atmosphere (atm) is an international reference pressure defined as 101.325 kPa and formerly used as unit of pressure. For practical purposes it has been replaced by the bar which is 100 kPa. The difference of about 1% is not significant for many applications, and is within the error range of common pressure gauges."@en ;
     skos:inScheme cs: ;
     skos:notation "atm"^^<https://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
     skos:prefLabel "standard atmosphere"@en ;
@@ -1047,7 +1047,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <http://qudt.org/vocab/unit/BAR>
     a skos:Concept ;
     rdfs:isDefinedBy <https://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
-    skos:definition "The bar is a non-International System of Units (SI) unit of pressure, defined by the International Union of Pure and Applied Chemistry (IUPAC) as exactly equal to 100 000 Pa. It is about equal to the atmospheric pressure on Earth at sea level, and since 1982 the IUPAC has recommended that the standard for atmospheric pressure should be harmonized to 100 000 Pa = 1 bar ≈ 750.0616827 Torr. Units derived from the bar are the megabar (Mbar), kilobar (kbar), decibar (dbar), centibar (cbar) and millibar (mbar or mb). They are not part of either the SI or Centimetre–Gram–Second (CGS) system of units, but they are accepted for use with the SI."@en ;
+    skos:definition "The bar is a non-International System of Units (SI) unit of pressure, defined by the International Union of Pure and Applied Chemistry (IUPAC) as exactly equal to 100 000 Pa. It is about equal to the atmospheric pressure on Earth at sea level, and since 1982 the IUPAC has recommended that the standard for atmospheric pressure should be harmonized to 100 000 Pa = 1 bar ≈ 750.0616827 Torr. Units derived from the bar are the megabar (Mbar), kilobar (kbar), decibar (dbar), centibar (cbar) and millibar (mbar or mb). They are not part of either the SI or Centimetre–Gram–Second (CGS) system of units, but they are accepted for use with the SI."@en ;
     skos:inScheme cs: ;
     skos:notation "bar"^^<https://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
     skos:prefLabel "bar"@en ;
@@ -1131,7 +1131,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         "carat"@en ,
         "carats"@en ,
         "cts"@en ;
-    skos:definition "The carat is a unit of mass equal to 200 mg (0.2 g) and is used for measuring gemstones and pearls. The current definition, sometimes known as the metric carat, was adopted in 1907 at the Fourth General Conference on Weights and Measures, and soon afterward in many countries around the world. The carat is divisible into one hundred points of 2 mg each. Other subdivisions, and slightly different mass values, have been used in the past in different locations. In terms of diamonds, a paragon is a flawless stone of at least 100 carats (20 g). The ANSI X.12 EDI standard abbreviation for the carat is CD."@en ;
+    skos:definition "The carat is a unit of mass equal to 200 mg (0.2 g) and is used for measuring gemstones and pearls. The current definition, sometimes known as the metric carat, was adopted in 1907 at the Fourth General Conference on Weights and Measures, and soon afterward in many countries around the world. The carat is divisible into one hundred points of 2 mg each. Other subdivisions, and slightly different mass values, have been used in the past in different locations. In terms of diamonds, a paragon is a flawless stone of at least 100 carats (20 g). The ANSI X.12 EDI standard abbreviation for the carat is CD."@en ;
     skos:inScheme cs: ;
     skos:notation "ct"^^<https://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
     skos:prefLabel "carat"@en ;
@@ -1172,7 +1172,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:altLabel
         "CM2"@en ,
         "square centimeter"@en ;
-    skos:definition "A unit of area equal to that of a square of sides 1 cm."@en ;
+    skos:definition "A unit of area equal to that of a square of sides 1 cm."@en ;
     skos:inScheme cs: ;
     skos:notation "cm²"^^<https://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
     skos:prefLabel "square centimetre"@en ;
@@ -1407,7 +1407,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         "cm/s²"@en ,
         "cm_s²"@en ,
         "gal"@en ;
-    skos:definition "The galileo (or Gal) is the unit of acceleration of free fall used extensively in the science of gravimetry. The galileo is defined as 1 cm/s². Unfortunately, the galileo is often denoted with the symbol Gal, not to be confused with the gallon that also uses the same symbol (gal)."@en ;
+    skos:definition "The galileo (or Gal) is the unit of acceleration of free fall used extensively in the science of gravimetry. The galileo is defined as 1 cm/s². Unfortunately, the galileo is often denoted with the symbol Gal, not to be confused with the gallon that also uses the same symbol (gal)."@en ;
     skos:historyNote "https://en.wikipedia.org/wiki/Gal_(unit)" ;
     skos:inScheme cs: ;
     skos:notation "Gal"^^<https://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
@@ -1553,7 +1553,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy <http://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
     skos:altLabel "gr_UK"@en ;
-    skos:definition "A grain is a unit of measurement of mass that is nominally based upon the mass of a single seed of a cereal. The grain is the only unit of mass measure common to the three traditional English mass and weight systems; the obsolete Tower grain was, by definition, exactly 1/64 of a troy grain. Since 1958, the grain or troy grain measure has been defined in terms of units of mass in the International System of Units (SI) as precisely 64.79891 mg. Thus, 1 gm ≈ 15.4323584 grains. There are precisely 7000 grains per avoirdupois pound in the imperial and US customary units, and 5760 grains in the troy pound."@en ;
+    skos:definition "A grain is a unit of measurement of mass that is nominally based upon the mass of a single seed of a cereal. The grain is the only unit of mass measure common to the three traditional English mass and weight systems; the obsolete Tower grain was, by definition, exactly 1/64 of a troy grain. Since 1958, the grain or troy grain measure has been defined in terms of units of mass in the International System of Units (SI) as precisely 64.79891 mg. Thus, 1 gm ≈ 15.4323584 grains. There are precisely 7000 grains per avoirdupois pound in the imperial and US customary units, and 5760 grains in the troy pound."@en ;
     skos:inScheme cs: ;
     skos:notation "gr{UK}"^^<https://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
     skos:prefLabel "grain"@en ;
@@ -1587,7 +1587,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <http://qudt.org/vocab/unit/GigaBYTE>
     a skos:Concept ;
     rdfs:isDefinedBy <http://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
-    skos:definition "The gigabyte is a multiple of the unit byte for digital information storage. The prefix giga means 10⁹ in the International System of Units (SI), therefore 1 GB is 1 000 000 000 B. The unit symbol for the gigabyte is GB or Gbyte, but not Gb (lower case b) which is typically used for the gigabit. Historically, the term has also been used in some fields of computer science and information technology to denote the gibibyte, or 1073741824 B."@en ;
+    skos:definition "The gigabyte is a multiple of the unit byte for digital information storage. The prefix giga means 10⁹ in the International System of Units (SI), therefore 1 GB is 1 000 000 000 B. The unit symbol for the gigabyte is GB or Gbyte, but not Gb (lower case b) which is typically used for the gigabit. Historically, the term has also been used in some fields of computer science and information technology to denote the gibibyte, or 1073741824 B."@en ;
     skos:inScheme cs: ;
     skos:notation "GB"^^<https://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
     skos:prefLabel "gigabyte"@en ;
@@ -3851,7 +3851,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:topConceptOf cs: ;
 .
 
-<https://linked.data.g​ov.au/org/gswa>
+<https://linked.data.gov.au/org/gswa>
     a schema:Organization ;
     schema:name "Gswa" ;
     schema:url ""^^xsd:anyURI ;
@@ -4176,9 +4176,9 @@ cs:
                     schema:url ""^^xsd:anyURI ;
                 ] ;
         ] ;
-    schema:creator <https://linked.data.g​ov.au/org/gswa> ;
+    schema:creator <https://linked.data.gov.au/org/gswa> ;
     schema:dateCreated "2023-11-01"^^xsd:date ;
     schema:dateModified "2023-11-01"^^xsd:date ;
-    schema:publisher <https://linked.data.g​ov.au/org/gswa> ;
+    schema:publisher <https://linked.data.gov.au/org/gswa> ;
     schema:version "1" ;
 .

--- a/vocabularies/borehole-drilling-method.ttl
+++ b/vocabularies/borehole-drilling-method.ttl
@@ -79,7 +79,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     rdfs:isDefinedBy <http://resource.geosciml.org/classifierscheme/cgi/2016.01/boreholedrillingmethod> ;
     skos:altLabel "Delft continuous sampler"@en ;
     skos:definition "The Delft continuous sampler, developed by GeoDelft, is used for obtaining high quality samples within very soft cohesive soils. The sampling system is available in two sizes to take continuous samples, 29 or 66 mm in diameter, normally with a maximum penetration of about 18 m. A steel outer tube is pushed into the ground using standard CPT (cone penetrometer test) equipment and the soil sample core is fed into a thin-walled plastic inner tube as the sampler advances. After extraction, the samples are cut into 1 m lengths and placed in purpose-made cases, being retained in the plastic tubes."@en ;
-    skos:historyNote "Begemann, HKSP 1974, The delft continuous soilsampler: Bulletin of the International Association of Engineering Geology, v. 10, p. 35–37, doi:10.1007/BF02634629." ;
+    skos:historyNote "Begemann, HKSP 1974, The delft continuous soilsampler: Bulletin of the International Association of Engineering Geology, v. 10, p. 35–37, doi:10.1007/BF02634629." ;
     skos:inScheme cs: ;
     skos:prefLabel "Delft sampler"@en ;
     schema:citation
@@ -108,7 +108,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/direct_push>
     a skos:Concept ;
     rdfs:isDefinedBy <http://resource.geosciml.org/classifierscheme/cgi/2016.01/boreholedrillingmethod> ;
-    skos:definition "Direct push technology includes several types of drilling rigs and drilling equipment that advance a drillstring by pushing or hammering without rotating the drillstring. Direct push rigs include both cone penetration testing rigs and direct push sampling rigs such as a PowerProbe or Geoprobe. Direct push rigs typically are limited to drilling in unconsolidated soil materials and very soft rock. Direct push drilling rigs use hydraulic cylinders and a hydraulic hammer in advancing a hollow core sampler, typically no longer than 2 m, to gather soil and groundwater samples. The core pipe has a valve on top that is used to create a vacuum at the top of the core when pulling the core out of the sediment. The method can be used in up to 5 m of water."@en ;
+    skos:definition "Direct push technology includes several types of drilling rigs and drilling equipment that advance a drillstring by pushing or hammering without rotating the drillstring. Direct push rigs include both cone penetration testing rigs and direct push sampling rigs such as a PowerProbe or Geoprobe. Direct push rigs typically are limited to drilling in unconsolidated soil materials and very soft rock. Direct push drilling rigs use hydraulic cylinders and a hydraulic hammer in advancing a hollow core sampler, typically no longer than 2 m, to gather soil and groundwater samples. The core pipe has a valve on top that is used to create a vacuum at the top of the core when pulling the core out of the sediment. The method can be used in up to 5 m of water."@en ;
     skos:historyNote "CGI Borehole drilling method vocabulary" ;
     skos:inScheme cs: ;
     skos:narrower
@@ -154,7 +154,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/kasten_core>
     a skos:Concept ;
     rdfs:isDefinedBy <http://resource.geosciml.org/classifierscheme/cgi/2016.01/boreholedrillingmethod> ;
-    skos:definition "Large volume, relatively undisturbed sediment core (~3 m long) from a Kasten Corer. The corer is constructed of stainless steel and is square in cross-section. A weight of several hundred kilograms on top of the corer pushes it 2 to 3 m into the seabed."@en ;
+    skos:definition "Large volume, relatively undisturbed sediment core (~3 m long) from a Kasten Corer. The corer is constructed of stainless steel and is square in cross-section. A weight of several hundred kilograms on top of the corer pushes it 2 to 3 m into the seabed."@en ;
     skos:historyNote "CGI Borehole drilling method vocabulary" ;
     skos:inScheme cs: ;
     skos:prefLabel "Kasten core"@en ;
@@ -164,7 +164,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/mackereth_core>
     a skos:Concept ;
     rdfs:isDefinedBy <http://resource.geosciml.org/classifierscheme/cgi/2016.01/boreholedrillingmethod> ;
-    skos:definition "The Mackereth corer (Mackereth, 1958; Smith, 1959) is a pneumatic device that consists of a cylindrical aluminium chamber about 1.2 m long and 0.5 m in diameter. The apparatus is lowered to the lake floor on a rope, and air hoses connect the chamber to the vessel at the water surface. Compressed air is used to pump the water out of the chamber and then to force the inner core barrel downward through the chamber and into the sediment. The method can recover single-drive moderate (up to 12 m) cores from lakes of diverse depths. Mackereth cores can be deployed on virtually any small craft and can be used in water depths up to 100 m."@en ;
+    skos:definition "The Mackereth corer (Mackereth, 1958; Smith, 1959) is a pneumatic device that consists of a cylindrical aluminium chamber about 1.2 m long and 0.5 m in diameter. The apparatus is lowered to the lake floor on a rope, and air hoses connect the chamber to the vessel at the water surface. Compressed air is used to pump the water out of the chamber and then to force the inner core barrel downward through the chamber and into the sediment. The method can recover single-drive moderate (up to 12 m) cores from lakes of diverse depths. Mackereth cores can be deployed on virtually any small craft and can be used in water depths up to 100 m."@en ;
     skos:historyNote "CGI Borehole drilling method vocabulary" ;
     skos:inScheme cs: ;
     skos:prefLabel "Mackereth core"@en ;
@@ -174,7 +174,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/mackintosh_probe>
     a skos:Concept ;
     rdfs:isDefinedBy <http://resource.geosciml.org/classifierscheme/cgi/2016.01/boreholedrillingmethod> ;
-    skos:definition "The Mackintosh tool consists of rods that can be threaded together with barrel connectors and which are normally fitted with a driving point at their base, and a light hand-operated driving hammer at their top. The tool provides a very economical method of determining the thickness of soft deposits such as peat. The driving point is streamlined in longitudinal section with a maximum diameter of 27 mm. The drive hammer has a total weight of about 4 kg. The rods are 1.2 m long and 12 mm diameter. The device is often used to provide a depth profile by driving the point and rods into the ground with equal blows of the full drop height available from the hammer: the number of blows for each 150 mm of penetration is recorded."@en ;
+    skos:definition "The Mackintosh tool consists of rods that can be threaded together with barrel connectors and which are normally fitted with a driving point at their base, and a light hand-operated driving hammer at their top. The tool provides a very economical method of determining the thickness of soft deposits such as peat. The driving point is streamlined in longitudinal section with a maximum diameter of 27 mm. The drive hammer has a total weight of about 4 kg. The rods are 1.2 m long and 12 mm diameter. The device is often used to provide a depth profile by driving the point and rods into the ground with equal blows of the full drop height available from the hammer: the number of blows for each 150 mm of penetration is recorded."@en ;
     skos:historyNote "Clayton, CRI, Matthews, MC, and Simons, NE 1995, Site investigation: A Handbook for engineers: Blackwell Science, Oxford, 584p." ;
     skos:inScheme cs: ;
     skos:prefLabel "Mackintosh probe"@en ;
@@ -201,7 +201,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         "SON"@en ,
         "sonic drilling"@en ,
         "vibratory"@en ;
-    skos:definition "A sonic or vibratory drillhead works by sending high-frequency resonant vibrations down the drillstring to the drillbit, while the operator controls these frequencies to suit the specific conditions of the soil/rock geology. Vibrations may also be generated within the drillhead. The frequency is generally between 50 and 180 Hz (cycles per second) and can be varied by the operator. Resonance magnifies the amplitude of the drillbit, which fluidizes the soil particles at the bit face, allowing for fast and easy penetration through most geological formations. An internal spring system isolates these vibrational forces from the rest of the drill rig."@en ;
+    skos:definition "A sonic or vibratory drillhead works by sending high-frequency resonant vibrations down the drillstring to the drillbit, while the operator controls these frequencies to suit the specific conditions of the soil/rock geology. Vibrations may also be generated within the drillhead. The frequency is generally between 50 and 180 Hz (cycles per second) and can be varied by the operator. Resonance magnifies the amplitude of the drillbit, which fluidizes the soil particles at the bit face, allowing for fast and easy penetration through most geological formations. An internal spring system isolates these vibrational forces from the rest of the drill rig."@en ;
     skos:historyNote "Powersd, JP, Corwin, AB, Schmall, PC and Kaeck, WE 2007, Construction dewatering and groundwater control: New Methods and Applications, Third edition: John Wyley and Sons Inc., 624p." ;
     skos:inScheme cs: ;
     skos:notation "SON"^^xsd:token ;
@@ -254,7 +254,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:altLabel "Caldwell bucket drilling"@en ;
-    skos:definition "A proprietary drilling method commonly used in opal mining, and more recently potash mining, involving a large rotating bucket on the end of a drillstem. Used for large diameter open holes up to 3 m wide. Also known as Calweld bucket drilling. The name originates from the California Welding Company that originally produced the rigs."@en ;
+    skos:definition "A proprietary drilling method commonly used in opal mining, and more recently potash mining, involving a large rotating bucket on the end of a drillstem. Used for large diameter open holes up to 3 m wide. Also known as Calweld bucket drilling. The name originates from the California Welding Company that originally produced the rigs."@en ;
     skos:inScheme cs: ;
     skos:prefLabel "Calweld"@en ;
     schema:citation "https://www.opalquest.com/blogs/news/mining-methods-equipment"^^xsd:anyURI ;
@@ -280,7 +280,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:altLabel "bucket auger"@en ;
-    skos:definition "The bucket rig is a form of the rotary drill rig. It uses mechanical or hydraulic drive to rotate a kelly (i.e. a steel bar with a hole drilled through the middle for a fluid path) which is attached to the bucket. This type of rig normally utilizes a square friction type or round locking type kelly with three or four telescoping sections which can extend to 30 m or more. Bucket rigs may be equipped to drill holes from 25.4 cm to 152.4 cm in diameter. Bucket drilling uses a cylindrical bucket with cutting blades or teeth mounted on a hinged bottom to repeatedly cut and lift sediments from the borehole. To drill, the bucket is rotated to allow the bottom of the cutting teeth to fill the bucket. When the bucket is full, it is raised by cable."@en ;
+    skos:definition "The bucket rig is a form of the rotary drill rig. It uses mechanical or hydraulic drive to rotate a kelly (i.e. a steel bar with a hole drilled through the middle for a fluid path) which is attached to the bucket. This type of rig normally utilizes a square friction type or round locking type kelly with three or four telescoping sections which can extend to 30 m or more. Bucket rigs may be equipped to drill holes from 25.4 cm to 152.4 cm in diameter. Bucket drilling uses a cylindrical bucket with cutting blades or teeth mounted on a hinged bottom to repeatedly cut and lift sediments from the borehole. To drill, the bucket is rotated to allow the bottom of the cutting teeth to fill the bucket. When the bucket is full, it is raised by cable."@en ;
     skos:inScheme cs: ;
     skos:narrower
         :Bauer-bucket ,
@@ -449,7 +449,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         "RC"@en ,
         "RC hammer drilling"@en ,
         "reverse circulation drilling"@en ;
-    skos:definition "The drilling mechanism for reverse circulation (RC) drilling is a pneumatic reciprocating piston known as a 'hammer' driving a tungsten-steel drillbit. Compressed air passes down to the drillbit along the annular space between an outer and inner drill rod to return to the surface inside the rods carrying drill cuttings. This is the reverse of the air path employed in normal ‘open hole’ rotary percussion drilling (including RAB drilling). At the top of the hole, the air and drill cuttings are passed through a cyclone to collect the cuttings for sampling. The RC drilling technique prevents the upcoming sample from being contaminated with material from the wall of the hole above the sampling depth. RC drilling utilizes much larger rigs and machinery and comparatively higher air pressure. Depths of up to 500 m are routinely achieved."@en ;
+    skos:definition "The drilling mechanism for reverse circulation (RC) drilling is a pneumatic reciprocating piston known as a 'hammer' driving a tungsten-steel drillbit. Compressed air passes down to the drillbit along the annular space between an outer and inner drill rod to return to the surface inside the rods carrying drill cuttings. This is the reverse of the air path employed in normal ‘open hole’ rotary percussion drilling (including RAB drilling). At the top of the hole, the air and drill cuttings are passed through a cyclone to collect the cuttings for sampling. The RC drilling technique prevents the upcoming sample from being contaminated with material from the wall of the hole above the sampling depth. RC drilling utilizes much larger rigs and machinery and comparatively higher air pressure. Depths of up to 500 m are routinely achieved."@en ;
     skos:exactMatch <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/reverse_circulation_drilling> ;
     skos:inScheme cs: ;
     skos:notation "RC"^^xsd:token ;
@@ -538,7 +538,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:altLabel
         "VAC"@en ,
         "vacuum drilling"@en ;
-    skos:definition "Vacuum drilling is principally designed for mineral exploration drilling to provide a low-cost, efficient recovery of uncontaminated drill samples. Vacuum drilling uses a tungsten carbide tipped blade bit to make the hole. The cuttings are then ‘sucked’ up the drillpipe using an industrial vacuum pump. The sample is separated from the air flow through a sealed cyclone into a transparent collection (vacuum) flask. Any remaining fine material is removed by a secondary filter before the air passes through the vacuum pump and vented to the atmosphere. In softer material, drilling with this method is a fast, accurate and economical method of obtaining samples. Although hole depths of 50 m or more have been recorded, most are less than 10 m."@en ;
+    skos:definition "Vacuum drilling is principally designed for mineral exploration drilling to provide a low-cost, efficient recovery of uncontaminated drill samples. Vacuum drilling uses a tungsten carbide tipped blade bit to make the hole. The cuttings are then ‘sucked’ up the drillpipe using an industrial vacuum pump. The sample is separated from the air flow through a sealed cyclone into a transparent collection (vacuum) flask. Any remaining fine material is removed by a secondary filter before the air passes through the vacuum pump and vented to the atmosphere. In softer material, drilling with this method is a fast, accurate and economical method of obtaining samples. Although hole depths of 50 m or more have been recorded, most are less than 10 m."@en ;
     skos:exactMatch <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/vacuum> ;
     skos:historyNote "Australian Drilling Industry Association 2018, Chapter 3, The Drilling Manual, Sixth edition: Australian Drilling Industry Association, p. 214." ;
     skos:inScheme cs: ;
@@ -558,7 +558,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:citation "https://en.wikipedia.org/wiki/Core_drill"^^xsd:anyURI ;
 .
 
-<https://linked.data.g​ov.au/org/gswa>
+<https://linked.data.gov.au/org/gswa>
     a schema:Organization ;
     schema:name "Gswa" ;
     schema:url ""^^xsd:anyURI ;
@@ -595,9 +595,9 @@ cs:
                     schema:url ""^^xsd:anyURI ;
                 ] ;
         ] ;
-    schema:creator <https://linked.data.g​ov.au/org/gswa> ;
+    schema:creator <https://linked.data.gov.au/org/gswa> ;
     schema:dateCreated "2023-10-25"^^xsd:date ;
     schema:dateModified "2023-10-25"^^xsd:date ;
-    schema:publisher <https://linked.data.g​ov.au/org/gswa> ;
+    schema:publisher <https://linked.data.gov.au/org/gswa> ;
     schema:version "1.0" ;
 .

--- a/vocabularies/location-method.ttl
+++ b/vocabularies/location-method.ttl
@@ -12,7 +12,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 :100k-geological-map-mga
     a skos:Concept ;
-    skos:definition "Geographical location determined from published 1:100 000 geological maps, typically with an accuracy of about 100 m. Captured as Map Grid of Australia (MGA) 1994 coordinates."@en ;
+    skos:definition "Geographical location determined from published 1:100 000 geological maps, typically with an accuracy of about 100 m. Captured as Map Grid of Australia (MGA) 1994 coordinates."@en ;
     skos:historyNote "Used by GSWA to capture locations of legacy geological observations or exploration/mining/infrastructure sites." ;
     skos:inScheme cs: ;
     skos:prefLabel "1:100 000 geological map (MGA)"@en ;
@@ -20,7 +20,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 :100k-topographic-map-mga
     a skos:Concept ;
-    skos:definition "Geographical location determined from published 1:100 000 topographic maps, typically with an accuracy of about 100 m. Captured as Map Grid of Australia (MGA) 1994 coordinates."@en ;
+    skos:definition "Geographical location determined from published 1:100 000 topographic maps, typically with an accuracy of about 100 m. Captured as Map Grid of Australia (MGA) 1994 coordinates."@en ;
     skos:historyNote "Used by GSWA to capture locations of legacy geological observations or exploration/mining/infrastructure sites." ;
     skos:inScheme cs: ;
     skos:prefLabel "1:100 000 topographic map (MGA)"@en ;
@@ -28,7 +28,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 :1M-geological-map-mga
     a skos:Concept ;
-    skos:definition "Geographical location determined from published 1:1 000 000 geological maps, typically with an accuracy of about 1000 m (1 kilometre). Captured as Map Grid of Australia (MGA) 1994 coordinates."@en ;
+    skos:definition "Geographical location determined from published 1:1 000 000 geological maps, typically with an accuracy of about 1000 m (1 kilometre). Captured as Map Grid of Australia (MGA) 1994 coordinates."@en ;
     skos:historyNote "Used by GSWA to capture locations of legacy geological observations or exploration/mining/infrastructure sites." ;
     skos:inScheme cs: ;
     skos:prefLabel "1:1 000 000 geological map (MGA)"@en ;
@@ -36,7 +36,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 :1M-topographic-map-mga
     a skos:Concept ;
-    skos:definition "Geographical location determined from published 1:1 000 000 topographic maps, typically with an accuracy of about 1000 m (1 kilometre). Captured as Map Grid of Australia (MGA) 1994 coordinates."@en ;
+    skos:definition "Geographical location determined from published 1:1 000 000 topographic maps, typically with an accuracy of about 1000 m (1 kilometre). Captured as Map Grid of Australia (MGA) 1994 coordinates."@en ;
     skos:historyNote "Used by GSWA to capture locations of legacy geological observations or exploration/mining/infrastructure sites." ;
     skos:inScheme cs: ;
     skos:prefLabel "1:1 000 000 topographic map (MGA)"@en ;
@@ -44,7 +44,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 :250k-geological-map-mga
     a skos:Concept ;
-    skos:definition "Geographical location determined from published 1:250 000 geological maps, typically with an accuracy of about 250 m. Captured as Map Grid of Australia (MGA) 1994 coordinates."@en ;
+    skos:definition "Geographical location determined from published 1:250 000 geological maps, typically with an accuracy of about 250 m. Captured as Map Grid of Australia (MGA) 1994 coordinates."@en ;
     skos:historyNote "Used by GSWA to capture locations of legacy geological observations or exploration/mining/infrastructure sites." ;
     skos:inScheme cs: ;
     skos:prefLabel "1:250 000 geological map (MGA)"@en ;
@@ -52,7 +52,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 :250k-topographic-map-mga
     a skos:Concept ;
-    skos:definition "Geographical location determined from published 1:250 000 topographic maps, typically with an accuracy of about 250 m. Captured as Map Grid of Australia (MGA) 1994 coordinates."@en ;
+    skos:definition "Geographical location determined from published 1:250 000 topographic maps, typically with an accuracy of about 250 m. Captured as Map Grid of Australia (MGA) 1994 coordinates."@en ;
     skos:historyNote "Used by GSWA to capture locations of legacy geological observations or exploration/mining/infrastructure sites." ;
     skos:inScheme cs: ;
     skos:prefLabel "1:250 000 topographic map (MGA)"@en ;
@@ -60,7 +60,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 :25k-geological-map-mga
     a skos:Concept ;
-    skos:definition "Geographical location determined from published 1:25 000 geological maps, typically with an accuracy of about 25 m. Captured as Map Grid of Australia (MGA) 1994 coordinates."@en ;
+    skos:definition "Geographical location determined from published 1:25 000 geological maps, typically with an accuracy of about 25 m. Captured as Map Grid of Australia (MGA) 1994 coordinates."@en ;
     skos:historyNote "Used by GSWA to capture locations of legacy geological observations or exploration/mining/infrastructure sites." ;
     skos:inScheme cs: ;
     skos:prefLabel "1:25 000 geological map (MGA)"@en ;
@@ -68,7 +68,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 :25k-topographic-map-mga
     a skos:Concept ;
-    skos:definition "Geographical location determined from published 1:25 000 topographic maps, typically with an accuracy of about 25 m. Captured as Map Grid of Australia (MGA) 1994 coordinates."@en ;
+    skos:definition "Geographical location determined from published 1:25 000 topographic maps, typically with an accuracy of about 25 m. Captured as Map Grid of Australia (MGA) 1994 coordinates."@en ;
     skos:historyNote "Used by GSWA to capture locations of legacy geological observations or exploration/mining/infrastructure sites." ;
     skos:inScheme cs: ;
     skos:prefLabel "1:25 000 topographic map (MGA)"@en ;
@@ -76,7 +76,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 :500k-geological-map-mga
     a skos:Concept ;
-    skos:definition "Geographical location determined from published 1:500 000 geological maps, typically with an accuracy of about 500 m. Captured as Map Grid of Australia (MGA) 1994 coordinates."@en ;
+    skos:definition "Geographical location determined from published 1:500 000 geological maps, typically with an accuracy of about 500 m. Captured as Map Grid of Australia (MGA) 1994 coordinates."@en ;
     skos:historyNote "Used by GSWA to capture locations of legacy geological observations or exploration/mining/infrastructure sites." ;
     skos:inScheme cs: ;
     skos:prefLabel "1:500 000 geological map (MGA)"@en ;
@@ -84,7 +84,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 :500k-topographic-map-mga
     a skos:Concept ;
-    skos:definition "Geographical location determined from published 1:500 000 topographic maps, typically with an accuracy of about 500 m. Captured as Map Grid of Australia (MGA) 1994 coordinates."@en ;
+    skos:definition "Geographical location determined from published 1:500 000 topographic maps, typically with an accuracy of about 500 m. Captured as Map Grid of Australia (MGA) 1994 coordinates."@en ;
     skos:historyNote "Used by GSWA to capture locations of legacy geological observations or exploration/mining/infrastructure sites." ;
     skos:inScheme cs: ;
     skos:prefLabel "1:500 000 topographic map (MGA)"@en ;
@@ -92,7 +92,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 :50k-geological-map-mga
     a skos:Concept ;
-    skos:definition "Geographical location determined from published 1:50 000 geological maps, typically with an accuracy of about 50 m. Captured as Map Grid of Australia (MGA) 1994 coordinates."@en ;
+    skos:definition "Geographical location determined from published 1:50 000 geological maps, typically with an accuracy of about 50 m. Captured as Map Grid of Australia (MGA) 1994 coordinates."@en ;
     skos:historyNote "Used by GSWA to capture locations of legacy geological observations or exploration/mining/infrastructure sites." ;
     skos:inScheme cs: ;
     skos:prefLabel "1:50 000 geological map (MGA)"@en ;
@@ -100,7 +100,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 :50k-topographic-map-mga
     a skos:Concept ;
-    skos:definition "Geographical location determined from published 1:50 000 topographic maps, typically with an accuracy of about 50 m. Captured as Map Grid of Australia (MGA) 1994 coordinates."@en ;
+    skos:definition "Geographical location determined from published 1:50 000 topographic maps, typically with an accuracy of about 50 m. Captured as Map Grid of Australia (MGA) 1994 coordinates."@en ;
     skos:historyNote "Used by GSWA to capture locations of legacy geological observations or exploration/mining/infrastructure sites." ;
     skos:inScheme cs: ;
     skos:prefLabel "1:50 000 topographic map (MGA)"@en ;
@@ -108,7 +108,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 :airphoto-alos-mga
     a skos:Concept ;
-    skos:definition "Geographical location of points marked on hardcopy airphotos (or images thereof) determined by visual comparison with georeferenced imagery acquired by the Advanced Land Observing Satellite (ALOS; https://earth.esa.int/eogateway/missions/alos). Captured as Map Grid of Australia (MGA) 1994 coordinates. Accuracy is typically within 25 m."@en ;
+    skos:definition "Geographical location of points marked on hardcopy airphotos (or images thereof) determined by visual comparison with georeferenced imagery acquired by the Advanced Land Observing Satellite (ALOS; https://earth.esa.int/eogateway/missions/alos). Captured as Map Grid of Australia (MGA) 1994 coordinates. Accuracy is typically within 25 m."@en ;
     skos:historyNote "Used by GSWA to capture locations of legacy geological observations or exploration/mining/infrastructure sites." ;
     skos:inScheme cs: ;
     skos:prefLabel "capture from airphoto using ALOS (MGA)"@en ;
@@ -117,7 +117,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 :airphoto-landsat-tm-mga
     a skos:Concept ;
-    skos:definition "Geographical location of points marked on hardcopy airphotos (or images thereof) determined by determined visual comparison with georeferenced imagery acquired by NASA's Landsat Thematic Mapper (TM ) satellites. Captured as Map Grid of Australia (MGA) 1994 coordinates. Accuracy is typically within 25 m."@en ;
+    skos:definition "Geographical location of points marked on hardcopy airphotos (or images thereof) determined by determined visual comparison with georeferenced imagery acquired by NASA's Landsat Thematic Mapper (TM ) satellites. Captured as Map Grid of Australia (MGA) 1994 coordinates. Accuracy is typically within 25 m."@en ;
     skos:historyNote "Used by GSWA to capture locations of legacy geological observations or exploration/mining/infrastructure sites." ;
     skos:inScheme cs: ;
     skos:prefLabel "capture from airphoto using Landsat TM (MGA)"@en ;
@@ -129,7 +129,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:altLabel
         "aerial photograph (MGA)"@en ,
         "air photo (MGA)"@en ;
-    skos:definition "Geographical location of points marked on hardcopy airphotos (or images thereof) determined by visual comparison with georeferenced imagery. Captured as Map Grid of Australia (MGA) 1994 coordinates. Accuracy varies from 5 to 100 m."@en ;
+    skos:definition "Geographical location of points marked on hardcopy airphotos (or images thereof) determined by visual comparison with georeferenced imagery. Captured as Map Grid of Australia (MGA) 1994 coordinates. Accuracy varies from 5 to 100 m."@en ;
     skos:historyNote "Used by GSWA to capture locations of geological observations or exploration/mining/infrastructure sites." ;
     skos:inScheme cs: ;
     skos:narrower
@@ -153,7 +153,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 :airphoto-spot-p-mga
     a skos:Concept ;
-    skos:definition "Geographical location of points marked on hardcopy airphotos (or images thereof) determined by visual comparison with georeferenced imagery acquired by Satellite Pour l'Observation de la Terre (SPOT P), a commercial satellite imaging system which uses a Panchromatic sensor to capture highly detailed black and white images. Captured as Map Grid of Australia (MGA) 1994 coordinates. Accuracy is typically 25 m."@en ;
+    skos:definition "Geographical location of points marked on hardcopy airphotos (or images thereof) determined by visual comparison with georeferenced imagery acquired by Satellite Pour l'Observation de la Terre (SPOT P), a commercial satellite imaging system which uses a Panchromatic sensor to capture highly detailed black and white images. Captured as Map Grid of Australia (MGA) 1994 coordinates. Accuracy is typically 25 m."@en ;
     skos:historyNote "Used by GSWA to capture locations of legacy geological observations or exploration/mining/infrastructure sites." ;
     skos:inScheme cs: ;
     skos:prefLabel "capture from airphoto using SPOT P (MGA)"@en ;
@@ -228,7 +228,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         "DGPS"@en ,
         "Differential GPS"@en ,
         "Differential Global Positioning System"@en ;
-    skos:definition "Geographical location acquired with a Differential Global Positioning System (DGPS), i.e. a receiver instrument that utilises a network of fixed-position, ground-based reference stations that calculate the difference between their highly accurate known position and their less accurate satellite-derived position, thereby increasing the accuracy compared to a Global Positioning System that only utilises satellite stations. Accuracy varies from 15 m to a few centimetres, but it is commonly within 1 m. Captured using the World Geodetic System 1984 or, in Australia, the Geocentric Datum of Australia 1994."@en ;
+    skos:definition "Geographical location acquired with a Differential Global Positioning System (DGPS), i.e. a receiver instrument that utilises a network of fixed-position, ground-based reference stations that calculate the difference between their highly accurate known position and their less accurate satellite-derived position, thereby increasing the accuracy compared to a Global Positioning System that only utilises satellite stations. Accuracy varies from 15 m to a few centimetres, but it is commonly within 1 m. Captured using the World Geodetic System 1984 or, in Australia, the Geocentric Datum of Australia 1994."@en ;
     skos:historyNote "Used by GSWA to capture locations of geological observations or exploration/mining/infrastructure sites." ;
     skos:inScheme cs: ;
     skos:prefLabel "Differential GPS (WGS-84/GDA-94)"@en ;
@@ -275,7 +275,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 :external-database
     a skos:Concept ;
-    skos:definition "Geographical location derived from a database source external to that of the organisation recording the observation. Accuracy is estimated to be within 100 m."@en ;
+    skos:definition "Geographical location derived from a database source external to that of the organisation recording the observation. Accuracy is estimated to be within 100 m."@en ;
     skos:historyNote "Used by GSWA to capture locations of geological observations or exploration/mining/infrastructure sites." ;
     skos:inScheme cs: ;
     skos:prefLabel "external database (WGS/GDA)"@en ;
@@ -283,7 +283,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 :ga-common-earth-model
     a skos:Concept ;
-    skos:definition "Geographical location based on Geoscience Australia (GA) Common Earth Model, a unified representation of Australia's geology that allows users to explore geological aspects of an area in detail. Accuracy estimated to be around 100 m."@en ;
+    skos:definition "Geographical location based on Geoscience Australia (GA) Common Earth Model, a unified representation of Australia's geology that allows users to explore geological aspects of an area in detail. Accuracy estimated to be around 100 m."@en ;
     skos:historyNote "Geoscience Australia's Common Earth Model is a collection of data compiled from various sources that aims to give a unified overview of the geology of Australia. The data are visualised in the Geoscience Australia 3D Data Viewer software, enabling users to interactively explore and analyze the geological features and formations of different locations across Australia." ;
     skos:inScheme cs: ;
     skos:prefLabel "GA Common Earth Model (WGS-84)"@en ;
@@ -310,8 +310,8 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 :google-earth
     a skos:Concept ;
-    skos:definition "Geographical location determined from Google Earth, a virtual model of Earth which uses the World Geodetic System 1984 (WGS-84) as its coordinate system. Typically accurate to 50 m."@en ;
-    skos:historyNote "Used by GSWA to capture locations of geological observations or exploration/mining/infrastructure sites. Google Earth is a computer program that renders a 3D representation of Earth based primarily on satellite imagery. The program maps the Earth by superimposing satellite images, aerial photography, and GIS data onto a 3D globe, allowing users to see cities and landscapes from various angles." ;
+    skos:definition "Geographical location determined from Google Earth, a virtual model of Earth which uses the World Geodetic System 1984 (WGS-84) as its coordinate system. Typically accurate to 50 m."@en ;
+    skos:historyNote "Used by GSWA to capture locations of geological observations or exploration/mining/infrastructure sites. Google Earth is a computer program that renders a 3D representation of Earth based primarily on satellite imagery. The program maps the Earth by superimposing satellite images, aerial photography, and GIS data onto a 3D globe, allowing users to see cities and landscapes from various angles." ;
     skos:inScheme cs: ;
     skos:prefLabel "Google Earth (WGS-84)"@en ;
     skos:topConceptOf cs: ;
@@ -556,7 +556,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:prefLabel "unpublished report (MGA/WGS/GDA)"@en ;
 .
 
-<https://linked.data.g​ov.au/org/gswa>
+<https://linked.data.gov.au/org/gswa>
     a schema:Organization ;
     schema:name "Gswa" ;
     schema:url ""^^xsd:anyURI ;
@@ -608,10 +608,10 @@ cs:
                     schema:url ""^^xsd:anyURI ;
                 ] ;
         ] ;
-    schema:creator <https://linked.data.g​ov.au/org/gswa> ;
+    schema:creator <https://linked.data.gov.au/org/gswa> ;
     schema:dateCreated "2022-11-23"^^xsd:date ;
     schema:dateModified "2022-11-23"^^xsd:date ;
     schema:keywords "Geodesy" ;
-    schema:publisher <https://linked.data.g​ov.au/org/gswa> ;
+    schema:publisher <https://linked.data.gov.au/org/gswa> ;
     schema:version "1" ;
 .


### PR DESCRIPTION
Some of the IRIs for GSWA still have the invisible whitespace character in them. This PR removes them from all vocabs and also removes other invisible whitespace chars I found.

I assume that these are still artifacts from VocExcel and copy 'n past text from other docs, so I will have to look back into the VocExcel templates to try and clean up.