### PR TITLE
Replace isoroles with dataroles

### DIFF
--- a/vocabularies/CRIRSCO-resource-reporting.ttl
+++ b/vocabularies/CRIRSCO-resource-reporting.ttl
@@ -1,6 +1,6 @@
 PREFIX cs: <https://linked.data.gov.au/def/CRIRSCO-mineral-resource-reporting>
 PREFIX dcat: <http://www.w3.org/ns/dcat#>
-PREFIX isoroles: <http://def.isotc211.org/iso19115/-1/2018/CitationAndResponsiblePartyInformation/code/CI_RoleCode/>
+PREFIX dataroles: <https://linked.data.gov.au/def/data-roles/>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
@@ -235,7 +235,7 @@ The CRIRSCO Code is closely related to the JORC Code used in Australasia to repo
     skos:prefLabel "CRIRSCO mineral resource reporting"@en ;
     prov:qualifiedAttribution
         [
-            dcat:hadRole isoroles:custodian ;
+            dcat:hadRole dataroles:custodian ;
             prov:agent
                 [
                     a schema:Organization ;
@@ -244,7 +244,7 @@ The CRIRSCO Code is closely related to the JORC Code used in Australasia to repo
                 ] ;
         ] ,
         [
-            dcat:hadRole isoroles:custodian ;
+            dcat:hadRole dataroles:custodian ;
             prov:agent
                 [
                     a schema:Organization ;

--- a/vocabularies/Geoscience-units-of-measurement.ttl
+++ b/vocabularies/Geoscience-units-of-measurement.ttl
@@ -1,7 +1,7 @@
 PREFIX : <https://linked.data.gov.au/def/uom-geoscience/>
 PREFIX cs: <https://linked.data.gov.au/def/uom-geoscience>
 PREFIX dcat: <http://www.w3.org/ns/dcat#>
-PREFIX isoroles: <http://def.isotc211.org/iso19115/-1/2018/CitationAndResponsiblePartyInformation/code/CI_RoleCode/>
+PREFIX dataroles: <https://linked.data.gov.au/def/data-roles/>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
@@ -4159,7 +4159,7 @@ cs:
     skos:prefLabel "Geoscience units of measurement"@en ;
     prov:qualifiedAttribution
         [
-            dcat:hadRole isoroles:custodian ;
+            dcat:hadRole dataroles:custodian ;
             prov:agent
                 [
                     a schema:Organization ;
@@ -4168,7 +4168,7 @@ cs:
                 ] ;
         ] ,
         [
-            dcat:hadRole isoroles:custodian ;
+            dcat:hadRole dataroles:custodian ;
             prov:agent
                 [
                     a schema:Organization ;

--- a/vocabularies/JORC-resource-reporting.ttl
+++ b/vocabularies/JORC-resource-reporting.ttl
@@ -1,7 +1,7 @@
 PREFIX : <https://linked.data.gov.au/def/JORC-Code/>
 PREFIX cs: <https://linked.data.gov.au/def/JORC-Code>
 PREFIX dcat: <http://www.w3.org/ns/dcat#>
-PREFIX isoroles: <http://def.isotc211.org/iso19115/-1/2018/CitationAndResponsiblePartyInformation/code/CI_RoleCode/>
+PREFIX dataroles: <https://linked.data.gov.au/def/data-roles/>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
@@ -221,7 +221,7 @@ The JORC Code vocabulary covers [MINEDEX].[ResourceEstimate.ResourceCategory], i
     skos:prefLabel "JORC Code"@en ;
     prov:qualifiedAttribution
         [
-            dcat:hadRole isoroles:custodian ;
+            dcat:hadRole dataroles:custodian ;
             prov:agent
                 [
                     a schema:Organization ;
@@ -230,7 +230,7 @@ The JORC Code vocabulary covers [MINEDEX].[ResourceEstimate.ResourceCategory], i
                 ] ;
         ] ,
         [
-            dcat:hadRole isoroles:custodian ;
+            dcat:hadRole dataroles:custodian ;
             prov:agent
                 [
                     a schema:Organization ;

--- a/vocabularies/australian-physiographic-units.ttl
+++ b/vocabularies/australian-physiographic-units.ttl
@@ -3,7 +3,7 @@ PREFIX agldwgstatus: <https://linked.data.gov.au/def/reg-statuses/>
 PREFIX cs: <https://linked.data.gov.au/def/australian-physiographic-units>
 PREFIX dcat: <http://www.w3.org/ns/dcat#>
 PREFIX dcterms: <http://purl.org/dc/terms/>
-PREFIX isoroles: <http://def.isotc211.org/iso19115/-1/2018/CitationAndResponsiblePartyInformation/code/CI_RoleCode/>
+PREFIX dataroles: <https://linked.data.gov.au/def/data-roles/>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
@@ -3250,14 +3250,14 @@ cs:
     skos:prefLabel "Australian physiographic units"@en ;
     prov:qualifiedAttribution
         [
-            dcat:hadRole isoroles:custodian ;
+            dcat:hadRole dataroles:custodian ;
             prov:agent [
                     a prov:Agent ;
                     sdo:name "Angela Riganti" ;
                 ]
         ] ,
         [
-            dcat:hadRole isoroles:custodian ;
+            dcat:hadRole dataroles:custodian ;
             prov:agent [
                     a prov:Agent ;
                     sdo:name "Erin Gray" ;

--- a/vocabularies/background/data-roles-labels.ttl
+++ b/vocabularies/background/data-roles-labels.ttl
@@ -1,0 +1,105 @@
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+<https://linked.data.gov.au/def/data-roles>
+    rdfs:label "IDN Role Codes"@en ;
+.
+
+<https://linked.data.gov.au/def/data-roles/author>
+    rdfs:label "author"@en ;
+.
+
+<https://linked.data.gov.au/def/data-roles/coAuthor>
+    rdfs:label "co author"@en ;
+.
+
+<https://linked.data.gov.au/def/data-roles/collaborator>
+    rdfs:label "collaborator"@en ;
+.
+
+<https://linked.data.gov.au/def/data-roles/contributor>
+    rdfs:label "contributor"@en ;
+.
+
+<https://linked.data.gov.au/def/data-roles/custodian>
+    rdfs:label "custodian"@en ;
+.
+
+<https://linked.data.gov.au/def/data-roles/distributor>
+    rdfs:label "distributor"@en ;
+.
+
+<https://linked.data.gov.au/def/data-roles/editor>
+    rdfs:label "editor"@en ;
+.
+
+<https://linked.data.gov.au/def/data-roles/funder>
+    rdfs:label "funder"@en ;
+.
+
+<https://linked.data.gov.au/def/data-roles/isoRoles>
+    rdfs:label "ISO CI Role Code codes"@en ;
+.
+
+<https://linked.data.gov.au/def/data-roles/mediator>
+    rdfs:label "mediator"@en ;
+.
+
+<https://linked.data.gov.au/def/data-roles/originator>
+    rdfs:label "originator"@en ;
+.
+
+<https://linked.data.gov.au/def/data-roles/owner>
+    rdfs:label "owner"@en ;
+.
+
+<https://linked.data.gov.au/def/data-roles/pointOfContact>
+    rdfs:label "point of contact"@en ;
+.
+
+<https://linked.data.gov.au/def/data-roles/principalInvestigator>
+    rdfs:label "principal investigator"@en ;
+.
+
+<https://linked.data.gov.au/def/data-roles/processor>
+    rdfs:label "processor"@en ;
+.
+
+<https://linked.data.gov.au/def/data-roles/publisher>
+    rdfs:label "publisher"@en ;
+.
+
+<https://linked.data.gov.au/def/data-roles/resourceProvider>
+    rdfs:label "resource provider"@en ;
+.
+
+<https://linked.data.gov.au/def/data-roles/rightsHolder>
+    rdfs:label "rights holder"@en ;
+.
+
+<https://linked.data.gov.au/def/data-roles/sponsor>
+    rdfs:label "sponsor"@en ;
+.
+
+<https://linked.data.gov.au/def/data-roles/stakeholder>
+    rdfs:label "stakeholder"@en ;
+.
+
+<https://linked.data.gov.au/def/data-roles/subjectAgent>
+    rdfs:label "subject agent"@en ;
+.
+
+<https://linked.data.gov.au/def/data-roles/subjectAgentRepresentative>
+    rdfs:label "subject agent representative"@en ;
+.
+
+<https://linked.data.gov.au/def/data-roles/user>
+    rdfs:label "user"@en ;
+.
+
+<https://linked.data.gov.au/org/agldwg>
+    rdfs:label "Australian Government Linked Data Working Group" ;
+.
+
+<https://linked.data.gov.au/org/idn>
+    rdfs:label "Indigenous Data Network" ;
+.

--- a/vocabularies/borehole-configuration-vertical-depth.ttl
+++ b/vocabularies/borehole-configuration-vertical-depth.ttl
@@ -3,7 +3,7 @@ PREFIX agldwgstatus: <https://linked.data.gov.au/def/reg-statuses/>
 PREFIX cs: <http://linked.data.gov.au/def/vertical-depth-reference-systems>
 PREFIX dcat: <http://www.w3.org/ns/dcat#>
 PREFIX dcterms: <http://purl.org/dc/terms/>
-PREFIX isoroles: <http://def.isotc211.org/iso19115/-1/2018/CitationAndResponsiblePartyInformation/code/CI_RoleCode/>
+PREFIX dataroles: <https://linked.data.gov.au/def/data-roles/>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
@@ -438,14 +438,14 @@ cs:
     skos:prefLabel "Vertical/depth reference systems"@en ;
     prov:qualifiedAttribution
         [
-            dcat:hadRole isoroles:custodian ;
+            dcat:hadRole dataroles:custodian ;
             prov:agent [
                     a prov:Agent ;
                     sdo:name "Erin Gray" ;
                 ]
         ] ,
         [
-            dcat:hadRole isoroles:custodian ;
+            dcat:hadRole dataroles:custodian ;
             prov:agent [
                     a prov:Agent ;
                     sdo:name "Angela Riganti" ;

--- a/vocabularies/borehole-configuration.ttl
+++ b/vocabularies/borehole-configuration.ttl
@@ -3,7 +3,7 @@ PREFIX agldwgstatus: <https://linked.data.gov.au/def/reg-statuses/>
 PREFIX cs: <https://linked.data.gov.au/def/borehole-configuration>
 PREFIX dcat: <http://www.w3.org/ns/dcat#>
 PREFIX dcterms: <http://purl.org/dc/terms/>
-PREFIX isoroles: <http://def.isotc211.org/iso19115/-1/2018/CitationAndResponsiblePartyInformation/code/CI_RoleCode/>
+PREFIX dataroles: <https://linked.data.gov.au/def/data-roles/>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
@@ -153,14 +153,14 @@ cs:
     skos:prefLabel "Borehole configuration"@en ;
     prov:qualifiedAttribution
         [
-            dcat:hadRole isoroles:custodian ;
+            dcat:hadRole dataroles:custodian ;
             prov:agent [
                     a prov:Agent ;
                     sdo:name "Erin Gray" ;
                 ]
         ] ,
         [
-            dcat:hadRole isoroles:custodian ;
+            dcat:hadRole dataroles:custodian ;
             prov:agent [
                     a prov:Agent ;
                     sdo:name "Angela Riganti" ;

--- a/vocabularies/borehole-drilling-method.ttl
+++ b/vocabularies/borehole-drilling-method.ttl
@@ -1,7 +1,7 @@
 PREFIX : <https://linked.data.gov.au/def/borehole-drilling-method-western-australia/>
 PREFIX cs: <https://linked.data.gov.au/def/borehole-drilling-method-western-australia>
 PREFIX dcat: <http://www.w3.org/ns/dcat#>
-PREFIX isoroles: <http://def.isotc211.org/iso19115/-1/2018/CitationAndResponsiblePartyInformation/code/CI_RoleCode/>
+PREFIX dataroles: <https://linked.data.gov.au/def/data-roles/>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
@@ -578,7 +578,7 @@ cs:
     skos:prefLabel "Borehole drilling method"@en ;
     prov:qualifiedAttribution
         [
-            dcat:hadRole isoroles:custodian ;
+            dcat:hadRole dataroles:custodian ;
             prov:agent
                 [
                     a schema:Organization ;
@@ -587,7 +587,7 @@ cs:
                 ] ;
         ] ,
         [
-            dcat:hadRole isoroles:custodian ;
+            dcat:hadRole dataroles:custodian ;
             prov:agent
                 [
                     a schema:Organization ;

--- a/vocabularies/borehole-geometry.ttl
+++ b/vocabularies/borehole-geometry.ttl
@@ -3,7 +3,7 @@ PREFIX agldwgstatus: <https://linked.data.gov.au/def/reg-statuses/>
 PREFIX cs: <https://linked.data.gov.au/def/borehole-geometry>
 PREFIX dcat: <http://www.w3.org/ns/dcat#>
 PREFIX dcterms: <http://purl.org/dc/terms/>
-PREFIX isoroles: <http://def.isotc211.org/iso19115/-1/2018/CitationAndResponsiblePartyInformation/code/CI_RoleCode/>
+PREFIX dataroles: <https://linked.data.gov.au/def/data-roles/>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
@@ -400,14 +400,14 @@ cs:
     skos:prefLabel "Borehole geometry"@en ;
     prov:qualifiedAttribution
         [
-            dcat:hadRole isoroles:custodian ;
+            dcat:hadRole dataroles:custodian ;
             prov:agent [
                     a prov:Agent ;
                     sdo:name "Erin Gray" ;
                 ]
         ] ,
         [
-            dcat:hadRole isoroles:custodian ;
+            dcat:hadRole dataroles:custodian ;
             prov:agent [
                     a prov:Agent ;
                     sdo:name "Angela Riganti" ;

--- a/vocabularies/borehole-start-point-setting.ttl
+++ b/vocabularies/borehole-start-point-setting.ttl
@@ -3,7 +3,7 @@ PREFIX agldwgstatus: <https://linked.data.gov.au/def/reg-statuses/>
 PREFIX cs: <https://linked.data.gov.au/def/borehole-start-point-setting>
 PREFIX dcat: <http://www.w3.org/ns/dcat#>
 PREFIX dcterms: <http://purl.org/dc/terms/>
-PREFIX isoroles: <http://def.isotc211.org/iso19115/-1/2018/CitationAndResponsiblePartyInformation/code/CI_RoleCode/>
+PREFIX dataroles: <https://linked.data.gov.au/def/data-roles/>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
@@ -124,14 +124,14 @@ cs:
     skos:prefLabel "Borehole start point setting"@en ;
     prov:qualifiedAttribution
         [
-            dcat:hadRole isoroles:custodian ;
+            dcat:hadRole dataroles:custodian ;
             prov:agent [
                     a prov:Agent ;
                     sdo:name "Erin Gray" ;
                 ]
         ] ,
         [
-            dcat:hadRole isoroles:custodian ;
+            dcat:hadRole dataroles:custodian ;
             prov:agent [
                     a prov:Agent ;
                     sdo:name "Angela Riganti" ;

--- a/vocabularies/dmirs-offices.ttl
+++ b/vocabularies/dmirs-offices.ttl
@@ -1,7 +1,7 @@
 PREFIX : <https://linked.data.gov.au/def/dmirs-offices/>
 PREFIX cs: <https://linked.data.gov.au/def/dmirs-offices>
 PREFIX dcat: <http://www.w3.org/ns/dcat#>
-PREFIX isoroles: <http://def.isotc211.org/iso19115/-1/2018/CitationAndResponsiblePartyInformation/code/CI_RoleCode/>
+PREFIX dataroles: <https://linked.data.gov.au/def/data-roles/>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
@@ -356,7 +356,7 @@ cs:
     skos:prefLabel "DEMIRS offices"@en ;
     prov:qualifiedAttribution
         [
-            dcat:hadRole isoroles:custodian ;
+            dcat:hadRole dataroles:custodian ;
             prov:agent
                 [
                     a schema:Organization ;
@@ -365,7 +365,7 @@ cs:
                 ] ;
         ] ,
         [
-            dcat:hadRole isoroles:custodian ;
+            dcat:hadRole dataroles:custodian ;
             prov:agent
                 [
                     a schema:Organization ;

--- a/vocabularies/geological-feature-type.ttl
+++ b/vocabularies/geological-feature-type.ttl
@@ -3,7 +3,7 @@ PREFIX agldwgstatus: <https://linked.data.gov.au/def/reg-statuses/>
 PREFIX cs: <https://linked.data.gov.au/def/geological-feature-type>
 PREFIX dcat: <http://www.w3.org/ns/dcat#>
 PREFIX dcterms: <http://purl.org/dc/terms/>
-PREFIX isoroles: <http://def.isotc211.org/iso19115/-1/2018/CitationAndResponsiblePartyInformation/code/CI_RoleCode/>
+PREFIX dataroles: <https://linked.data.gov.au/def/data-roles/>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
@@ -203,21 +203,21 @@ cs:
     skos:prefLabel "Geological feature type"@en ;
     prov:qualifiedAttribution
         [
-            dcat:hadRole isoroles:custodian ;
+            dcat:hadRole dataroles:custodian ;
             prov:agent [
                     a prov:Agent ;
                     sdo:name "Angela Riganti" ;
                 ]
         ] ,
         [
-            dcat:hadRole isoroles:custodian ;
+            dcat:hadRole dataroles:custodian ;
             prov:agent [
                     a prov:Agent ;
                     sdo:name "David Martin" ;
                 ]
         ] ,
         [
-            dcat:hadRole isoroles:custodian ;
+            dcat:hadRole dataroles:custodian ;
             prov:agent [
                     a prov:Agent ;
                     sdo:name "Erin Gray" ;

--- a/vocabularies/gswa-collection-facility.ttl
+++ b/vocabularies/gswa-collection-facility.ttl
@@ -1,7 +1,7 @@
 PREFIX : <https://linked.data.gov.au/def/gswa-collection-facilities/>
 PREFIX cs: <https://linked.data.gov.au/def/gswa-collection-facilities>
 PREFIX dcat: <http://www.w3.org/ns/dcat#>
-PREFIX isoroles: <http://def.isotc211.org/iso19115/-1/2018/CitationAndResponsiblePartyInformation/code/CI_RoleCode/>
+PREFIX dataroles: <https://linked.data.gov.au/def/data-roles/>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
@@ -224,7 +224,7 @@ cs:
     skos:prefLabel "GSWA collection facilities"@en ;
     prov:qualifiedAttribution
         [
-            dcat:hadRole isoroles:custodian ;
+            dcat:hadRole dataroles:custodian ;
             prov:agent
                 [
                     a schema:Organization ;
@@ -233,7 +233,7 @@ cs:
                 ] ;
         ] ,
         [
-            dcat:hadRole isoroles:custodian ;
+            dcat:hadRole dataroles:custodian ;
             prov:agent
                 [
                     a schema:Organization ;
@@ -242,7 +242,7 @@ cs:
                 ] ;
         ] ,
         [
-            dcat:hadRole isoroles:custodian ;
+            dcat:hadRole dataroles:custodian ;
             prov:agent
                 [
                     a schema:Organization ;

--- a/vocabularies/location-method.ttl
+++ b/vocabularies/location-method.ttl
@@ -1,7 +1,7 @@
 PREFIX : <https://linked.data.gov.au/def/location-method/>
 PREFIX cs: <https://linked.data.gov.au/def/location-method>
 PREFIX dcat: <http://www.w3.org/ns/dcat#>
-PREFIX isoroles: <http://def.isotc211.org/iso19115/-1/2018/CitationAndResponsiblePartyInformation/code/CI_RoleCode/>
+PREFIX dataroles: <https://linked.data.gov.au/def/data-roles/>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
@@ -591,7 +591,7 @@ cs:
     skos:prefLabel "Location method"@en ;
     prov:qualifiedAttribution
         [
-            dcat:hadRole isoroles:custodian ;
+            dcat:hadRole dataroles:custodian ;
             prov:agent
                 [
                     a schema:Organization ;
@@ -600,7 +600,7 @@ cs:
                 ] ;
         ] ,
         [
-            dcat:hadRole isoroles:custodian ;
+            dcat:hadRole dataroles:custodian ;
             prov:agent
                 [
                     a schema:Organization ;

--- a/vocabularies/metamorphic-P-T-trajectory.ttl
+++ b/vocabularies/metamorphic-P-T-trajectory.ttl
@@ -3,7 +3,7 @@ PREFIX agldwgstatus: <https://linked.data.gov.au/def/reg-statuses/>
 PREFIX cs: <https://linked.data.gov.au/def/metamorphic-P-T-trajectory>
 PREFIX dcat: <http://www.w3.org/ns/dcat#>
 PREFIX dcterms: <http://purl.org/dc/terms/>
-PREFIX isoroles: <http://def.isotc211.org/iso19115/-1/2018/CitationAndResponsiblePartyInformation/code/CI_RoleCode/>
+PREFIX dataroles: <https://linked.data.gov.au/def/data-roles/>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
@@ -208,14 +208,14 @@ d) https://en.wikipedia.org/wiki/Pressure-temperature-time_path."""@en ;
     skos:prefLabel "Metamorphic P–T trajectory"@en ;
     prov:qualifiedAttribution
         [
-            dcat:hadRole isoroles:custodian ;
+            dcat:hadRole dataroles:custodian ;
             prov:agent [
                     a prov:Agent ;
                     sdo:name "Fawna Korhonen" ;
                 ]
         ] ,
         [
-            dcat:hadRole isoroles:custodian ;
+            dcat:hadRole dataroles:custodian ;
             prov:agent [
                     a prov:Agent ;
                     sdo:name "Dave Kelsey" ;

--- a/vocabularies/metamorphic-facies.ttl
+++ b/vocabularies/metamorphic-facies.ttl
@@ -3,7 +3,7 @@ PREFIX agldwgstatus: <https://linked.data.gov.au/def/reg-statuses/>
 PREFIX cs: <https://linked.data.gov.au/def/metamorphic-facies>
 PREFIX dcat: <http://www.w3.org/ns/dcat#>
 PREFIX dcterms: <http://purl.org/dc/terms/>
-PREFIX isoroles: <http://def.isotc211.org/iso19115/-1/2018/CitationAndResponsiblePartyInformation/code/CI_RoleCode/>
+PREFIX dataroles: <https://linked.data.gov.au/def/data-roles/>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
@@ -271,14 +271,14 @@ cs:
     skos:prefLabel "Metamorphic facies"@en ;
     prov:qualifiedAttribution
         [
-            dcat:hadRole isoroles:custodian ;
+            dcat:hadRole dataroles:custodian ;
             prov:agent [
                     a prov:Agent ;
                     sdo:name "Dave Kelsey" ;
                 ]
         ] ,
         [
-            dcat:hadRole isoroles:custodian ;
+            dcat:hadRole dataroles:custodian ;
             prov:agent [
                     a prov:Agent ;
                     sdo:name "Fawna Korhonen" ;

--- a/vocabularies/metamorphic-stage.ttl
+++ b/vocabularies/metamorphic-stage.ttl
@@ -3,7 +3,7 @@ PREFIX agldwgstatus: <https://linked.data.gov.au/def/reg-statuses/>
 PREFIX cs: <https://linked.data.gov.au/def/metamorphic-stage>
 PREFIX dcat: <http://www.w3.org/ns/dcat#>
 PREFIX dcterms: <http://purl.org/dc/terms/>
-PREFIX isoroles: <http://def.isotc211.org/iso19115/-1/2018/CitationAndResponsiblePartyInformation/code/CI_RoleCode/>
+PREFIX dataroles: <https://linked.data.gov.au/def/data-roles/>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
@@ -144,14 +144,14 @@ Fettes, D and Desmons, J (eds.) 2007, Metamorphic Rocks: a classification and gl
     skos:prefLabel "Metamorphic stage"@en ;
     prov:qualifiedAttribution
         [
-            dcat:hadRole isoroles:custodian ;
+            dcat:hadRole dataroles:custodian ;
             prov:agent [
                     a prov:Agent ;
                     sdo:name "Fawna Korhonen" ;
                 ]
         ] ,
         [
-            dcat:hadRole isoroles:custodian ;
+            dcat:hadRole dataroles:custodian ;
             prov:agent [
                     a prov:Agent ;
                     sdo:name "Dave Kelsey" ;

--- a/vocabularies/metamorphic-thermal-regime-style.ttl
+++ b/vocabularies/metamorphic-thermal-regime-style.ttl
@@ -3,7 +3,7 @@ PREFIX agldwgstatus: <https://linked.data.gov.au/def/reg-statuses/>
 PREFIX cs: <https://linked.data.gov.au/def/metamorphic-thermal-regime>
 PREFIX dcat: <http://www.w3.org/ns/dcat#>
 PREFIX dcterms: <http://purl.org/dc/terms/>
-PREFIX isoroles: <http://def.isotc211.org/iso19115/-1/2018/CitationAndResponsiblePartyInformation/code/CI_RoleCode/>
+PREFIX dataroles: <https://linked.data.gov.au/def/data-roles/>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
@@ -142,14 +142,14 @@ c) Stüwe, K 2007, Geodynamics of the lithosphere: An introduction: Springer, Be
 """@en ;
     prov:qualifiedAttribution
         [
-            dcat:hadRole isoroles:custodian ;
+            dcat:hadRole dataroles:custodian ;
             prov:agent [
                     a prov:Agent ;
                     sdo:name "Dave Kelsey" ;
                 ]
         ] ,
         [
-            dcat:hadRole isoroles:custodian ;
+            dcat:hadRole dataroles:custodian ;
             prov:agent [
                     a prov:Agent ;
                     sdo:name "Fawna Korhonen" ;

--- a/vocabularies/physiographic-unit-types.ttl
+++ b/vocabularies/physiographic-unit-types.ttl
@@ -3,7 +3,7 @@ PREFIX agldwgstatus: <https://linked.data.gov.au/def/reg-statuses/>
 PREFIX cs: <https://linked.data.gov.au/def/physiographic-unit-types>
 PREFIX dcat: <http://www.w3.org/ns/dcat#>
 PREFIX dcterms: <http://purl.org/dc/terms/>
-PREFIX isoroles: <http://def.isotc211.org/iso19115/-1/2018/CitationAndResponsiblePartyInformation/code/CI_RoleCode/>
+PREFIX dataroles: <https://linked.data.gov.au/def/data-roles/>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
@@ -71,14 +71,14 @@ cs:
     skos:prefLabel "Physiographic unit types"@en ;
     prov:qualifiedAttribution
         [
-            dcat:hadRole isoroles:custodian ;
+            dcat:hadRole dataroles:custodian ;
             prov:agent [
                     a prov:Agent ;
                     sdo:name "Erin Gray" ;
                 ]
         ] ,
         [
-            dcat:hadRole isoroles:custodian ;
+            dcat:hadRole dataroles:custodian ;
             prov:agent [
                     a prov:Agent ;
                     sdo:name "Angela Riganti" ;

--- a/vocabularies/tectonic-unit-type.ttl
+++ b/vocabularies/tectonic-unit-type.ttl
@@ -3,7 +3,7 @@ PREFIX agldwgstatus: <https://linked.data.gov.au/def/reg-statuses/>
 PREFIX cs: <https://linked.data.gov.au/def/tectonic-unit-type>
 PREFIX dcat: <http://www.w3.org/ns/dcat#>
 PREFIX dcterms: <http://purl.org/dc/terms/>
-PREFIX isoroles: <http://def.isotc211.org/iso19115/-1/2018/CitationAndResponsiblePartyInformation/code/CI_RoleCode/>
+PREFIX dataroles: <https://linked.data.gov.au/def/data-roles/>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
@@ -333,14 +333,14 @@ The concepts outline the type of tectonic elements that are recognized and/or in
     skos:prefLabel "Tectonic unit type"@en ;
     prov:qualifiedAttribution
         [
-            dcat:hadRole isoroles:custodian ;
+            dcat:hadRole dataroles:custodian ;
             prov:agent [
                     a prov:Agent ;
                     sdo:name "Erin Gray" ;
                 ]
         ] ,
         [
-            dcat:hadRole isoroles:custodian ;
+            dcat:hadRole dataroles:custodian ;
             prov:agent [
                     a prov:Agent ;
                     sdo:name "Angela Riganti" ;

--- a/vocabularies/wa-coordinate-reference-system.ttl
+++ b/vocabularies/wa-coordinate-reference-system.ttl
@@ -3,7 +3,7 @@ PREFIX agldwgstatus: <https://linked.data.gov.au/def/reg-statuses/>
 PREFIX cs: <https://linked.data.gov.au/def/wa-coordinate-reference-systems>
 PREFIX dcat: <http://www.w3.org/ns/dcat#>
 PREFIX dcterms: <http://purl.org/dc/terms/>
-PREFIX isoroles: <http://def.isotc211.org/iso19115/-1/2018/CitationAndResponsiblePartyInformation/code/CI_RoleCode/>
+PREFIX dataroles: <https://linked.data.gov.au/def/data-roles/>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
@@ -742,14 +742,14 @@ cs:
     skos:prefLabel "Western Australian coordinate reference systems"@en ;
     prov:qualifiedAttribution
         [
-            dcat:hadRole isoroles:custodian ;
+            dcat:hadRole dataroles:custodian ;
             prov:agent [
                     a prov:Agent ;
                     sdo:name "Erin Gray" ;
                 ]
         ] ,
         [
-            dcat:hadRole isoroles:custodian ;
+            dcat:hadRole dataroles:custodian ;
             prov:agent [
                     a prov:Agent ;
                     sdo:name "Angela Riganti" ;

--- a/vocabularies/wa-mineral-fields-and-districts.ttl
+++ b/vocabularies/wa-mineral-fields-and-districts.ttl
@@ -3,7 +3,7 @@ PREFIX agldwgstatus: <https://linked.data.gov.au/def/reg-statuses/>
 PREFIX cs: <https://linked.data.gov.au/def/wa-mineral-fields-and-districts>
 PREFIX dcat: <http://www.w3.org/ns/dcat#>
 PREFIX dcterms: <http://purl.org/dc/terms/>
-PREFIX isoroles: <http://def.isotc211.org/iso19115/-1/2018/CitationAndResponsiblePartyInformation/code/CI_RoleCode/>
+PREFIX dataroles: <https://linked.data.gov.au/def/data-roles/>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
@@ -943,14 +943,14 @@ cs:
     skos:prefLabel "Western Australian mineral fields and districts"@en ;
     prov:qualifiedAttribution
         [
-            dcat:hadRole isoroles:custodian ;
+            dcat:hadRole dataroles:custodian ;
             prov:agent [
                     a prov:Agent ;
                     sdo:name "Erin Gray" ;
                 ]
         ] ,
         [
-            dcat:hadRole isoroles:custodian ;
+            dcat:hadRole dataroles:custodian ;
             prov:agent [
                     a prov:Agent ;
                     sdo:name "Angela Riganti" ;


### PR DESCRIPTION
I'm replacing all references to the ISO's RoleCodes vocab, e.g. http://def.isotc211.org/iso19115/-1/2018/CitationAndResponsiblePartyInformation/code/CI_RoleCode/author, with references to the same vocab but now published by the Aust Gov LD WG. This is because the ISO aren't going to make that vocab resolve any time soon - we hoped they would.