### PR TITLE
Replace bad GSWA org label

### DIFF
--- a/vocabularies/CRIRSCO-resource-reporting.ttl
+++ b/vocabularies/CRIRSCO-resource-reporting.ttl
@@ -209,7 +209,7 @@ cs:Scoping-Study
 
 <https://linked.data.gov.au/org/gswa>
     a schema:Organization ;
-    schema:name "Gswa" ;
+    schema:name "Geological Survey of Western Australia" ;
     schema:url ""^^xsd:anyURI ;
 .
 

--- a/vocabularies/CRIRSCO-resource-reporting.ttl
+++ b/vocabularies/CRIRSCO-resource-reporting.ttl
@@ -239,6 +239,7 @@ The CRIRSCO Code is closely related to the JORC Code used in Australasia to repo
             prov:agent
                 [
                     a schema:Person ;
+                    schema:email ""^^xsd:anyURI ;
                     schema:name "Angela Riganti" ;
                 ] ;
         ] ,
@@ -247,6 +248,7 @@ The CRIRSCO Code is closely related to the JORC Code used in Australasia to repo
             prov:agent
                 [
                     a schema:Person ;
+                    schema:email ""^^xsd:anyURI ;
                     schema:name "Erin Gray" ;
                 ] ;
         ] ;

--- a/vocabularies/CRIRSCO-resource-reporting.ttl
+++ b/vocabularies/CRIRSCO-resource-reporting.ttl
@@ -210,7 +210,7 @@ cs:Scoping-Study
 <https://linked.data.gov.au/org/gswa>
     a schema:Organization ;
     schema:name "Geological Survey of Western Australia" ;
-    schema:url ""^^xsd:anyURI ;
+    schema:url "https://www.dmp.wa.gov.au/Geological-Survey/Geological-Survey-262.aspx"^^xsd:anyURI ;
 .
 
 cs:
@@ -240,7 +240,6 @@ The CRIRSCO Code is closely related to the JORC Code used in Australasia to repo
                 [
                     a schema:Organization ;
                     schema:name "Angela Riganti" ;
-                    schema:url ""^^xsd:anyURI ;
                 ] ;
         ] ,
         [
@@ -249,7 +248,6 @@ The CRIRSCO Code is closely related to the JORC Code used in Australasia to repo
                 [
                     a schema:Organization ;
                     schema:name "Erin Gray" ;
-                    schema:url ""^^xsd:anyURI ;
                 ] ;
         ] ;
     schema:creator <https://linked.data.gov.au/org/gswa> ;

--- a/vocabularies/CRIRSCO-resource-reporting.ttl
+++ b/vocabularies/CRIRSCO-resource-reporting.ttl
@@ -238,7 +238,7 @@ The CRIRSCO Code is closely related to the JORC Code used in Australasia to repo
             dcat:hadRole isoroles:custodian ;
             prov:agent
                 [
-                    a schema:Organization ;
+                    a schema:Person ;
                     schema:name "Angela Riganti" ;
                 ] ;
         ] ,
@@ -246,7 +246,7 @@ The CRIRSCO Code is closely related to the JORC Code used in Australasia to repo
             dcat:hadRole isoroles:custodian ;
             prov:agent
                 [
-                    a schema:Organization ;
+                    a schema:Person ;
                     schema:name "Erin Gray" ;
                 ] ;
         ] ;

--- a/vocabularies/ChronostratChart2023-09.ttl
+++ b/vocabularies/ChronostratChart2023-09.ttl
@@ -8,7 +8,7 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX rank: <http://resource.geosciml.org/ontology/timescale/rank/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX reg: <http://purl.org/linked-data/registry#>
-PREFIX sdo: <https://schema.org/>
+PREFIX schema: <https://schema.org/>
 PREFIX sh: <http://www.w3.org/ns/shacl#>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX time: <http://www.w3.org/2006/time#>
@@ -309,15 +309,15 @@ ischart:Aalenian
     skos:prefLabel "Aalenian"@en ;
     time:hasBeginning [
             ischart:inMYA 174.7 ;
-            sdo:marginOfError 0.8
+            schema:marginOfError 0.8
         ] ;
     time:hasEnd [
             ischart:inMYA 170.9 ;
-            sdo:marginOfError 0.8
+            schema:marginOfError 0.8
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 58 ;
-    sdo:color "#9AD9DD"^^ischart:RGBHex ;
+    schema:color "#9AD9DD"^^ischart:RGBHex ;
 .
 
 ischart:Aeronian
@@ -352,15 +352,15 @@ ischart:Aeronian
     skos:prefLabel "Aeronian"@en ;
     time:hasBeginning [
             ischart:inMYA 440.8 ;
-            sdo:marginOfError 1.2
+            schema:marginOfError 1.2
         ] ;
     time:hasEnd [
             ischart:inMYA 438.5 ;
-            sdo:marginOfError 1.1
+            schema:marginOfError 1.1
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 127 ;
-    sdo:color "#B3E1C2"^^ischart:RGBHex ;
+    schema:color "#B3E1C2"^^ischart:RGBHex ;
 .
 
 ischart:Albian
@@ -402,7 +402,7 @@ ischart:Albian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 43 ;
-    sdo:color "#CCEA97"^^ischart:RGBHex ;
+    schema:color "#CCEA97"^^ischart:RGBHex ;
 .
 
 ischart:Anisian
@@ -444,7 +444,7 @@ ischart:Anisian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 71 ;
-    sdo:color "#BC75B7"^^ischart:RGBHex ;
+    schema:color "#BC75B7"^^ischart:RGBHex ;
 .
 
 ischart:Aptian
@@ -487,7 +487,7 @@ ischart:Aptian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 44 ;
-    sdo:color "#BFE48A"^^ischart:RGBHex ;
+    schema:color "#BFE48A"^^ischart:RGBHex ;
 .
 
 ischart:Aquitanian
@@ -528,7 +528,7 @@ ischart:Aquitanian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 19 ;
-    sdo:color "#FFFF33"^^ischart:RGBHex ;
+    schema:color "#FFFF33"^^ischart:RGBHex ;
 .
 
 ischart:Artinskian
@@ -563,15 +563,15 @@ ischart:Artinskian
     skos:prefLabel "Artinskian"@en ;
     time:hasBeginning [
             ischart:inMYA 290.1 ;
-            sdo:marginOfError 0.26
+            schema:marginOfError 0.26
         ] ;
     time:hasEnd [
             ischart:inMYA 283.5 ;
-            sdo:marginOfError 0.6
+            schema:marginOfError 0.6
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 87 ;
-    sdo:color "#E37B68"^^ischart:RGBHex ;
+    schema:color "#E37B68"^^ischart:RGBHex ;
 .
 
 ischart:Asselian
@@ -606,15 +606,15 @@ ischart:Asselian
     skos:prefLabel "Asselian"@en ;
     time:hasBeginning [
             ischart:inMYA 298.9 ;
-            sdo:marginOfError 0.15
+            schema:marginOfError 0.15
         ] ;
     time:hasEnd [
             ischart:inMYA 293.51 ;
-            sdo:marginOfError 0.17
+            schema:marginOfError 0.17
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 89 ;
-    sdo:color "#E36350"^^ischart:RGBHex ;
+    schema:color "#E36350"^^ischart:RGBHex ;
 .
 
 ischart:Bajocian
@@ -649,15 +649,15 @@ ischart:Bajocian
     skos:prefLabel "Bajocian"@en ;
     time:hasBeginning [
             ischart:inMYA 170.9 ;
-            sdo:marginOfError 0.8
+            schema:marginOfError 0.8
         ] ;
     time:hasEnd [
             ischart:inMYA 168.2 ;
-            sdo:marginOfError 1.2
+            schema:marginOfError 1.2
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 57 ;
-    sdo:color "#A6DDE0"^^ischart:RGBHex ;
+    schema:color "#A6DDE0"^^ischart:RGBHex ;
 .
 
 ischart:Barremian
@@ -699,7 +699,7 @@ ischart:Barremian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 45 ;
-    sdo:color "#B3DF7F"^^ischart:RGBHex ;
+    schema:color "#B3DF7F"^^ischart:RGBHex ;
 .
 
 ischart:Bartonian
@@ -740,7 +740,7 @@ ischart:Bartonian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 26 ;
-    sdo:color "#FDC091"^^ischart:RGBHex ;
+    schema:color "#FDC091"^^ischart:RGBHex ;
 .
 
 ischart:Bashkirian
@@ -775,15 +775,15 @@ ischart:Bashkirian
     skos:prefLabel "Bashkirian"@en ;
     time:hasBeginning [
             ischart:inMYA 323.2 ;
-            sdo:marginOfError 0.4
+            schema:marginOfError 0.4
         ] ;
     time:hasEnd [
             ischart:inMYA 315.2 ;
-            sdo:marginOfError 0.2
+            schema:marginOfError 0.2
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 97 ;
-    sdo:color "#99C2B5"^^ischart:RGBHex ;
+    schema:color "#99C2B5"^^ischart:RGBHex ;
 .
 
 ischart:Bathonian
@@ -818,15 +818,15 @@ ischart:Bathonian
     skos:prefLabel "Bathonian"@en ;
     time:hasBeginning [
             ischart:inMYA 168.2 ;
-            sdo:marginOfError 1.2
+            schema:marginOfError 1.2
         ] ;
     time:hasEnd [
             ischart:inMYA 165.3 ;
-            sdo:marginOfError 1.1
+            schema:marginOfError 1.1
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 56 ;
-    sdo:color "#B3E2E3"^^ischart:RGBHex ;
+    schema:color "#B3E2E3"^^ischart:RGBHex ;
 .
 
 ischart:Berriasian
@@ -869,7 +869,7 @@ ischart:Berriasian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 48 ;
-    sdo:color "#8CCD60"^^ischart:RGBHex ;
+    schema:color "#8CCD60"^^ischart:RGBHex ;
 .
 
 ischart:Burdigalian
@@ -910,7 +910,7 @@ ischart:Burdigalian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 18 ;
-    sdo:color "#FFFF41"^^ischart:RGBHex ;
+    schema:color "#FFFF41"^^ischart:RGBHex ;
 .
 
 ischart:Calabrian
@@ -951,7 +951,7 @@ ischart:Calabrian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 7 ;
-    sdo:color "#FFF2BA"^^ischart:RGBHex ;
+    schema:color "#FFF2BA"^^ischart:RGBHex ;
 .
 
 ischart:Callovian
@@ -986,15 +986,15 @@ ischart:Callovian
     skos:prefLabel "Callovian"@en ;
     time:hasBeginning [
             ischart:inMYA 165.3 ;
-            sdo:marginOfError 1.1
+            schema:marginOfError 1.1
         ] ;
     time:hasEnd [
             ischart:inMYA 161.5 ;
-            sdo:marginOfError 1.0
+            schema:marginOfError 1.0
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 55 ;
-    sdo:color "#BFE7E5"^^ischart:RGBHex ;
+    schema:color "#BFE7E5"^^ischart:RGBHex ;
 .
 
 ischart:Calymmian
@@ -1035,7 +1035,7 @@ ischart:Calymmian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 164 ;
-    sdo:color "#FDC07A"^^ischart:RGBHex ;
+    schema:color "#FDC07A"^^ischart:RGBHex ;
 .
 
 ischart:CambrianStage10
@@ -1074,11 +1074,11 @@ ischart:CambrianStage10
         ] ;
     time:hasEnd [
             ischart:inMYA 485.4 ;
-            sdo:marginOfError 1.9
+            schema:marginOfError 1.9
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 142 ;
-    sdo:color "#E6F5C9"^^ischart:RGBHex ;
+    schema:color "#E6F5C9"^^ischart:RGBHex ;
 .
 
 ischart:CambrianStage2
@@ -1121,7 +1121,7 @@ ischart:CambrianStage2
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 152 ;
-    sdo:color "#A6BA80"^^ischart:RGBHex ;
+    schema:color "#A6BA80"^^ischart:RGBHex ;
 .
 
 ischart:CambrianStage3
@@ -1164,7 +1164,7 @@ ischart:CambrianStage3
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 153 ;
-    sdo:color "#A6C583"^^ischart:RGBHex ;
+    schema:color "#A6C583"^^ischart:RGBHex ;
 .
 
 ischart:CambrianStage4
@@ -1207,7 +1207,7 @@ ischart:CambrianStage4
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 150 ;
-    sdo:color "#B3CA8E"^^ischart:RGBHex ;
+    schema:color "#B3CA8E"^^ischart:RGBHex ;
 .
 
 ischart:Campanian
@@ -1242,15 +1242,15 @@ ischart:Campanian
     skos:prefLabel "Campanian"@en ;
     time:hasBeginning [
             ischart:inMYA 83.6 ;
-            sdo:marginOfError 0.2
+            schema:marginOfError 0.2
         ] ;
     time:hasEnd [
             ischart:inMYA 72.1 ;
-            sdo:marginOfError 0.2
+            schema:marginOfError 0.2
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 37 ;
-    sdo:color "#E6F47F"^^ischart:RGBHex ;
+    schema:color "#E6F47F"^^ischart:RGBHex ;
 .
 
 ischart:Capitanian
@@ -1285,15 +1285,15 @@ ischart:Capitanian
     skos:prefLabel "Capitanian"@en ;
     time:hasBeginning [
             ischart:inMYA 264.28 ;
-            sdo:marginOfError 0.16
+            schema:marginOfError 0.16
         ] ;
     time:hasEnd [
             ischart:inMYA 259.51 ;
-            sdo:marginOfError 0.21
+            schema:marginOfError 0.21
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 82 ;
-    sdo:color "#FB9A85"^^ischart:RGBHex ;
+    schema:color "#FB9A85"^^ischart:RGBHex ;
 .
 
 ischart:Carnian
@@ -1336,7 +1336,7 @@ ischart:Carnian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 68 ;
-    sdo:color "#C99BCB"^^ischart:RGBHex ;
+    schema:color "#C99BCB"^^ischart:RGBHex ;
 .
 
 ischart:Cenomanian
@@ -1377,7 +1377,7 @@ ischart:Cenomanian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 41 ;
-    sdo:color "#B3DE53"^^ischart:RGBHex ;
+    schema:color "#B3DE53"^^ischart:RGBHex ;
 .
 
 ischart:Changhsingian
@@ -1412,15 +1412,15 @@ ischart:Changhsingian
     skos:prefLabel "Changhsingian"@en ;
     time:hasBeginning [
             ischart:inMYA 254.14 ;
-            sdo:marginOfError 0.07
+            schema:marginOfError 0.07
         ] ;
     time:hasEnd [
             ischart:inMYA 251.902 ;
-            sdo:marginOfError 0.024
+            schema:marginOfError 0.024
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 79 ;
-    sdo:color "#FCC0B2"^^ischart:RGBHex ;
+    schema:color "#FCC0B2"^^ischart:RGBHex ;
 .
 
 ischart:Chattian
@@ -1461,7 +1461,7 @@ ischart:Chattian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 22 ;
-    sdo:color "#FEE6AA"^^ischart:RGBHex ;
+    schema:color "#FEE6AA"^^ischart:RGBHex ;
 .
 
 ischart:Chibanian
@@ -1481,7 +1481,7 @@ ischart:Chibanian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 6 ;
-    sdo:color "#FFF2C7"^^ischart:RGBHex ;
+    schema:color "#FFF2C7"^^ischart:RGBHex ;
 .
 
 ischart:Coniacian
@@ -1516,15 +1516,15 @@ ischart:Coniacian
     skos:prefLabel "Coniacian"@en ;
     time:hasBeginning [
             ischart:inMYA 89.8 ;
-            sdo:marginOfError 0.3
+            schema:marginOfError 0.3
         ] ;
     time:hasEnd [
             ischart:inMYA 86.3 ;
-            sdo:marginOfError 0.5
+            schema:marginOfError 0.5
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 39 ;
-    sdo:color "#CCE968"^^ischart:RGBHex ;
+    schema:color "#CCE968"^^ischart:RGBHex ;
 .
 
 ischart:Cryogenian
@@ -1567,7 +1567,7 @@ ischart:Cryogenian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 159 ;
-    sdo:color "#FECC5C"^^ischart:RGBHex ;
+    schema:color "#FECC5C"^^ischart:RGBHex ;
 .
 
 ischart:Danian
@@ -1608,7 +1608,7 @@ ischart:Danian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 33 ;
-    sdo:color "#FDB462"^^ischart:RGBHex ;
+    schema:color "#FDB462"^^ischart:RGBHex ;
 .
 
 ischart:Dapingian
@@ -1643,15 +1643,15 @@ ischart:Dapingian
     skos:prefLabel "Dapingian"@en ;
     time:hasBeginning [
             ischart:inMYA 470.0 ;
-            sdo:marginOfError 1.4
+            schema:marginOfError 1.4
         ] ;
     time:hasEnd [
             ischart:inMYA 467.3 ;
-            sdo:marginOfError 1.1
+            schema:marginOfError 1.1
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 136 ;
-    sdo:color "#66C092"^^ischart:RGBHex ;
+    schema:color "#66C092"^^ischart:RGBHex ;
 .
 
 ischart:Darriwilian
@@ -1686,15 +1686,15 @@ ischart:Darriwilian
     skos:prefLabel "Darriwilian"@en ;
     time:hasBeginning [
             ischart:inMYA 467.3 ;
-            sdo:marginOfError 1.1
+            schema:marginOfError 1.1
         ] ;
     time:hasEnd [
             ischart:inMYA 458.4 ;
-            sdo:marginOfError 0.9
+            schema:marginOfError 0.9
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 135 ;
-    sdo:color "#74C69C"^^ischart:RGBHex ;
+    schema:color "#74C69C"^^ischart:RGBHex ;
 .
 
 ischart:Drumian
@@ -1737,7 +1737,7 @@ ischart:Drumian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 147 ;
-    sdo:color "#BFD99D"^^ischart:RGBHex ;
+    schema:color "#BFD99D"^^ischart:RGBHex ;
 .
 
 ischart:Ectasian
@@ -1778,7 +1778,7 @@ ischart:Ectasian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 163 ;
-    sdo:color "#FDCC8A"^^ischart:RGBHex ;
+    schema:color "#FDCC8A"^^ischart:RGBHex ;
 .
 
 ischart:Ediacaran
@@ -1817,11 +1817,11 @@ ischart:Ediacaran
         ] ;
     time:hasEnd [
             ischart:inMYA 538.8 ;
-            sdo:marginOfError 0.2
+            schema:marginOfError 0.2
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 158 ;
-    sdo:color "#FED96A"^^ischart:RGBHex ;
+    schema:color "#FED96A"^^ischart:RGBHex ;
 .
 
 ischart:Eifelian
@@ -1856,15 +1856,15 @@ ischart:Eifelian
     skos:prefLabel "Eifelian"@en ;
     time:hasBeginning [
             ischart:inMYA 393.3 ;
-            sdo:marginOfError 1.2
+            schema:marginOfError 1.2
         ] ;
     time:hasEnd [
             ischart:inMYA 387.7 ;
-            sdo:marginOfError 0.8
+            schema:marginOfError 0.8
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 112 ;
-    sdo:color "#F1D576"^^ischart:RGBHex ;
+    schema:color "#F1D576"^^ischart:RGBHex ;
 .
 
 ischart:Emsian
@@ -1899,15 +1899,15 @@ ischart:Emsian
     skos:prefLabel "Emsian"@en ;
     time:hasBeginning [
             ischart:inMYA 407.6 ;
-            sdo:marginOfError 2.6
+            schema:marginOfError 2.6
         ] ;
     time:hasEnd [
             ischart:inMYA 393.3 ;
-            sdo:marginOfError 1.2
+            schema:marginOfError 1.2
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 114 ;
-    sdo:color "#E5D075"^^ischart:RGBHex ;
+    schema:color "#E5D075"^^ischart:RGBHex ;
 .
 
 ischart:Eoarchean
@@ -1944,14 +1944,14 @@ ischart:Eoarchean
     skos:prefLabel "Eoarchean"@en ;
     time:hasBeginning [
             ischart:inMYA 4031 ;
-            sdo:marginOfError 3
+            schema:marginOfError 3
         ] ;
     time:hasEnd [
             ischart:inMYA 3600
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 176 ;
-    sdo:color "#DA037F"^^ischart:RGBHex ;
+    schema:color "#DA037F"^^ischart:RGBHex ;
 .
 
 ischart:Famennian
@@ -1986,15 +1986,15 @@ ischart:Famennian
     skos:prefLabel "Famennian"@en ;
     time:hasBeginning [
             ischart:inMYA 372.2 ;
-            sdo:marginOfError 1.6
+            schema:marginOfError 1.6
         ] ;
     time:hasEnd [
             ischart:inMYA 358.9 ;
-            sdo:marginOfError 0.4
+            schema:marginOfError 0.4
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 108 ;
-    sdo:color "#F2EDB3"^^ischart:RGBHex ;
+    schema:color "#F2EDB3"^^ischart:RGBHex ;
 .
 
 ischart:Floian
@@ -2028,15 +2028,15 @@ ischart:Floian
     skos:prefLabel "Floian"@en ;
     time:hasBeginning [
             ischart:inMYA 477.7 ;
-            sdo:marginOfError 1.4
+            schema:marginOfError 1.4
         ] ;
     time:hasEnd [
             ischart:inMYA 470.0 ;
-            sdo:marginOfError 1.4
+            schema:marginOfError 1.4
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 138 ;
-    sdo:color "#41B087"^^ischart:RGBHex ;
+    schema:color "#41B087"^^ischart:RGBHex ;
 .
 
 ischart:Fortunian
@@ -2071,7 +2071,7 @@ ischart:Fortunian
     skos:prefLabel "Fortunian"@en ;
     time:hasBeginning [
             ischart:inMYA 538.8 ;
-            sdo:marginOfError 0.2
+            schema:marginOfError 0.2
         ] ;
     time:hasEnd [
             ischart:inMYA 529 ;
@@ -2079,7 +2079,7 @@ ischart:Fortunian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 155 ;
-    sdo:color "#99B575"^^ischart:RGBHex ;
+    schema:color "#99B575"^^ischart:RGBHex ;
 .
 
 ischart:Frasnian
@@ -2114,15 +2114,15 @@ ischart:Frasnian
     skos:prefLabel "Frasnian"@en ;
     time:hasBeginning [
             ischart:inMYA 382.7 ;
-            sdo:marginOfError 1.6
+            schema:marginOfError 1.6
         ] ;
     time:hasEnd [
             ischart:inMYA 372.2 ;
-            sdo:marginOfError 1.6
+            schema:marginOfError 1.6
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 109 ;
-    sdo:color "#F2EDAD"^^ischart:RGBHex ;
+    schema:color "#F2EDAD"^^ischart:RGBHex ;
 .
 
 ischart:Gelasian
@@ -2162,7 +2162,7 @@ ischart:Gelasian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 8 ;
-    sdo:color "#FFEDB3"^^ischart:RGBHex ;
+    schema:color "#FFEDB3"^^ischart:RGBHex ;
 .
 
 ischart:Givetian
@@ -2197,15 +2197,15 @@ ischart:Givetian
     skos:prefLabel "Givetian"@en ;
     time:hasBeginning [
             ischart:inMYA 387.7 ;
-            sdo:marginOfError 0.8
+            schema:marginOfError 0.8
         ] ;
     time:hasEnd [
             ischart:inMYA 382.7 ;
-            sdo:marginOfError 1.6
+            schema:marginOfError 1.6
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 111 ;
-    sdo:color "#F1E185"^^ischart:RGBHex ;
+    schema:color "#F1E185"^^ischart:RGBHex ;
 .
 
 ischart:Gorstian
@@ -2240,15 +2240,15 @@ ischart:Gorstian
     skos:prefLabel "Gorstian"@en ;
     time:hasBeginning [
             ischart:inMYA 427.4 ;
-            sdo:marginOfError 0.5
+            schema:marginOfError 0.5
         ] ;
     time:hasEnd [
             ischart:inMYA 425.6 ;
-            sdo:marginOfError 0.9
+            schema:marginOfError 0.9
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 121 ;
-    sdo:color "#CCECDD"^^ischart:RGBHex ;
+    schema:color "#CCECDD"^^ischart:RGBHex ;
 .
 
 ischart:Greenlandian
@@ -2268,7 +2268,7 @@ ischart:Greenlandian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 3 ;
-    sdo:color "#FEECDB"^^ischart:RGBHex ;
+    schema:color "#FEECDB"^^ischart:RGBHex ;
 .
 
 ischart:Guzhangian
@@ -2311,7 +2311,7 @@ ischart:Guzhangian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 146 ;
-    sdo:color "#CCDFAA"^^ischart:RGBHex ;
+    schema:color "#CCDFAA"^^ischart:RGBHex ;
 .
 
 ischart:Gzhelian
@@ -2346,15 +2346,15 @@ ischart:Gzhelian
     skos:prefLabel "Gzhelian"@en ;
     time:hasBeginning [
             ischart:inMYA 303.7 ;
-            sdo:marginOfError 0.1
+            schema:marginOfError 0.1
         ] ;
     time:hasEnd [
             ischart:inMYA 298.9 ;
-            sdo:marginOfError 0.15
+            schema:marginOfError 0.15
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 92 ;
-    sdo:color "#CCD4C7"^^ischart:RGBHex ;
+    schema:color "#CCD4C7"^^ischart:RGBHex ;
 .
 
 ischart:Hadean
@@ -2391,11 +2391,11 @@ ischart:Hadean
         ] ;
     time:hasEnd [
             ischart:inMYA 4031 ;
-            sdo:marginOfError 3
+            schema:marginOfError 3
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 177 ;
-    sdo:color "#AE027E"^^ischart:RGBHex ;
+    schema:color "#AE027E"^^ischart:RGBHex ;
 .
 
 ischart:Hauterivian
@@ -2437,7 +2437,7 @@ ischart:Hauterivian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 46 ;
-    sdo:color "#A6D975"^^ischart:RGBHex ;
+    schema:color "#A6D975"^^ischart:RGBHex ;
 .
 
 ischart:Hettangian
@@ -2472,15 +2472,15 @@ ischart:Hettangian
     skos:prefLabel "Hettangian"@en ;
     time:hasBeginning [
             ischart:inMYA 201.4 ;
-            sdo:marginOfError 0.2
+            schema:marginOfError 0.2
         ] ;
     time:hasEnd [
             ischart:inMYA 199.5 ;
-            sdo:marginOfError 0.3
+            schema:marginOfError 0.3
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 63 ;
-    sdo:color "#4EB3D3"^^ischart:RGBHex ;
+    schema:color "#4EB3D3"^^ischart:RGBHex ;
 .
 
 ischart:Hirnantian
@@ -2515,15 +2515,15 @@ ischart:Hirnantian
     skos:prefLabel "Hirnantian"@en ;
     time:hasBeginning [
             ischart:inMYA 445.2 ;
-            sdo:marginOfError 1.4
+            schema:marginOfError 1.4
         ] ;
     time:hasEnd [
             ischart:inMYA 443.8 ;
-            sdo:marginOfError 1.5
+            schema:marginOfError 1.5
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 131 ;
-    sdo:color "#A6DBAB"^^ischart:RGBHex ;
+    schema:color "#A6DBAB"^^ischart:RGBHex ;
 .
 
 ischart:Homerian
@@ -2558,15 +2558,15 @@ ischart:Homerian
     skos:prefLabel "Homerian"@en ;
     time:hasBeginning [
             ischart:inMYA 430.5 ;
-            sdo:marginOfError 0.7
+            schema:marginOfError 0.7
         ] ;
     time:hasEnd [
             ischart:inMYA 427.4 ;
-            sdo:marginOfError 0.5
+            schema:marginOfError 0.5
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 123 ;
-    sdo:color "#CCEBD1"^^ischart:RGBHex ;
+    schema:color "#CCEBD1"^^ischart:RGBHex ;
 .
 
 ischart:Induan
@@ -2601,14 +2601,14 @@ ischart:Induan
     skos:prefLabel "Induan"@en ;
     time:hasBeginning [
             ischart:inMYA 251.902 ;
-            sdo:marginOfError 0.024
+            schema:marginOfError 0.024
         ] ;
     time:hasEnd [
             ischart:inMYA 251.2
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 74 ;
-    sdo:color "#A4469F"^^ischart:RGBHex ;
+    schema:color "#A4469F"^^ischart:RGBHex ;
 .
 
 ischart:Jiangshanian
@@ -2631,7 +2631,7 @@ ischart:Jiangshanian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 143 ;
-    sdo:color "#D9F0BB"^^ischart:RGBHex ;
+    schema:color "#D9F0BB"^^ischart:RGBHex ;
 .
 
 ischart:Kasimovian
@@ -2666,15 +2666,15 @@ ischart:Kasimovian
     skos:prefLabel "Kasimovian"@en ;
     time:hasBeginning [
             ischart:inMYA 307.0 ;
-            sdo:marginOfError 0.1
+            schema:marginOfError 0.1
         ] ;
     time:hasEnd [
             ischart:inMYA 303.7 ;
-            sdo:marginOfError 0.1
+            schema:marginOfError 0.1
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 93 ;
-    sdo:color "#BFD0C5"^^ischart:RGBHex ;
+    schema:color "#BFD0C5"^^ischart:RGBHex ;
 .
 
 ischart:Katian
@@ -2709,15 +2709,15 @@ ischart:Katian
     skos:prefLabel "Katian"@en ;
     time:hasBeginning [
             ischart:inMYA 453.0 ;
-            sdo:marginOfError 0.7
+            schema:marginOfError 0.7
         ] ;
     time:hasEnd [
             ischart:inMYA 445.2 ;
-            sdo:marginOfError 1.4
+            schema:marginOfError 1.4
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 132 ;
-    sdo:color "#99D69F"^^ischart:RGBHex ;
+    schema:color "#99D69F"^^ischart:RGBHex ;
 .
 
 ischart:Kimmeridgian
@@ -2752,15 +2752,15 @@ ischart:Kimmeridgian
     skos:prefLabel "Kimmeridgian"@en ;
     time:hasBeginning [
             ischart:inMYA 154.8 ;
-            sdo:marginOfError 0.8
+            schema:marginOfError 0.8
         ] ;
     time:hasEnd [
             ischart:inMYA 149.2 ;
-            sdo:marginOfError 0.7
+            schema:marginOfError 0.7
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 52 ;
-    sdo:color "#CCECF4"^^ischart:RGBHex ;
+    schema:color "#CCECF4"^^ischart:RGBHex ;
 .
 
 ischart:Kungurian
@@ -2795,15 +2795,15 @@ ischart:Kungurian
     skos:prefLabel "Kungurian"@en ;
     time:hasBeginning [
             ischart:inMYA 283.5 ;
-            sdo:marginOfError 0.6
+            schema:marginOfError 0.6
         ] ;
     time:hasEnd [
             ischart:inMYA 273.01 ;
-            sdo:marginOfError 0.14
+            schema:marginOfError 0.14
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 86 ;
-    sdo:color "#E38776"^^ischart:RGBHex ;
+    schema:color "#E38776"^^ischart:RGBHex ;
 .
 
 ischart:Ladinian
@@ -2846,7 +2846,7 @@ ischart:Ladinian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 70 ;
-    sdo:color "#C983BF"^^ischart:RGBHex ;
+    schema:color "#C983BF"^^ischart:RGBHex ;
 .
 
 ischart:Langhian
@@ -2887,7 +2887,7 @@ ischart:Langhian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 17 ;
-    sdo:color "#FFFF4D"^^ischart:RGBHex ;
+    schema:color "#FFFF4D"^^ischart:RGBHex ;
 .
 
 ischart:Lochkovian
@@ -2922,15 +2922,15 @@ ischart:Lochkovian
     skos:prefLabel "Lochkovian"@en ;
     time:hasBeginning [
             ischart:inMYA 419.2 ;
-            sdo:marginOfError 3.2
+            schema:marginOfError 3.2
         ] ;
     time:hasEnd [
             ischart:inMYA 410.8 ;
-            sdo:marginOfError 2.8
+            schema:marginOfError 2.8
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 117 ;
-    sdo:color "#E5B75A"^^ischart:RGBHex ;
+    schema:color "#E5B75A"^^ischart:RGBHex ;
 .
 
 ischart:Ludfordian
@@ -2965,15 +2965,15 @@ ischart:Ludfordian
     skos:prefLabel "Ludfordian"@en ;
     time:hasBeginning [
             ischart:inMYA 425.6 ;
-            sdo:marginOfError 0.9
+            schema:marginOfError 0.9
         ] ;
     time:hasEnd [
             ischart:inMYA 423.0 ;
-            sdo:marginOfError 2.3
+            schema:marginOfError 2.3
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 120 ;
-    sdo:color "#D9F0DF"^^ischart:RGBHex ;
+    schema:color "#D9F0DF"^^ischart:RGBHex ;
 .
 
 ischart:Lutetian
@@ -3014,7 +3014,7 @@ ischart:Lutetian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 27 ;
-    sdo:color "#FDB482"^^ischart:RGBHex ;
+    schema:color "#FDB482"^^ischart:RGBHex ;
 .
 
 ischart:Maastrichtian
@@ -3049,14 +3049,14 @@ ischart:Maastrichtian
     skos:prefLabel "Maastrichtian"@en ;
     time:hasBeginning [
             ischart:inMYA 72.1 ;
-            sdo:marginOfError 0.2
+            schema:marginOfError 0.2
         ] ;
     time:hasEnd [
             ischart:inMYA 66.0
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 36 ;
-    sdo:color "#F2FA8C"^^ischart:RGBHex ;
+    schema:color "#F2FA8C"^^ischart:RGBHex ;
 .
 
 ischart:Meghalayan
@@ -3076,7 +3076,7 @@ ischart:Meghalayan
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 1 ;
-    sdo:color "#FDEDEC"^^ischart:RGBHex ;
+    schema:color "#FDEDEC"^^ischart:RGBHex ;
 .
 
 ischart:Mesoarchean
@@ -3119,7 +3119,7 @@ ischart:Mesoarchean
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 173 ;
-    sdo:color "#F768A9"^^ischart:RGBHex ;
+    schema:color "#F768A9"^^ischart:RGBHex ;
 .
 
 ischart:Messinian
@@ -3160,7 +3160,7 @@ ischart:Messinian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 14 ;
-    sdo:color "#FFFF73"^^ischart:RGBHex ;
+    schema:color "#FFFF73"^^ischart:RGBHex ;
 .
 
 ischart:Moscovian
@@ -3195,15 +3195,15 @@ ischart:Moscovian
     skos:prefLabel "Moscovian"@en ;
     time:hasBeginning [
             ischart:inMYA 315.2 ;
-            sdo:marginOfError 0.2
+            schema:marginOfError 0.2
         ] ;
     time:hasEnd [
             ischart:inMYA 307.0 ;
-            sdo:marginOfError 0.1
+            schema:marginOfError 0.1
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 96 ;
-    sdo:color "#B3CBB9"^^ischart:RGBHex ;
+    schema:color "#B3CBB9"^^ischart:RGBHex ;
 .
 
 ischart:Neoarchean
@@ -3246,7 +3246,7 @@ ischart:Neoarchean
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 172 ;
-    sdo:color "#F99BC1"^^ischart:RGBHex ;
+    schema:color "#F99BC1"^^ischart:RGBHex ;
 .
 
 ischart:Norian
@@ -3289,7 +3289,7 @@ ischart:Norian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 67 ;
-    sdo:color "#D6AAD3"^^ischart:RGBHex ;
+    schema:color "#D6AAD3"^^ischart:RGBHex ;
 .
 
 ischart:Northgrippian
@@ -3309,7 +3309,7 @@ ischart:Northgrippian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 2 ;
-    sdo:color "#FDECE4"^^ischart:RGBHex ;
+    schema:color "#FDECE4"^^ischart:RGBHex ;
 .
 
 ischart:Olenekian
@@ -3350,7 +3350,7 @@ ischart:Olenekian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 73 ;
-    sdo:color "#B051A5"^^ischart:RGBHex ;
+    schema:color "#B051A5"^^ischart:RGBHex ;
 .
 
 ischart:Orosirian
@@ -3391,7 +3391,7 @@ ischart:Orosirian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 167 ;
-    sdo:color "#F76898"^^ischart:RGBHex ;
+    schema:color "#F76898"^^ischart:RGBHex ;
 .
 
 ischart:Oxfordian
@@ -3426,15 +3426,15 @@ ischart:Oxfordian
     skos:prefLabel "Oxfordian"@en ;
     time:hasBeginning [
             ischart:inMYA 161.5 ;
-            sdo:marginOfError 1.0
+            schema:marginOfError 1.0
         ] ;
     time:hasEnd [
             ischart:inMYA 154.8 ;
-            sdo:marginOfError 0.8
+            schema:marginOfError 0.8
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 53 ;
-    sdo:color "#BFE7F1"^^ischart:RGBHex ;
+    schema:color "#BFE7F1"^^ischart:RGBHex ;
 .
 
 ischart:Paibian
@@ -3477,7 +3477,7 @@ ischart:Paibian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 145 ;
-    sdo:color "#CCEBAE"^^ischart:RGBHex ;
+    schema:color "#CCEBAE"^^ischart:RGBHex ;
 .
 
 ischart:Paleoarchean
@@ -3520,7 +3520,7 @@ ischart:Paleoarchean
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 174 ;
-    sdo:color "#F4449F"^^ischart:RGBHex ;
+    schema:color "#F4449F"^^ischart:RGBHex ;
 .
 
 ischart:Piacenzian
@@ -3561,7 +3561,7 @@ ischart:Piacenzian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 11 ;
-    sdo:color "#FFFFBF"^^ischart:RGBHex ;
+    schema:color "#FFFFBF"^^ischart:RGBHex ;
 .
 
 ischart:Pliensbachian
@@ -3596,15 +3596,15 @@ ischart:Pliensbachian
     skos:prefLabel "Pliensbachian"@en ;
     time:hasBeginning [
             ischart:inMYA 192.9 ;
-            sdo:marginOfError 0.3
+            schema:marginOfError 0.3
         ] ;
     time:hasEnd [
             ischart:inMYA 184.2 ;
-            sdo:marginOfError 0.3
+            schema:marginOfError 0.3
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 61 ;
-    sdo:color "#80C5DD"^^ischart:RGBHex ;
+    schema:color "#80C5DD"^^ischart:RGBHex ;
 .
 
 ischart:Pragian
@@ -3639,15 +3639,15 @@ ischart:Pragian
     skos:prefLabel "Pragian"@en ;
     time:hasBeginning [
             ischart:inMYA 410.8 ;
-            sdo:marginOfError 2.8
+            schema:marginOfError 2.8
         ] ;
     time:hasEnd [
             ischart:inMYA 407.6 ;
-            sdo:marginOfError 2.6
+            schema:marginOfError 2.6
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 115 ;
-    sdo:color "#E5C468"^^ischart:RGBHex ;
+    schema:color "#E5C468"^^ischart:RGBHex ;
 .
 
 ischart:Priabonian
@@ -3688,7 +3688,7 @@ ischart:Priabonian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 25 ;
-    sdo:color "#FDCDA1"^^ischart:RGBHex ;
+    schema:color "#FDCDA1"^^ischart:RGBHex ;
 .
 
 ischart:Rhaetian
@@ -3727,11 +3727,11 @@ ischart:Rhaetian
         ] ;
     time:hasEnd [
             ischart:inMYA 201.4 ;
-            sdo:marginOfError 0.2
+            schema:marginOfError 0.2
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 66 ;
-    sdo:color "#E3B9DB"^^ischart:RGBHex ;
+    schema:color "#E3B9DB"^^ischart:RGBHex ;
 .
 
 ischart:Rhuddanian
@@ -3766,15 +3766,15 @@ ischart:Rhuddanian
     skos:prefLabel "Rhuddanian"@en ;
     time:hasBeginning [
             ischart:inMYA 443.8 ;
-            sdo:marginOfError 1.5
+            schema:marginOfError 1.5
         ] ;
     time:hasEnd [
             ischart:inMYA 440.8 ;
-            sdo:marginOfError 1.2
+            schema:marginOfError 1.2
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 129 ;
-    sdo:color "#A6DCB5"^^ischart:RGBHex ;
+    schema:color "#A6DCB5"^^ischart:RGBHex ;
 .
 
 ischart:Rhyacian
@@ -3815,7 +3815,7 @@ ischart:Rhyacian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 168 ;
-    sdo:color "#F75B89"^^ischart:RGBHex ;
+    schema:color "#F75B89"^^ischart:RGBHex ;
 .
 
 ischart:Roadian
@@ -3850,15 +3850,15 @@ ischart:Roadian
     skos:prefLabel "Roadian"@en ;
     time:hasBeginning [
             ischart:inMYA 273.01 ;
-            sdo:marginOfError 0.14
+            schema:marginOfError 0.14
         ] ;
     time:hasEnd [
             ischart:inMYA 266.9 ;
-            sdo:marginOfError 0.4
+            schema:marginOfError 0.4
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 85 ;
-    sdo:color "#FB8069"^^ischart:RGBHex ;
+    schema:color "#FB8069"^^ischart:RGBHex ;
 .
 
 ischart:Rupelian
@@ -3899,7 +3899,7 @@ ischart:Rupelian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 24 ;
-    sdo:color "#FED99A"^^ischart:RGBHex ;
+    schema:color "#FED99A"^^ischart:RGBHex ;
 .
 
 ischart:Sakmarian
@@ -3934,15 +3934,15 @@ ischart:Sakmarian
     skos:prefLabel "Sakmarian"@en ;
     time:hasBeginning [
             ischart:inMYA 293.51 ;
-            sdo:marginOfError 0.17
+            schema:marginOfError 0.17
         ] ;
     time:hasEnd [
             ischart:inMYA 290.1 ;
-            sdo:marginOfError 0.26
+            schema:marginOfError 0.26
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 88 ;
-    sdo:color "#E36F5C"^^ischart:RGBHex ;
+    schema:color "#E36F5C"^^ischart:RGBHex ;
 .
 
 ischart:Sandbian
@@ -3977,15 +3977,15 @@ ischart:Sandbian
     skos:prefLabel "Sandbian"@en ;
     time:hasBeginning [
             ischart:inMYA 458.4 ;
-            sdo:marginOfError 0.9
+            schema:marginOfError 0.9
         ] ;
     time:hasEnd [
             ischart:inMYA 453.0 ;
-            sdo:marginOfError 0.7
+            schema:marginOfError 0.7
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 133 ;
-    sdo:color "#8CD094"^^ischart:RGBHex ;
+    schema:color "#8CD094"^^ischart:RGBHex ;
 .
 
 ischart:Santonian
@@ -4020,15 +4020,15 @@ ischart:Santonian
     skos:prefLabel "Santonian"@en ;
     time:hasBeginning [
             ischart:inMYA 86.3 ;
-            sdo:marginOfError 0.5
+            schema:marginOfError 0.5
         ] ;
     time:hasEnd [
             ischart:inMYA 83.6 ;
-            sdo:marginOfError 0.2
+            schema:marginOfError 0.2
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 38 ;
-    sdo:color "#D9EF74"^^ischart:RGBHex ;
+    schema:color "#D9EF74"^^ischart:RGBHex ;
 .
 
 ischart:Selandian
@@ -4069,7 +4069,7 @@ ischart:Selandian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 31 ;
-    sdo:color "#FEBF65"^^ischart:RGBHex ;
+    schema:color "#FEBF65"^^ischart:RGBHex ;
 .
 
 ischart:Serpukhovian
@@ -4104,15 +4104,15 @@ ischart:Serpukhovian
     skos:prefLabel "Serpukhovian"@en ;
     time:hasBeginning [
             ischart:inMYA 330.9 ;
-            sdo:marginOfError 0.2
+            schema:marginOfError 0.2
         ] ;
     time:hasEnd [
             ischart:inMYA 323.2 ;
-            sdo:marginOfError 0.4
+            schema:marginOfError 0.4
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 100 ;
-    sdo:color "#BFC26B"^^ischart:RGBHex ;
+    schema:color "#BFC26B"^^ischart:RGBHex ;
 .
 
 ischart:Serravallian
@@ -4153,7 +4153,7 @@ ischart:Serravallian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 16 ;
-    sdo:color "#FFFF59"^^ischart:RGBHex ;
+    schema:color "#FFFF59"^^ischart:RGBHex ;
 .
 
 ischart:Sheinwoodian
@@ -4188,15 +4188,15 @@ ischart:Sheinwoodian
     skos:prefLabel "Sheinwoodian"@en ;
     time:hasBeginning [
             ischart:inMYA 433.4 ;
-            sdo:marginOfError 0.8
+            schema:marginOfError 0.8
         ] ;
     time:hasEnd [
             ischart:inMYA 430.5 ;
-            sdo:marginOfError 0.7
+            schema:marginOfError 0.7
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 124 ;
-    sdo:color "#BFE6C3"^^ischart:RGBHex ;
+    schema:color "#BFE6C3"^^ischart:RGBHex ;
 .
 
 ischart:Siderian
@@ -4237,7 +4237,7 @@ ischart:Siderian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 171 ;
-    sdo:color "#F74F7C"^^ischart:RGBHex ;
+    schema:color "#F74F7C"^^ischart:RGBHex ;
 .
 
 ischart:Sinemurian
@@ -4272,15 +4272,15 @@ ischart:Sinemurian
     skos:prefLabel "Sinemurian"@en ;
     time:hasBeginning [
             ischart:inMYA 199.5 ;
-            sdo:marginOfError 0.3
+            schema:marginOfError 0.3
         ] ;
     time:hasEnd [
             ischart:inMYA 192.9 ;
-            sdo:marginOfError 0.3
+            schema:marginOfError 0.3
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 62 ;
-    sdo:color "#67BCD8"^^ischart:RGBHex ;
+    schema:color "#67BCD8"^^ischart:RGBHex ;
 .
 
 ischart:Statherian
@@ -4321,7 +4321,7 @@ ischart:Statherian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 166 ;
-    sdo:color "#F875A7"^^ischart:RGBHex ;
+    schema:color "#F875A7"^^ischart:RGBHex ;
 .
 
 ischart:Stenian
@@ -4362,7 +4362,7 @@ ischart:Stenian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 162 ;
-    sdo:color "#FED99A"^^ischart:RGBHex ;
+    schema:color "#FED99A"^^ischart:RGBHex ;
 .
 
 ischart:Telychian
@@ -4397,15 +4397,15 @@ ischart:Telychian
     skos:prefLabel "Telychian"@en ;
     time:hasBeginning [
             ischart:inMYA 438.5 ;
-            sdo:marginOfError 1.1
+            schema:marginOfError 1.1
         ] ;
     time:hasEnd [
             ischart:inMYA 433.4 ;
-            sdo:marginOfError 0.8
+            schema:marginOfError 0.8
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 126 ;
-    sdo:color "#BFE6CF"^^ischart:RGBHex ;
+    schema:color "#BFE6CF"^^ischart:RGBHex ;
 .
 
 ischart:Thanetian
@@ -4446,7 +4446,7 @@ ischart:Thanetian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 30 ;
-    sdo:color "#FDBF6F"^^ischart:RGBHex ;
+    schema:color "#FDBF6F"^^ischart:RGBHex ;
 .
 
 ischart:Tithonian
@@ -4481,7 +4481,7 @@ ischart:Tithonian
     skos:prefLabel "Tithonian"@en ;
     time:hasBeginning [
             ischart:inMYA 149.2 ;
-            sdo:marginOfError 0.7
+            schema:marginOfError 0.7
         ] ;
     time:hasEnd [
             ischart:inMYA 145 ;
@@ -4489,7 +4489,7 @@ ischart:Tithonian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 51 ;
-    sdo:color "#D9F1F7"^^ischart:RGBHex ;
+    schema:color "#D9F1F7"^^ischart:RGBHex ;
 .
 
 ischart:Toarcian
@@ -4524,15 +4524,15 @@ ischart:Toarcian
     skos:prefLabel "Toarcian"@en ;
     time:hasBeginning [
             ischart:inMYA 184.2 ;
-            sdo:marginOfError 0.3
+            schema:marginOfError 0.3
         ] ;
     time:hasEnd [
             ischart:inMYA 174.7 ;
-            sdo:marginOfError 0.8
+            schema:marginOfError 0.8
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 60 ;
-    sdo:color "#99CEE3"^^ischart:RGBHex ;
+    schema:color "#99CEE3"^^ischart:RGBHex ;
 .
 
 ischart:Tonian
@@ -4574,7 +4574,7 @@ ischart:Tonian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 161 ;
-    sdo:color "#FEBF4E"^^ischart:RGBHex ;
+    schema:color "#FEBF4E"^^ischart:RGBHex ;
 .
 
 ischart:Tortonian
@@ -4615,7 +4615,7 @@ ischart:Tortonian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 15 ;
-    sdo:color "#FFFF66"^^ischart:RGBHex ;
+    schema:color "#FFFF66"^^ischart:RGBHex ;
 .
 
 ischart:Tournaisian
@@ -4650,15 +4650,15 @@ ischart:Tournaisian
     skos:prefLabel "Tournaisian"@en ;
     time:hasBeginning [
             ischart:inMYA 358.9 ;
-            sdo:marginOfError 0.4
+            schema:marginOfError 0.4
         ] ;
     time:hasEnd [
             ischart:inMYA 346.7 ;
-            sdo:marginOfError 0.4
+            schema:marginOfError 0.4
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 107 ;
-    sdo:color "#8CB06C"^^ischart:RGBHex ;
+    schema:color "#8CB06C"^^ischart:RGBHex ;
 .
 
 ischart:Tremadocian
@@ -4693,15 +4693,15 @@ ischart:Tremadocian
     skos:prefLabel "Tremadocian"@en ;
     time:hasBeginning [
             ischart:inMYA 485.4 ;
-            sdo:marginOfError 1.9
+            schema:marginOfError 1.9
         ] ;
     time:hasEnd [
             ischart:inMYA 477.7 ;
-            sdo:marginOfError 1.4
+            schema:marginOfError 1.4
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 141 ;
-    sdo:color "#33A97E"^^ischart:RGBHex ;
+    schema:color "#33A97E"^^ischart:RGBHex ;
 .
 
 ischart:Turonian
@@ -4739,11 +4739,11 @@ ischart:Turonian
         ] ;
     time:hasEnd [
             ischart:inMYA 89.8 ;
-            sdo:marginOfError 0.3
+            schema:marginOfError 0.3
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 40 ;
-    sdo:color "#BFE35D"^^ischart:RGBHex ;
+    schema:color "#BFE35D"^^ischart:RGBHex ;
 .
 
 ischart:UpperPleistocene
@@ -4780,7 +4780,7 @@ ischart:UpperPleistocene
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 5 ;
-    sdo:color "#FFF2D3"^^ischart:RGBHex ;
+    schema:color "#FFF2D3"^^ischart:RGBHex ;
 .
 
 ischart:Valanginian
@@ -4823,7 +4823,7 @@ ischart:Valanginian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 47 ;
-    sdo:color "#99D36A"^^ischart:RGBHex ;
+    schema:color "#99D36A"^^ischart:RGBHex ;
 .
 
 ischart:Visean
@@ -4858,15 +4858,15 @@ ischart:Visean
     skos:prefLabel "Visean"@en ;
     time:hasBeginning [
             ischart:inMYA 346.7 ;
-            sdo:marginOfError 0.4
+            schema:marginOfError 0.4
         ] ;
     time:hasEnd [
             ischart:inMYA 330.9 ;
-            sdo:marginOfError 0.2
+            schema:marginOfError 0.2
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 103 ;
-    sdo:color "#A6B96C"^^ischart:RGBHex ;
+    schema:color "#A6B96C"^^ischart:RGBHex ;
 .
 
 ischart:Wordian
@@ -4901,15 +4901,15 @@ ischart:Wordian
     skos:prefLabel "Wordian"@en ;
     time:hasBeginning [
             ischart:inMYA 266.9 ;
-            sdo:marginOfError 0.4
+            schema:marginOfError 0.4
         ] ;
     time:hasEnd [
             ischart:inMYA 264.28 ;
-            sdo:marginOfError 0.16
+            schema:marginOfError 0.16
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 83 ;
-    sdo:color "#FB8D76"^^ischart:RGBHex ;
+    schema:color "#FB8D76"^^ischart:RGBHex ;
 .
 
 ischart:Wuchiapingian
@@ -4944,15 +4944,15 @@ ischart:Wuchiapingian
     skos:prefLabel "Wuchiapingian"@en ;
     time:hasBeginning [
             ischart:inMYA 259.51 ;
-            sdo:marginOfError 0.21
+            schema:marginOfError 0.21
         ] ;
     time:hasEnd [
             ischart:inMYA 254.14 ;
-            sdo:marginOfError 0.07
+            schema:marginOfError 0.07
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 81 ;
-    sdo:color "#FCB4A2"^^ischart:RGBHex ;
+    schema:color "#FCB4A2"^^ischart:RGBHex ;
 .
 
 ischart:Wuliuan
@@ -4974,7 +4974,7 @@ ischart:Wuliuan
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 149 ;
-    sdo:color "#B3D492"^^ischart:RGBHex ;
+    schema:color "#B3D492"^^ischart:RGBHex ;
 .
 
 ischart:Ypresian
@@ -5015,7 +5015,7 @@ ischart:Ypresian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 29 ;
-    sdo:color "#FCA773"^^ischart:RGBHex ;
+    schema:color "#FCA773"^^ischart:RGBHex ;
 .
 
 ischart:Zanclean
@@ -5056,7 +5056,7 @@ ischart:Zanclean
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 13 ;
-    sdo:color "#FFFFB3"^^ischart:RGBHex ;
+    schema:color "#FFFFB3"^^ischart:RGBHex ;
 .
 
 ischart:LowerMississippian
@@ -5074,15 +5074,15 @@ ischart:LowerMississippian
     skos:prefLabel "Early Mississippian"@en ;
     time:hasBeginning [
             ischart:inMYA 358.9 ;
-            sdo:marginOfError 0.4
+            schema:marginOfError 0.4
         ] ;
     time:hasEnd [
             ischart:inMYA 346.7 ;
-            sdo:marginOfError 0.4
+            schema:marginOfError 0.4
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 105 ;
-    sdo:color "#80AB6C"^^ischart:RGBHex ;
+    schema:color "#80AB6C"^^ischart:RGBHex ;
 .
 
 ischart:LowerPennsylvanian
@@ -5100,15 +5100,15 @@ ischart:LowerPennsylvanian
     skos:prefLabel "Early Pennsylvanian"@en ;
     time:hasBeginning [
             ischart:inMYA 323.2 ;
-            sdo:marginOfError 0.4
+            schema:marginOfError 0.4
         ] ;
     time:hasEnd [
             ischart:inMYA 315.2 ;
-            sdo:marginOfError 0.2
+            schema:marginOfError 0.2
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 98 ;
-    sdo:color "#8CBEB4"^^ischart:RGBHex ;
+    schema:color "#8CBEB4"^^ischart:RGBHex ;
 .
 
 ischart:MiddleMississippian
@@ -5126,15 +5126,15 @@ ischart:MiddleMississippian
     skos:prefLabel "Middle Mississippian"@en ;
     time:hasBeginning [
             ischart:inMYA 346.7 ;
-            sdo:marginOfError 0.4
+            schema:marginOfError 0.4
         ] ;
     time:hasEnd [
             ischart:inMYA 330.9 ;
-            sdo:marginOfError 0.2
+            schema:marginOfError 0.2
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 102 ;
-    sdo:color "#99B46C"^^ischart:RGBHex ;
+    schema:color "#99B46C"^^ischart:RGBHex ;
 .
 
 ischart:MiddlePennsylvanian
@@ -5152,15 +5152,15 @@ ischart:MiddlePennsylvanian
     skos:prefLabel "Middle Pennsylvanian"@en ;
     time:hasBeginning [
             ischart:inMYA 315.2 ;
-            sdo:marginOfError 0.2
+            schema:marginOfError 0.2
         ] ;
     time:hasEnd [
             ischart:inMYA 307.0 ;
-            sdo:marginOfError 0.1
+            schema:marginOfError 0.1
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 95 ;
-    sdo:color "#A6C7B7"^^ischart:RGBHex ;
+    schema:color "#A6C7B7"^^ischart:RGBHex ;
 .
 
 ischart:Pridoli
@@ -5197,15 +5197,15 @@ ischart:Pridoli
     skos:prefLabel "Pridoli"@en ;
     time:hasBeginning [
             ischart:inMYA 423.0 ;
-            sdo:marginOfError 2.3
+            schema:marginOfError 2.3
         ] ;
     time:hasEnd [
             ischart:inMYA 419.2 ;
-            sdo:marginOfError 3.2
+            schema:marginOfError 3.2
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 119 ;
-    sdo:color "#E6F5E1"^^ischart:RGBHex ;
+    schema:color "#E6F5E1"^^ischart:RGBHex ;
 .
 
 ischart:UpperMississippian
@@ -5223,21 +5223,21 @@ ischart:UpperMississippian
     skos:prefLabel "Late Mississippian"@en ;
     time:hasBeginning [
             ischart:inMYA 330.9 ;
-            sdo:marginOfError 0.2
+            schema:marginOfError 0.2
         ] ;
     time:hasEnd [
             ischart:inMYA 323.2 ;
-            sdo:marginOfError 0.4
+            schema:marginOfError 0.4
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 101 ;
-    sdo:color "#B3BE6C"^^ischart:RGBHex ;
+    schema:color "#B3BE6C"^^ischart:RGBHex ;
 .
 
 <https://linked.data.gov.au/org/ics>
-    a sdo:Organization ;
-    sdo:name "International Commission on Stratigraphy" ;
-    sdo:url "https://stratigraphy.org"^^xsd:anyURI ;
+    a schema:Organization ;
+    schema:name "International Commission on Stratigraphy" ;
+    schema:url "https://stratigraphy.org"^^xsd:anyURI ;
 .
 
 ischart:CambrianSeries2
@@ -5283,7 +5283,7 @@ ischart:CambrianSeries2
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 151 ;
-    sdo:color "#99C078"^^ischart:RGBHex ;
+    schema:color "#99C078"^^ischart:RGBHex ;
 .
 
 ischart:Carboniferous
@@ -5321,15 +5321,15 @@ ischart:Carboniferous
     skos:prefLabel "Carboniferous"@en ;
     time:hasBeginning [
             ischart:inMYA 358.9 ;
-            sdo:marginOfError 0.4
+            schema:marginOfError 0.4
         ] ;
     time:hasEnd [
             ischart:inMYA 298.9 ;
-            sdo:marginOfError 0.15
+            schema:marginOfError 0.15
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 104 ;
-    sdo:color "#67A599"^^ischart:RGBHex ;
+    schema:color "#67A599"^^ischart:RGBHex ;
 .
 
 ischart:Cretaceous
@@ -5374,7 +5374,7 @@ ischart:Cretaceous
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 49 ;
-    sdo:color "#7FC64E"^^ischart:RGBHex ;
+    schema:color "#7FC64E"^^ischart:RGBHex ;
 .
 
 ischart:Lopingian
@@ -5412,15 +5412,15 @@ ischart:Lopingian
     skos:prefLabel "Lopingian"@en ;
     time:hasBeginning [
             ischart:inMYA 259.51 ;
-            sdo:marginOfError 0.21
+            schema:marginOfError 0.21
         ] ;
     time:hasEnd [
             ischart:inMYA 251.902 ;
-            sdo:marginOfError 0.024
+            schema:marginOfError 0.024
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 80 ;
-    sdo:color "#FBA794"^^ischart:RGBHex ;
+    schema:color "#FBA794"^^ischart:RGBHex ;
 .
 
 ischart:LowerOrdovician
@@ -5458,15 +5458,15 @@ ischart:LowerOrdovician
     skos:prefLabel "Early Ordovician"@en ;
     time:hasBeginning [
             ischart:inMYA 485.4 ;
-            sdo:marginOfError 1.9
+            schema:marginOfError 1.9
         ] ;
     time:hasEnd [
             ischart:inMYA 470.0 ;
-            sdo:marginOfError 1.4
+            schema:marginOfError 1.4
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 139 ;
-    sdo:color "#1A9D6F"^^ischart:RGBHex ;
+    schema:color "#1A9D6F"^^ischart:RGBHex ;
 .
 
 ischart:LowerTriassic
@@ -5504,14 +5504,14 @@ ischart:LowerTriassic
     skos:prefLabel "Early Triassic"@en ;
     time:hasBeginning [
             ischart:inMYA 251.902 ;
-            sdo:marginOfError 0.024
+            schema:marginOfError 0.024
         ] ;
     time:hasEnd [
             ischart:inMYA 247.2
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 75 ;
-    sdo:color "#983999"^^ischart:RGBHex ;
+    schema:color "#983999"^^ischart:RGBHex ;
 .
 
 ischart:Ludlow
@@ -5549,15 +5549,15 @@ ischart:Ludlow
     skos:prefLabel "Ludlow"@en ;
     time:hasBeginning [
             ischart:inMYA 427.4 ;
-            sdo:marginOfError 0.5
+            schema:marginOfError 0.5
         ] ;
     time:hasEnd [
             ischart:inMYA 419.2 ;
-            sdo:marginOfError 3.2
+            schema:marginOfError 3.2
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 122 ;
-    sdo:color "#BFE6CF"^^ischart:RGBHex ;
+    schema:color "#BFE6CF"^^ischart:RGBHex ;
 .
 
 ischart:MiddleDevonian
@@ -5595,15 +5595,15 @@ ischart:MiddleDevonian
     skos:prefLabel "Middle Devonian"@en ;
     time:hasBeginning [
             ischart:inMYA 393.3 ;
-            sdo:marginOfError 1.2
+            schema:marginOfError 1.2
         ] ;
     time:hasEnd [
             ischart:inMYA 382.7 ;
-            sdo:marginOfError 1.6
+            schema:marginOfError 1.6
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 113 ;
-    sdo:color "#F1C868"^^ischart:RGBHex ;
+    schema:color "#F1C868"^^ischart:RGBHex ;
 .
 
 ischart:MiddleOrdovician
@@ -5641,15 +5641,15 @@ ischart:MiddleOrdovician
     skos:prefLabel "Middle Ordovician"@en ;
     time:hasBeginning [
             ischart:inMYA 470.0 ;
-            sdo:marginOfError 1.4
+            schema:marginOfError 1.4
         ] ;
     time:hasEnd [
             ischart:inMYA 458.4 ;
-            sdo:marginOfError 0.9
+            schema:marginOfError 0.9
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 137 ;
-    sdo:color "#4DB47E"^^ischart:RGBHex ;
+    schema:color "#4DB47E"^^ischart:RGBHex ;
 .
 
 ischart:MiddleTriassic
@@ -5694,7 +5694,7 @@ ischart:MiddleTriassic
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 72 ;
-    sdo:color "#B168B1"^^ischart:RGBHex ;
+    schema:color "#B168B1"^^ischart:RGBHex ;
 .
 
 ischart:Neogene
@@ -5738,7 +5738,7 @@ ischart:Neogene
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 21 ;
-    sdo:color "#FFE619"^^ischart:RGBHex ;
+    schema:color "#FFE619"^^ischart:RGBHex ;
 .
 
 ischart:Oligocene
@@ -5782,7 +5782,7 @@ ischart:Oligocene
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 23 ;
-    sdo:color "#FEC07A"^^ischart:RGBHex ;
+    schema:color "#FEC07A"^^ischart:RGBHex ;
 .
 
 ischart:Pliocene
@@ -5826,7 +5826,7 @@ ischart:Pliocene
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 12 ;
-    sdo:color "#FFFF99"^^ischart:RGBHex ;
+    schema:color "#FFFF99"^^ischart:RGBHex ;
 .
 
 ischart:Quaternary
@@ -5870,7 +5870,7 @@ ischart:Quaternary
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 10 ;
-    sdo:color "#F9F97F"^^ischart:RGBHex ;
+    schema:color "#F9F97F"^^ischart:RGBHex ;
 .
 
 ischart:Terreneuvian
@@ -5908,7 +5908,7 @@ ischart:Terreneuvian
     skos:prefLabel "Terreneuvian"@en ;
     time:hasBeginning [
             ischart:inMYA 538.8 ;
-            sdo:marginOfError 0.2
+            schema:marginOfError 0.2
         ] ;
     time:hasEnd [
             ischart:inMYA 521 ;
@@ -5916,7 +5916,7 @@ ischart:Terreneuvian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 157 ;
-    sdo:color "#8CB06C"^^ischart:RGBHex ;
+    schema:color "#8CB06C"^^ischart:RGBHex ;
 .
 
 ischart:UpperDevonian
@@ -5950,15 +5950,15 @@ ischart:UpperDevonian
     skos:prefLabel "Late Devonian"@en ;
     time:hasBeginning [
             ischart:inMYA 382.7 ;
-            sdo:marginOfError 1.6
+            schema:marginOfError 1.6
         ] ;
     time:hasEnd [
             ischart:inMYA 358.9 ;
-            sdo:marginOfError 0.4
+            schema:marginOfError 0.4
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 110 ;
-    sdo:color "#F1E19D"^^ischart:RGBHex ;
+    schema:color "#F1E19D"^^ischart:RGBHex ;
 .
 
 ischart:UpperPennsylvanian
@@ -5992,15 +5992,15 @@ ischart:UpperPennsylvanian
     skos:prefLabel "Late Pennsylvanian"@en ;
     time:hasBeginning [
             ischart:inMYA 307.0 ;
-            sdo:marginOfError 0.1
+            schema:marginOfError 0.1
         ] ;
     time:hasEnd [
             ischart:inMYA 298.9 ;
-            sdo:marginOfError 0.15
+            schema:marginOfError 0.15
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 94 ;
-    sdo:color "#BFD0BA"^^ischart:RGBHex ;
+    schema:color "#BFD0BA"^^ischart:RGBHex ;
 .
 
 ischart:Wenlock
@@ -6038,15 +6038,15 @@ ischart:Wenlock
     skos:prefLabel "Wenlock"@en ;
     time:hasBeginning [
             ischart:inMYA 433.4 ;
-            sdo:marginOfError 0.8
+            schema:marginOfError 0.8
         ] ;
     time:hasEnd [
             ischart:inMYA 427.4 ;
-            sdo:marginOfError 0.5
+            schema:marginOfError 0.5
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 125 ;
-    sdo:color "#B3E1C2"^^ischart:RGBHex ;
+    schema:color "#B3E1C2"^^ischart:RGBHex ;
 .
 
 ischart:Cenozoic
@@ -6093,7 +6093,7 @@ ischart:Cenozoic
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 32 ;
-    sdo:color "#F2F91D"^^ischart:RGBHex ;
+    schema:color "#F2F91D"^^ischart:RGBHex ;
 .
 
 ischart:Devonian
@@ -6132,15 +6132,15 @@ ischart:Devonian
     skos:prefLabel "Devonian"@en ;
     time:hasBeginning [
             ischart:inMYA 419.2 ;
-            sdo:marginOfError 3.2
+            schema:marginOfError 3.2
         ] ;
     time:hasEnd [
             ischart:inMYA 358.9 ;
-            sdo:marginOfError 0.4
+            schema:marginOfError 0.4
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 116 ;
-    sdo:color "#CB8C37"^^ischart:RGBHex ;
+    schema:color "#CB8C37"^^ischart:RGBHex ;
 .
 
 ischart:Furongian
@@ -6183,11 +6183,11 @@ ischart:Furongian
         ] ;
     time:hasEnd [
             ischart:inMYA 485.4 ;
-            sdo:marginOfError 1.9
+            schema:marginOfError 1.9
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 144 ;
-    sdo:color "#B3E095"^^ischart:RGBHex ;
+    schema:color "#B3E095"^^ischart:RGBHex ;
 .
 
 ischart:Guadalupian
@@ -6226,15 +6226,15 @@ ischart:Guadalupian
     skos:prefLabel "Guadalupian"@en ;
     time:hasBeginning [
             ischart:inMYA 273.01 ;
-            sdo:marginOfError 0.14
+            schema:marginOfError 0.14
         ] ;
     time:hasEnd [
             ischart:inMYA 259.51 ;
-            sdo:marginOfError 0.21
+            schema:marginOfError 0.21
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 84 ;
-    sdo:color "#FB745C"^^ischart:RGBHex ;
+    schema:color "#FB745C"^^ischart:RGBHex ;
 .
 
 ischart:Holocene
@@ -6279,7 +6279,7 @@ ischart:Holocene
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 4 ;
-    sdo:color "#FEEBD2"^^ischart:RGBHex ;
+    schema:color "#FEEBD2"^^ischart:RGBHex ;
 .
 
 ischart:Jurassic
@@ -6318,7 +6318,7 @@ ischart:Jurassic
     skos:prefLabel "Jurassic"@en ;
     time:hasBeginning [
             ischart:inMYA 201.4 ;
-            sdo:marginOfError 0.2
+            schema:marginOfError 0.2
         ] ;
     time:hasEnd [
             ischart:inMYA 145.0 ;
@@ -6326,7 +6326,7 @@ ischart:Jurassic
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 64 ;
-    sdo:color "#34B2C9"^^ischart:RGBHex ;
+    schema:color "#34B2C9"^^ischart:RGBHex ;
 .
 
 ischart:Llandovery
@@ -6365,15 +6365,15 @@ ischart:Llandovery
     skos:prefLabel "Llandovery"@en ;
     time:hasBeginning [
             ischart:inMYA 443.8 ;
-            sdo:marginOfError 1.5
+            schema:marginOfError 1.5
         ] ;
     time:hasEnd [
             ischart:inMYA 433.4 ;
-            sdo:marginOfError 0.8
+            schema:marginOfError 0.8
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 128 ;
-    sdo:color "#99D7B3"^^ischart:RGBHex ;
+    schema:color "#99D7B3"^^ischart:RGBHex ;
 .
 
 ischart:LowerDevonian
@@ -6412,15 +6412,15 @@ ischart:LowerDevonian
     skos:prefLabel "Early Devonian"@en ;
     time:hasBeginning [
             ischart:inMYA 419.2 ;
-            sdo:marginOfError 3.2
+            schema:marginOfError 3.2
         ] ;
     time:hasEnd [
             ischart:inMYA 393.3 ;
-            sdo:marginOfError 1.2
+            schema:marginOfError 1.2
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 118 ;
-    sdo:color "#E5AC4D"^^ischart:RGBHex ;
+    schema:color "#E5AC4D"^^ischart:RGBHex ;
 .
 
 ischart:Mesoproterozoic
@@ -6465,7 +6465,7 @@ ischart:Mesoproterozoic
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 165 ;
-    sdo:color "#FDB462"^^ischart:RGBHex ;
+    schema:color "#FDB462"^^ischart:RGBHex ;
 .
 
 ischart:Mesozoic
@@ -6504,14 +6504,14 @@ ischart:Mesozoic
     skos:prefLabel "Mesozoic"@en ;
     time:hasBeginning [
             ischart:inMYA 251.902 ;
-            sdo:marginOfError 0.024
+            schema:marginOfError 0.024
         ] ;
     time:hasEnd [
             ischart:inMYA 66.0
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 76 ;
-    sdo:color "#67C5CA"^^ischart:RGBHex ;
+    schema:color "#67C5CA"^^ischart:RGBHex ;
 .
 
 ischart:Miaolingian
@@ -6537,7 +6537,7 @@ ischart:Miaolingian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 148 ;
-    sdo:color "#A6CF86"^^ischart:RGBHex ;
+    schema:color "#A6CF86"^^ischart:RGBHex ;
 .
 
 ischart:Mississippian
@@ -6576,15 +6576,15 @@ ischart:Mississippian
     skos:prefLabel "Mississippian"@en ;
     time:hasBeginning [
             ischart:inMYA 358.9 ;
-            sdo:marginOfError 0.4
+            schema:marginOfError 0.4
         ] ;
     time:hasEnd [
             ischart:inMYA 323.2 ;
-            sdo:marginOfError 0.4
+            schema:marginOfError 0.4
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 106 ;
-    sdo:color "#678F66"^^ischart:RGBHex ;
+    schema:color "#678F66"^^ischart:RGBHex ;
 .
 
 ischart:Neoproterozoic
@@ -6626,11 +6626,11 @@ ischart:Neoproterozoic
         ] ;
     time:hasEnd [
             ischart:inMYA 538.8 ;
-            sdo:marginOfError 0.2
+            schema:marginOfError 0.2
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 160 ;
-    sdo:color "#FEB342"^^ischart:RGBHex ;
+    schema:color "#FEB342"^^ischart:RGBHex ;
 .
 
 ischart:Ordovician
@@ -6669,15 +6669,15 @@ ischart:Ordovician
     skos:prefLabel "Ordovician"@en ;
     time:hasBeginning [
             ischart:inMYA 485.4 ;
-            sdo:marginOfError 1.9
+            schema:marginOfError 1.9
         ] ;
     time:hasEnd [
             ischart:inMYA 443.8 ;
-            sdo:marginOfError 1.5
+            schema:marginOfError 1.5
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 140 ;
-    sdo:color "#009270"^^ischart:RGBHex ;
+    schema:color "#009270"^^ischart:RGBHex ;
 .
 
 ischart:Paleocene
@@ -6724,7 +6724,7 @@ ischart:Paleocene
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 34 ;
-    sdo:color "#FDA75F"^^ischart:RGBHex ;
+    schema:color "#FDA75F"^^ischart:RGBHex ;
 .
 
 ischart:Paleogene
@@ -6771,7 +6771,7 @@ ischart:Paleogene
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 35 ;
-    sdo:color "#FD9A52"^^ischart:RGBHex ;
+    schema:color "#FD9A52"^^ischart:RGBHex ;
 .
 
 ischart:Pennsylvanian
@@ -6810,15 +6810,15 @@ ischart:Pennsylvanian
     skos:prefLabel "Pennsylvanian"@en ;
     time:hasBeginning [
             ischart:inMYA 323.2 ;
-            sdo:marginOfError 0.4
+            schema:marginOfError 0.4
         ] ;
     time:hasEnd [
             ischart:inMYA 298.9 ;
-            sdo:marginOfError 0.15
+            schema:marginOfError 0.15
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 99 ;
-    sdo:color "#7EBCC6"^^ischart:RGBHex ;
+    schema:color "#7EBCC6"^^ischart:RGBHex ;
 .
 
 ischart:Permian
@@ -6857,15 +6857,15 @@ ischart:Permian
     skos:prefLabel "Permian"@en ;
     time:hasBeginning [
             ischart:inMYA 298.9 ;
-            sdo:marginOfError 0.15
+            schema:marginOfError 0.15
         ] ;
     time:hasEnd [
             ischart:inMYA 251.902 ;
-            sdo:marginOfError 0.024
+            schema:marginOfError 0.024
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 91 ;
-    sdo:color "#F04028"^^ischart:RGBHex ;
+    schema:color "#F04028"^^ischart:RGBHex ;
 .
 
 ischart:Phanerozoic
@@ -6903,14 +6903,14 @@ ischart:Phanerozoic
     skos:prefLabel "Phanerozoic"@en ;
     time:hasBeginning [
             ischart:inMYA 538.8 ;
-            sdo:marginOfError 0.2
+            schema:marginOfError 0.2
         ] ;
     time:hasEnd [
             ischart:inMYA 0
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 156 ;
-    sdo:color "#9AD9DD"^^ischart:RGBHex ;
+    schema:color "#9AD9DD"^^ischart:RGBHex ;
 .
 
 ischart:Precambrian
@@ -6951,11 +6951,11 @@ ischart:Precambrian
         ] ;
     time:hasEnd [
             ischart:inMYA 538.8 ;
-            sdo:marginOfError 0.2
+            schema:marginOfError 0.2
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 178 ;
-    sdo:color "#F74370"^^ischart:RGBHex ;
+    schema:color "#F74370"^^ischart:RGBHex ;
 .
 
 ischart:Proterozoic
@@ -6997,11 +6997,11 @@ ischart:Proterozoic
         ] ;
     time:hasEnd [
             ischart:inMYA 538.8 ;
-            sdo:marginOfError 0.2
+            schema:marginOfError 0.2
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 170 ;
-    sdo:color "#F73563"^^ischart:RGBHex ;
+    schema:color "#F73563"^^ischart:RGBHex ;
 .
 
 ischart:Triassic
@@ -7040,15 +7040,15 @@ ischart:Triassic
     skos:prefLabel "Triassic"@en ;
     time:hasBeginning [
             ischart:inMYA 251.902 ;
-            sdo:marginOfError 0.024
+            schema:marginOfError 0.024
         ] ;
     time:hasEnd [
             ischart:inMYA 201.4 ;
-            sdo:marginOfError 0.2
+            schema:marginOfError 0.2
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 78 ;
-    sdo:color "#812B92"^^ischart:RGBHex ;
+    schema:color "#812B92"^^ischart:RGBHex ;
 .
 
 ischart:UpperJurassic
@@ -7083,7 +7083,7 @@ ischart:UpperJurassic
     skos:prefLabel "Late Jurassic"@en ;
     time:hasBeginning [
             ischart:inMYA 161.5 ;
-            sdo:marginOfError 1.0
+            schema:marginOfError 1.0
         ] ;
     time:hasEnd [
             ischart:inMYA 145 ;
@@ -7091,7 +7091,7 @@ ischart:UpperJurassic
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 54 ;
-    sdo:color "#B3E3EE"^^ischart:RGBHex ;
+    schema:color "#B3E3EE"^^ischart:RGBHex ;
 .
 
 ischart:UpperOrdovician
@@ -7126,15 +7126,15 @@ ischart:UpperOrdovician
     skos:prefLabel "Late Ordovician"@en ;
     time:hasBeginning [
             ischart:inMYA 458.4 ;
-            sdo:marginOfError 0.9
+            schema:marginOfError 0.9
         ] ;
     time:hasEnd [
             ischart:inMYA 443.8 ;
-            sdo:marginOfError 1.5
+            schema:marginOfError 1.5
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 134 ;
-    sdo:color "#7FCA93"^^ischart:RGBHex ;
+    schema:color "#7FCA93"^^ischart:RGBHex ;
 .
 
 ischart:UpperTriassic
@@ -7173,11 +7173,11 @@ ischart:UpperTriassic
         ] ;
     time:hasEnd [
             ischart:inMYA 201.4 ;
-            sdo:marginOfError 0.2
+            schema:marginOfError 0.2
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 69 ;
-    sdo:color "#BD8CC3"^^ischart:RGBHex ;
+    schema:color "#BD8CC3"^^ischart:RGBHex ;
 .
 
 ischart:Archean
@@ -7219,14 +7219,14 @@ ischart:Archean
     skos:prefLabel "Archean"@en ;
     time:hasBeginning [
             ischart:inMYA 4031 ;
-            sdo:marginOfError 3
+            schema:marginOfError 3
         ] ;
     time:hasEnd [
             ischart:inMYA 2500
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 175 ;
-    sdo:color "#F0047F"^^ischart:RGBHex ;
+    schema:color "#F0047F"^^ischart:RGBHex ;
 .
 
 ischart:Cambrian
@@ -7266,15 +7266,15 @@ ischart:Cambrian
     skos:prefLabel "Cambrian"@en ;
     time:hasBeginning [
             ischart:inMYA 538.8 ;
-            sdo:marginOfError 0.2
+            schema:marginOfError 0.2
         ] ;
     time:hasEnd [
             ischart:inMYA 485.4 ;
-            sdo:marginOfError 1.9
+            schema:marginOfError 1.9
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 154 ;
-    sdo:color "#7FA056"^^ischart:RGBHex ;
+    schema:color "#7FA056"^^ischart:RGBHex ;
 .
 
 ischart:Cisuralian
@@ -7314,15 +7314,15 @@ ischart:Cisuralian
     skos:prefLabel "Cisuralian"@en ;
     time:hasBeginning [
             ischart:inMYA 298.9 ;
-            sdo:marginOfError 0.15
+            schema:marginOfError 0.15
         ] ;
     time:hasEnd [
             ischart:inMYA 273.01 ;
-            sdo:marginOfError 0.14
+            schema:marginOfError 0.14
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 90 ;
-    sdo:color "#EF5845"^^ischart:RGBHex ;
+    schema:color "#EF5845"^^ischart:RGBHex ;
 .
 
 ischart:Eocene
@@ -7368,7 +7368,7 @@ ischart:Eocene
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 28 ;
-    sdo:color "#FDB46C"^^ischart:RGBHex ;
+    schema:color "#FDB46C"^^ischart:RGBHex ;
 .
 
 ischart:LowerJurassic
@@ -7408,15 +7408,15 @@ ischart:LowerJurassic
     skos:prefLabel "Early Jurassic"@en ;
     time:hasBeginning [
             ischart:inMYA 201.4 ;
-            sdo:marginOfError 0.2
+            schema:marginOfError 0.2
         ] ;
     time:hasEnd [
             ischart:inMYA 174.7 ;
-            sdo:marginOfError 0.8
+            schema:marginOfError 0.8
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 65 ;
-    sdo:color "#42AED0"^^ischart:RGBHex ;
+    schema:color "#42AED0"^^ischart:RGBHex ;
 .
 
 ischart:MiddleJurassic
@@ -7456,15 +7456,15 @@ ischart:MiddleJurassic
     skos:prefLabel "Middle Jurassic"@en ;
     time:hasBeginning [
             ischart:inMYA 174.7 ;
-            sdo:marginOfError 0.8
+            schema:marginOfError 0.8
         ] ;
     time:hasEnd [
             ischart:inMYA 161.5 ;
-            sdo:marginOfError 1.0
+            schema:marginOfError 1.0
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 59 ;
-    sdo:color "#80CFD8"^^ischart:RGBHex ;
+    schema:color "#80CFD8"^^ischart:RGBHex ;
 .
 
 ischart:Paleoproterozoic
@@ -7512,7 +7512,7 @@ ischart:Paleoproterozoic
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 169 ;
-    sdo:color "#F74370"^^ischart:RGBHex ;
+    schema:color "#F74370"^^ischart:RGBHex ;
 .
 
 ischart:Pleistocene
@@ -7558,7 +7558,7 @@ ischart:Pleistocene
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 9 ;
-    sdo:color "#FFEFAF"^^ischart:RGBHex ;
+    schema:color "#FFEFAF"^^ischart:RGBHex ;
 .
 
 ischart:Silurian
@@ -7598,15 +7598,15 @@ ischart:Silurian
     skos:prefLabel "Silurian"@en ;
     time:hasBeginning [
             ischart:inMYA 443.8 ;
-            sdo:marginOfError 1.5
+            schema:marginOfError 1.5
         ] ;
     time:hasEnd [
             ischart:inMYA 419.2 ;
-            sdo:marginOfError 3.2
+            schema:marginOfError 3.2
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 130 ;
-    sdo:color "#B3E1B6"^^ischart:RGBHex ;
+    schema:color "#B3E1B6"^^ischart:RGBHex ;
 .
 
 ischart:LowerCretaceous
@@ -7653,7 +7653,7 @@ ischart:LowerCretaceous
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 50 ;
-    sdo:color "#8CCD57"^^ischart:RGBHex ;
+    schema:color "#8CCD57"^^ischart:RGBHex ;
 .
 
 ischart:Miocene
@@ -7701,7 +7701,7 @@ ischart:Miocene
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 20 ;
-    sdo:color "#FFFF00"^^ischart:RGBHex ;
+    schema:color "#FFFF00"^^ischart:RGBHex ;
 .
 
 ischart:Paleozoic
@@ -7745,15 +7745,15 @@ ischart:Paleozoic
     skos:prefLabel "Paleozoic"@en ;
     time:hasBeginning [
             ischart:inMYA 251.902 ;
-            sdo:marginOfError 0.024
+            schema:marginOfError 0.024
         ] ;
     time:hasEnd [
             ischart:inMYA 538.8 ;
-            sdo:marginOfError 0.2
+            schema:marginOfError 0.2
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 77 ;
-    sdo:color "#99C08D"^^ischart:RGBHex ;
+    schema:color "#99C08D"^^ischart:RGBHex ;
 .
 
 ischart:UpperCretaceous
@@ -7797,7 +7797,7 @@ ischart:UpperCretaceous
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 42 ;
-    sdo:color "#A6D84A"^^ischart:RGBHex ;
+    schema:color "#A6D84A"^^ischart:RGBHex ;
 .
 
 cs:
@@ -7817,8 +7817,8 @@ cs:
     skos:historyNote "This vocabulary uses IRIs created for the Geologic Timescale (2020) data (see http://resource.geosciml.org/vocabulary/timescale/) with dates updated from the 2023-09 Chart (see https://stratigraphy.org/chart)" ;
     skos:prefLabel "International Chronostratigraphic Chart"@en ;
     prov:wasDerivedFrom ts:gts2020 ;
-    sdo:citation "https://stratigraphy.org/chart"^^xsd:anyURI ;
-    sdo:copyrightHolder <https://linked.data.gov.au/org/ics> ;
-    sdo:copyrightNotice "(c) International Commission on Stratigraphy, 2023"@en ;
-    sdo:license <https://creativecommons.org/licenses/by/4.0/> ;
+    schema:citation "https://stratigraphy.org/chart"^^xsd:anyURI ;
+    schema:copyrightHolder <https://linked.data.gov.au/org/ics> ;
+    schema:copyrightNotice "(c) International Commission on Stratigraphy, 2023"@en ;
+    schema:license <https://creativecommons.org/licenses/by/4.0/> ;
 .

--- a/vocabularies/Geoscience-units-of-measurement.ttl
+++ b/vocabularies/Geoscience-units-of-measurement.ttl
@@ -4162,7 +4162,7 @@ cs:
             dcat:hadRole isoroles:custodian ;
             prov:agent
                 [
-                    a schema:Organization ;
+                    a schema:Person ;
                     schema:name "Erin Gray" ;
                 ] ;
         ] ,
@@ -4170,7 +4170,7 @@ cs:
             dcat:hadRole isoroles:custodian ;
             prov:agent
                 [
-                    a schema:Organization ;
+                    a schema:Person ;
                     schema:name "Angela Riganti" ;
                 ] ;
         ] ;

--- a/vocabularies/Geoscience-units-of-measurement.ttl
+++ b/vocabularies/Geoscience-units-of-measurement.ttl
@@ -3853,7 +3853,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.g​ov.au/org/gswa>
     a schema:Organization ;
-    schema:name "Gswa" ;
+    schema:name "Geological Survey of Western Australia" ;
     schema:url ""^^xsd:anyURI ;
 .
 

--- a/vocabularies/Geoscience-units-of-measurement.ttl
+++ b/vocabularies/Geoscience-units-of-measurement.ttl
@@ -4163,6 +4163,7 @@ cs:
             prov:agent
                 [
                     a schema:Person ;
+                    schema:email ""^^xsd:anyURI ;
                     schema:name "Erin Gray" ;
                 ] ;
         ] ,
@@ -4171,6 +4172,7 @@ cs:
             prov:agent
                 [
                     a schema:Person ;
+                    schema:email ""^^xsd:anyURI ;
                     schema:name "Angela Riganti" ;
                 ] ;
         ] ;

--- a/vocabularies/Geoscience-units-of-measurement.ttl
+++ b/vocabularies/Geoscience-units-of-measurement.ttl
@@ -3854,7 +3854,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.g​ov.au/org/gswa>
     a schema:Organization ;
     schema:name "Geological Survey of Western Australia" ;
-    schema:url ""^^xsd:anyURI ;
+    schema:url "https://www.dmp.wa.gov.au/Geological-Survey/Geological-Survey-262.aspx"^^xsd:anyURI ;
 .
 
 cs:
@@ -4164,7 +4164,6 @@ cs:
                 [
                     a schema:Organization ;
                     schema:name "Erin Gray" ;
-                    schema:url ""^^xsd:anyURI ;
                 ] ;
         ] ,
         [
@@ -4173,7 +4172,6 @@ cs:
                 [
                     a schema:Organization ;
                     schema:name "Angela Riganti" ;
-                    schema:url ""^^xsd:anyURI ;
                 ] ;
         ] ;
     schema:creator <https://linked.data.g​ov.au/org/gswa> ;

--- a/vocabularies/JORC-resource-reporting.ttl
+++ b/vocabularies/JORC-resource-reporting.ttl
@@ -195,7 +195,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/org/gswa>
     a schema:Organization ;
-    schema:name "Gswa" ;
+    schema:name "Geological Survey of Western Australia" ;
     schema:url ""^^xsd:anyURI ;
 .
 

--- a/vocabularies/JORC-resource-reporting.ttl
+++ b/vocabularies/JORC-resource-reporting.ttl
@@ -196,7 +196,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/org/gswa>
     a schema:Organization ;
     schema:name "Geological Survey of Western Australia" ;
-    schema:url ""^^xsd:anyURI ;
+    schema:url "https://www.dmp.wa.gov.au/Geological-Survey/Geological-Survey-262.aspx"^^xsd:anyURI ;
 .
 
 cs:
@@ -226,7 +226,6 @@ The JORC Code vocabulary covers [MINEDEX].[ResourceEstimate.ResourceCategory], i
                 [
                     a schema:Organization ;
                     schema:name "Angela Riganti" ;
-                    schema:url ""^^xsd:anyURI ;
                 ] ;
         ] ,
         [
@@ -235,7 +234,6 @@ The JORC Code vocabulary covers [MINEDEX].[ResourceEstimate.ResourceCategory], i
                 [
                     a schema:Organization ;
                     schema:name "Erin Gray" ;
-                    schema:url ""^^xsd:anyURI ;
                 ] ;
         ] ;
     schema:creator <https://linked.data.gov.au/org/gswa> ;

--- a/vocabularies/JORC-resource-reporting.ttl
+++ b/vocabularies/JORC-resource-reporting.ttl
@@ -224,7 +224,7 @@ The JORC Code vocabulary covers [MINEDEX].[ResourceEstimate.ResourceCategory], i
             dcat:hadRole isoroles:custodian ;
             prov:agent
                 [
-                    a schema:Organization ;
+                    a schema:Person ;
                     schema:name "Angela Riganti" ;
                 ] ;
         ] ,
@@ -232,7 +232,7 @@ The JORC Code vocabulary covers [MINEDEX].[ResourceEstimate.ResourceCategory], i
             dcat:hadRole isoroles:custodian ;
             prov:agent
                 [
-                    a schema:Organization ;
+                    a schema:Person ;
                     schema:name "Erin Gray" ;
                 ] ;
         ] ;

--- a/vocabularies/JORC-resource-reporting.ttl
+++ b/vocabularies/JORC-resource-reporting.ttl
@@ -225,6 +225,7 @@ The JORC Code vocabulary covers [MINEDEX].[ResourceEstimate.ResourceCategory], i
             prov:agent
                 [
                     a schema:Person ;
+                    schema:email ""^^xsd:anyURI ;
                     schema:name "Angela Riganti" ;
                 ] ;
         ] ,
@@ -233,6 +234,7 @@ The JORC Code vocabulary covers [MINEDEX].[ResourceEstimate.ResourceCategory], i
             prov:agent
                 [
                     a schema:Person ;
+                    schema:email ""^^xsd:anyURI ;
                     schema:name "Erin Gray" ;
                 ] ;
         ] ;

--- a/vocabularies/australian-physiographic-units.ttl
+++ b/vocabularies/australian-physiographic-units.ttl
@@ -3252,14 +3252,14 @@ cs:
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    a prov:Agent ;
+                    schema:Person
                     sdo:name "Angela Riganti" ;
                 ]
         ] ,
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    a prov:Agent ;
+                    schema:Person
                     sdo:name "Erin Gray" ;
                 ]
         ] ;

--- a/vocabularies/australian-physiographic-units.ttl
+++ b/vocabularies/australian-physiographic-units.ttl
@@ -8,7 +8,7 @@ PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX reg: <http://purl.org/linked-data/registry#>
-PREFIX sdo: <https://schema.org/>
+PREFIX schema: <https://schema.org/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
@@ -3225,9 +3225,9 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 .
 
 <https://linked.data.gov.au/org/gswa>
-    a sdo:Organization ;
-    sdo:name "Geological Survey of Western Australia" ;
-    sdo:url "https://dmp.wa.gov.au/Geological-Survey/Geological-Survey-262.aspx"^^xsd:anyURI ;
+    a schema:Organization ;
+    schema:name "Geological Survey of Western Australia" ;
+    schema:url "https://dmp.wa.gov.au/Geological-Survey/Geological-Survey-262.aspx"^^xsd:anyURI ;
 .
 
 cs:
@@ -3252,15 +3252,17 @@ cs:
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    schema:Person
-                    sdo:name "Angela Riganti" ;
+                    a schema:Person ;
+                    schema:email ""^^xsd:anyURI ;
+                    schema:name "Angela Riganti" ;
                 ]
         ] ,
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    schema:Person
-                    sdo:name "Erin Gray" ;
+                    a schema:Person ;
+                    schema:email ""^^xsd:anyURI ;
+                    schema:name "Erin Gray" ;
                 ]
         ] ;
 .

--- a/vocabularies/background/labels-ischart.ttl
+++ b/vocabularies/background/labels-ischart.ttl
@@ -1,6 +1,6 @@
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX reg: <http://purl.org/linked-data/registry#>
-PREFIX sdo: <https://schema.org/>
+PREFIX schema: <https://schema.org/>
 PREFIX sh: <http://www.w3.org/ns/shacl#>
 
 <http://resource.geosciml.org/classifier/ics/ischart/CMYK>

--- a/vocabularies/background/labels.ttl
+++ b/vocabularies/background/labels.ttl
@@ -4,7 +4,7 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX reg: <http://purl.org/linked-data/registry#>
-PREFIX sdo: <https://schema.org/>
+PREFIX schema: <https://schema.org/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX time: <http://www.w3.org/2006/time#>
 
@@ -2647,38 +2647,38 @@ If you wish to make comments regarding this document, please send them to public
     rdfs:label "Creative Commons BY 4.0" ;
 .
 
-sdo:3DModel
+schema:3DModel
     rdfs:label "3DModel" ;
     rdfs:comment """A 3D model represents some kind of 3D content, which may have [[encoding]]s in one or more [[MediaObject]]s. Many 3D formats are available (e.g. see [Wikipedia](https://en.wikipedia.org/wiki/Category:3D_graphics_file_formats)); specific encoding formats can be represented using the [[encodingFormat]] property applied to the relevant [[MediaObject]]. For the
 case of a single file published after Zip compression, the convention of appending '+zip' to the [[encodingFormat]] can be used. Geospatial, AR/VR, artistic/animation, gaming, engineering and scientific content can all be represented using [[3DModel]].""" ;
 .
 
-sdo:AMRadioChannel
+schema:AMRadioChannel
     rdfs:label "AM Radio Channel" ;
     rdfs:comment "A radio channel that uses AM." ;
 .
 
-sdo:APIReference
+schema:APIReference
     rdfs:label "APIReference" ;
     rdfs:comment "Reference documentation for application programming interfaces (APIs)." ;
 .
 
-sdo:Abdomen
+schema:Abdomen
     rdfs:label "Abdomen" ;
     rdfs:comment "Abdomen clinical examination." ;
 .
 
-sdo:AboutPage
+schema:AboutPage
     rdfs:label "About Page" ;
     rdfs:comment "Web page type: About page." ;
 .
 
-sdo:AcceptAction
+schema:AcceptAction
     rdfs:label "Accept Action" ;
     rdfs:comment "The act of committing to/adopting an object.\\n\\nRelated actions:\\n\\n* [[RejectAction]]: The antonym of AcceptAction." ;
 .
 
-sdo:Accommodation
+schema:Accommodation
     rdfs:label "Accommodation" ;
     rdfs:comment """An accommodation is a place that can accommodate human beings, e.g. a hotel room, a camping pitch, or a meeting room. Many accommodations are for overnight stays, but this is not a mandatory requirement.
 For more specific types of accommodations not defined in schema.org, one can use additionalType with external vocabularies.
@@ -2687,410 +2687,410 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 """ ;
 .
 
-sdo:AccountingService
+schema:AccountingService
     rdfs:label "Accounting Service" ;
     rdfs:comment """Accountancy business.\\n\\nAs a [[LocalBusiness]] it can be described as a [[provider]] of one or more [[Service]]\\(s).
       """ ;
 .
 
-sdo:AchieveAction
+schema:AchieveAction
     rdfs:label "Achieve Action" ;
     rdfs:comment "The act of accomplishing something via previous efforts. It is an instantaneous action rather than an ongoing process." ;
 .
 
-sdo:Action
+schema:Action
     rdfs:label "Action" ;
     rdfs:comment "An action performed by a direct agent and indirect participants upon a direct object. Optionally happens at a location with the help of an inanimate instrument. The execution of the action may produce a result. Specific action sub-type documentation specifies the exact expectation of each argument/role.\\n\\nSee also [blog post](http://blog.schema.org/2014/04/announcing-schemaorg-actions.html) and [Actions overview document](https://schema.org/docs/actions.html)." ;
 .
 
-sdo:ActionAccessSpecification
+schema:ActionAccessSpecification
     rdfs:label "Action  Access Specification" ;
     rdfs:comment "A set of requirements that a must be fulfilled in order to perform an Action." ;
 .
 
-sdo:ActionStatusType
+schema:ActionStatusType
     rdfs:label "Action  Status Type" ;
     rdfs:comment "The status of an Action." ;
 .
 
-sdo:ActivateAction
+schema:ActivateAction
     rdfs:label "Activate Action" ;
     rdfs:comment "The act of starting or activating a device or application (e.g. starting a timer or turning on a flashlight)." ;
 .
 
-sdo:ActivationFee
+schema:ActivationFee
     rdfs:label "Activation Fee" ;
     rdfs:comment "Represents the activation fee part of the total price for an offered product, for example a cellphone contract." ;
 .
 
-sdo:ActiveActionStatus
+schema:ActiveActionStatus
     rdfs:label "Active  Action Status" ;
     rdfs:comment "An in-progress action (e.g, while watching the movie, or driving to a location)." ;
 .
 
-sdo:ActiveNotRecruiting
+schema:ActiveNotRecruiting
     rdfs:label "Active  Not Recruiting" ;
     rdfs:comment "Active, but not recruiting new participants." ;
 .
 
-sdo:AddAction
+schema:AddAction
     rdfs:label "Add Action" ;
     rdfs:comment "The act of editing by adding an object to a collection." ;
 .
 
-sdo:AdministrativeArea
+schema:AdministrativeArea
     rdfs:label "Administrative Area" ;
     rdfs:comment "A geographical region, typically under the jurisdiction of a particular government." ;
 .
 
-sdo:AdultEntertainment
+schema:AdultEntertainment
     rdfs:label "Adult Entertainment" ;
     rdfs:comment "An adult entertainment establishment." ;
 .
 
-sdo:AdvertiserContentArticle
+schema:AdvertiserContentArticle
     rdfs:label "Advertiser  Content Article" ;
     rdfs:comment "An [[Article]] that an external entity has paid to place or to produce to its specifications. Includes [advertorials](https://en.wikipedia.org/wiki/Advertorial), sponsored content, native advertising and other paid content." ;
 .
 
-sdo:AerobicActivity
+schema:AerobicActivity
     rdfs:label "Aerobic Activity" ;
     rdfs:comment "Physical activity of relatively low intensity that depends primarily on the aerobic energy-generating process; during activity, the aerobic metabolism uses oxygen to adequately meet energy demands during exercise." ;
 .
 
-sdo:AggregateOffer
+schema:AggregateOffer
     rdfs:label "Aggregate Offer" ;
     rdfs:comment "When a single product is associated with multiple offers (for example, the same pair of shoes is offered by different merchants), then AggregateOffer can be used.\\n\\nNote: AggregateOffers are normally expected to associate multiple offers that all share the same defined [[businessFunction]] value, or default to http://purl.org/goodrelations/v1#Sell if businessFunction is not explicitly defined." ;
 .
 
-sdo:AggregateRating
+schema:AggregateRating
     rdfs:label "Aggregate Rating" ;
     rdfs:comment "The average rating based on multiple ratings or reviews." ;
 .
 
-sdo:AgreeAction
+schema:AgreeAction
     rdfs:label "Agree Action" ;
     rdfs:comment "The act of expressing a consistency of opinion with the object. An agent agrees to/about an object (a proposition, topic or theme) with participants." ;
 .
 
-sdo:Airline
+schema:Airline
     rdfs:label "Airline" ;
     rdfs:comment "An organization that provides flights for passengers." ;
 .
 
-sdo:Airport
+schema:Airport
     rdfs:label "Airport" ;
     rdfs:comment "An airport." ;
 .
 
-sdo:AlbumRelease
+schema:AlbumRelease
     rdfs:label "Album Release" ;
     rdfs:comment "AlbumRelease." ;
 .
 
-sdo:AlignmentObject
+schema:AlignmentObject
     rdfs:label "Alignment Object" ;
     rdfs:comment """An intangible item that describes an alignment between a learning resource and a node in an educational framework.
 
 Should not be used where the nature of the alignment can be described using a simple property, for example to express that a resource [[teaches]] or [[assesses]] a competency.""" ;
 .
 
-sdo:AllWheelDriveConfiguration
+schema:AllWheelDriveConfiguration
     rdfs:label "All Wheel Drive Configuration" ;
     rdfs:comment "All-wheel Drive is a transmission layout where the engine drives all four wheels." ;
 .
 
-sdo:AllergiesHealthAspect
+schema:AllergiesHealthAspect
     rdfs:label "Allergies  Health Aspect" ;
     rdfs:comment "Content about the allergy-related aspects of a health topic." ;
 .
 
-sdo:AllocateAction
+schema:AllocateAction
     rdfs:label "Allocate Action" ;
     rdfs:comment "The act of organizing tasks/objects/events by associating resources to it." ;
 .
 
-sdo:AmpStory
+schema:AmpStory
     rdfs:label "Amp Story" ;
     rdfs:comment "A creative work with a visual storytelling format intended to be viewed online, particularly on mobile devices." ;
 .
 
-sdo:AmusementPark
+schema:AmusementPark
     rdfs:label "Amusement Park" ;
     rdfs:comment "An amusement park." ;
 .
 
-sdo:AnaerobicActivity
+schema:AnaerobicActivity
     rdfs:label "Anaerobic Activity" ;
     rdfs:comment "Physical activity that is of high-intensity which utilizes the anaerobic metabolism of the body." ;
 .
 
-sdo:AnalysisNewsArticle
+schema:AnalysisNewsArticle
     rdfs:label "Analysis  News Article" ;
     rdfs:comment "An AnalysisNewsArticle is a [[NewsArticle]] that, while based on factual reporting, incorporates the expertise of the author/producer, offering interpretations and conclusions." ;
 .
 
-sdo:AnatomicalStructure
+schema:AnatomicalStructure
     rdfs:label "Anatomical Structure" ;
     rdfs:comment "Any part of the human body, typically a component of an anatomical system. Organs, tissues, and cells are all anatomical structures." ;
 .
 
-sdo:AnatomicalSystem
+schema:AnatomicalSystem
     rdfs:label "Anatomical System" ;
     rdfs:comment "An anatomical system is a group of anatomical structures that work together to perform a certain task. Anatomical systems, such as organ systems, are one organizing principle of anatomy, and can includes circulatory, digestive, endocrine, integumentary, immune, lymphatic, muscular, nervous, reproductive, respiratory, skeletal, urinary, vestibular, and other systems." ;
 .
 
-sdo:Anesthesia
+schema:Anesthesia
     rdfs:label "Anesthesia" ;
     rdfs:comment "A specific branch of medical science that pertains to study of anesthetics and their application." ;
 .
 
-sdo:AnimalShelter
+schema:AnimalShelter
     rdfs:label "Animal Shelter" ;
     rdfs:comment "Animal shelter." ;
 .
 
-sdo:Answer
+schema:Answer
     rdfs:label "Answer" ;
     rdfs:comment "An answer offered to a question; perhaps correct, perhaps opinionated or wrong." ;
 .
 
-sdo:Apartment
+schema:Apartment
     rdfs:label "Apartment" ;
     rdfs:comment "An apartment (in American English) or flat (in British English) is a self-contained housing unit (a type of residential real estate) that occupies only part of a building (Source: Wikipedia, the free encyclopedia, see <a href=\"http://en.wikipedia.org/wiki/Apartment\">http://en.wikipedia.org/wiki/Apartment</a>)." ;
 .
 
-sdo:ApartmentComplex
+schema:ApartmentComplex
     rdfs:label "Apartment Complex" ;
     rdfs:comment "Residence type: Apartment complex." ;
 .
 
-sdo:Appearance
+schema:Appearance
     rdfs:label "Appearance" ;
     rdfs:comment "Appearance assessment with clinical examination." ;
 .
 
-sdo:AppendAction
+schema:AppendAction
     rdfs:label "Append Action" ;
     rdfs:comment "The act of inserting at the end if an ordered collection." ;
 .
 
-sdo:ApplyAction
+schema:ApplyAction
     rdfs:label "Apply Action" ;
     rdfs:comment "The act of registering to an organization/service without the guarantee to receive it.\\n\\nRelated actions:\\n\\n* [[RegisterAction]]: Unlike RegisterAction, ApplyAction has no guarantees that the application will be accepted." ;
 .
 
-sdo:ApprovedIndication
+schema:ApprovedIndication
     rdfs:label "Approved Indication" ;
     rdfs:comment "An indication for a medical therapy that has been formally specified or approved by a regulatory body that regulates use of the therapy; for example, the US FDA approves indications for most drugs in the US." ;
 .
 
-sdo:Aquarium
+schema:Aquarium
     rdfs:label "Aquarium" ;
     rdfs:comment "Aquarium." ;
 .
 
-sdo:ArchiveComponent
+schema:ArchiveComponent
     rdfs:label "Archive Component"@en ;
     rdfs:comment "An intangible type to be applied to any archive content, carrying with it a set of properties required to describe archival items and collections."@en ;
 .
 
-sdo:ArchiveOrganization
+schema:ArchiveOrganization
     rdfs:label "Archive Organization"@en ;
     rdfs:comment "An organization with archival holdings. An organization which keeps and preserves archival material and typically makes it accessible to the public."@en ;
 .
 
-sdo:ArriveAction
+schema:ArriveAction
     rdfs:label "Arrive Action" ;
     rdfs:comment "The act of arriving at a place. An agent arrives at a destination from a fromLocation, optionally with participants." ;
 .
 
-sdo:ArtGallery
+schema:ArtGallery
     rdfs:label "Art Gallery" ;
     rdfs:comment "An art gallery." ;
 .
 
-sdo:Artery
+schema:Artery
     rdfs:label "Artery" ;
     rdfs:comment "A type of blood vessel that specifically carries blood away from the heart." ;
 .
 
-sdo:Article
+schema:Article
     rdfs:label "Article" ;
     rdfs:comment "An article, such as a news article or piece of investigative report. Newspapers and magazines have articles of many different types and this is intended to cover them all.\\n\\nSee also [blog post](http://blog.schema.org/2014/09/schemaorg-support-for-bibliographic_2.html)." ;
 .
 
-sdo:AskAction
+schema:AskAction
     rdfs:label "Ask Action" ;
     rdfs:comment "The act of posing a question / favor to someone.\\n\\nRelated actions:\\n\\n* [[ReplyAction]]: Appears generally as a response to AskAction." ;
 .
 
-sdo:AskPublicNewsArticle
+schema:AskPublicNewsArticle
     rdfs:label "Ask Public News Article" ;
     rdfs:comment "A [[NewsArticle]] expressing an open call by a [[NewsMediaOrganization]] asking the public for input, insights, clarifications, anecdotes, documentation, etc., on an issue, for reporting purposes." ;
 .
 
-sdo:AssessAction
+schema:AssessAction
     rdfs:label "Assess Action" ;
     rdfs:comment "The act of forming one's opinion, reaction or sentiment." ;
 .
 
-sdo:AssignAction
+schema:AssignAction
     rdfs:label "Assign Action" ;
     rdfs:comment "The act of allocating an action/event/task to some destination (someone or something)." ;
 .
 
-sdo:Atlas
+schema:Atlas
     rdfs:label "Atlas" ;
     rdfs:comment "A collection or bound volume of maps, charts, plates or tables, physical or in media form illustrating any subject." ;
 .
 
-sdo:Attorney
+schema:Attorney
     rdfs:label "Attorney" ;
     rdfs:comment "Professional service: Attorney. \\n\\nThis type is deprecated - [[LegalService]] is more inclusive and less ambiguous." ;
 .
 
-sdo:Audience
+schema:Audience
     rdfs:label "Audience" ;
     rdfs:comment "Intended audience for an item, i.e. the group for whom the item was created." ;
 .
 
-sdo:AudioObject
+schema:AudioObject
     rdfs:label "Audio Object" ;
     rdfs:comment "An audio file." ;
 .
 
-sdo:AudioObjectSnapshot
+schema:AudioObjectSnapshot
     rdfs:label "Audio  Object Snapshot" ;
     rdfs:comment "A specific and exact (byte-for-byte) version of an [[AudioObject]]. Two byte-for-byte identical files, for the purposes of this type, considered identical. If they have different embedded metadata the files will differ. Different external facts about the files, e.g. creator or dateCreated that aren't represented in their actual content, do not affect this notion of identity." ;
 .
 
-sdo:Audiobook
+schema:Audiobook
     rdfs:label "Audiobook" ;
     rdfs:comment "An audiobook." ;
 .
 
-sdo:AudiobookFormat
+schema:AudiobookFormat
     rdfs:label "Audiobook Format" ;
     rdfs:comment "Book format: Audiobook. This is an enumerated value for use with the bookFormat property. There is also a type 'Audiobook' in the bib extension which includes Audiobook specific properties." ;
 .
 
-sdo:AuthoritativeLegalValue
+schema:AuthoritativeLegalValue
     rdfs:label "Authoritative  Legal Value" ;
     rdfs:comment "Indicates that the publisher gives some special status to the publication of the document. (\"The Queens Printer\" version of a UK Act of Parliament, or the PDF version of a Directive published by the EU Office of Publications). Something \"Authoritative\" is considered to be also [[OfficialLegalValue]]\"." ;
 .
 
-sdo:AuthorizeAction
+schema:AuthorizeAction
     rdfs:label "Authorize Action" ;
     rdfs:comment "The act of granting permission to an object." ;
 .
 
-sdo:AutoBodyShop
+schema:AutoBodyShop
     rdfs:label "Auto  Body Shop" ;
     rdfs:comment "Auto body shop." ;
 .
 
-sdo:AutoDealer
+schema:AutoDealer
     rdfs:label "Auto Dealer" ;
     rdfs:comment "An car dealership." ;
 .
 
-sdo:AutoPartsStore
+schema:AutoPartsStore
     rdfs:label "Auto  Parts Store" ;
     rdfs:comment "An auto parts store." ;
 .
 
-sdo:AutoRental
+schema:AutoRental
     rdfs:label "Auto Rental" ;
     rdfs:comment "A car rental business." ;
 .
 
-sdo:AutoRepair
+schema:AutoRepair
     rdfs:label "Auto Repair" ;
     rdfs:comment "Car repair business." ;
 .
 
-sdo:AutoWash
+schema:AutoWash
     rdfs:label "Auto Wash" ;
     rdfs:comment "A car wash business." ;
 .
 
-sdo:AutomatedTeller
+schema:AutomatedTeller
     rdfs:label "Automated Teller" ;
     rdfs:comment "ATM/cash machine." ;
 .
 
-sdo:AutomotiveBusiness
+schema:AutomotiveBusiness
     rdfs:label "Automotive Business" ;
     rdfs:comment "Car repair, sales, or parts." ;
 .
 
-sdo:Ayurvedic
+schema:Ayurvedic
     rdfs:label "Ayurvedic" ;
     rdfs:comment "A system of medicine that originated in India over thousands of years and that focuses on integrating and balancing the body, mind, and spirit." ;
 .
 
-sdo:BackOrder
+schema:BackOrder
     rdfs:label "Back Order" ;
     rdfs:comment "Indicates that the item is available on back order." ;
 .
 
-sdo:BackgroundNewsArticle
+schema:BackgroundNewsArticle
     rdfs:label "Background  News Article" ;
     rdfs:comment "A [[NewsArticle]] providing historical context, definition and detail on a specific topic (aka \"explainer\" or \"backgrounder\"). For example, an in-depth article or frequently-asked-questions ([FAQ](https://en.wikipedia.org/wiki/FAQ)) document on topics such as Climate Change or the European Union. Other kinds of background material from a non-news setting are often described using [[Book]] or [[Article]], in particular [[ScholarlyArticle]]. See also [[NewsArticle]] for related vocabulary from a learning/education perspective." ;
 .
 
-sdo:Bacteria
+schema:Bacteria
     rdfs:label "Bacteria" ;
     rdfs:comment "Pathogenic bacteria that cause bacterial infection." ;
 .
 
-sdo:Bakery
+schema:Bakery
     rdfs:label "Bakery" ;
     rdfs:comment "A bakery." ;
 .
 
-sdo:Balance
+schema:Balance
     rdfs:label "Balance" ;
     rdfs:comment "Physical activity that is engaged to help maintain posture and balance." ;
 .
 
-sdo:BankAccount
+schema:BankAccount
     rdfs:label "Bank Account" ;
     rdfs:comment "A product or service offered by a bank whereby one may deposit, withdraw or transfer money and in some cases be paid interest." ;
 .
 
-sdo:BankOrCreditUnion
+schema:BankOrCreditUnion
     rdfs:label "Bank Or Credit Union" ;
     rdfs:comment "Bank or credit union." ;
 .
 
-sdo:BarOrPub
+schema:BarOrPub
     rdfs:label "Bar  Or Pub" ;
     rdfs:comment "A bar or pub." ;
 .
 
-sdo:Barcode
+schema:Barcode
     rdfs:label "Barcode" ;
     rdfs:comment "An image of a visual machine-readable code such as a barcode or QR code." ;
 .
 
-sdo:BasicIncome
+schema:BasicIncome
     rdfs:label "Basic Income" ;
     rdfs:comment "BasicIncome: this is a benefit for basic income." ;
 .
 
-sdo:Beach
+schema:Beach
     rdfs:label "Beach" ;
     rdfs:comment "Beach." ;
 .
 
-sdo:BeautySalon
+schema:BeautySalon
     rdfs:label "Beauty Salon" ;
     rdfs:comment "Beauty salon." ;
 .
 
-sdo:BedAndBreakfast
+schema:BedAndBreakfast
     rdfs:label "Bed  And Breakfast" ;
     rdfs:comment """Bed and breakfast.
 <br /><br />
@@ -3098,312 +3098,312 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 """ ;
 .
 
-sdo:BedDetails
+schema:BedDetails
     rdfs:label "Bed Details" ;
     rdfs:comment "An entity holding detailed information about the available bed types, e.g. the quantity of twin beds for a hotel room. For the single case of just one bed of a certain type, you can use bed directly with a text. See also [[BedType]] (under development)." ;
 .
 
-sdo:BedType
+schema:BedType
     rdfs:label "Bed Type" ;
     rdfs:comment "A type of bed. This is used for indicating the bed or beds available in an accommodation." ;
 .
 
-sdo:BefriendAction
+schema:BefriendAction
     rdfs:label "Befriend Action" ;
     rdfs:comment "The act of forming a personal connection with someone (object) mutually/bidirectionally/symmetrically.\\n\\nRelated actions:\\n\\n* [[FollowAction]]: Unlike FollowAction, BefriendAction implies that the connection is reciprocal." ;
 .
 
-sdo:BenefitsHealthAspect
+schema:BenefitsHealthAspect
     rdfs:label "Benefits  Health Aspect" ;
     rdfs:comment "Content about the benefits and advantages of usage or utilization of topic." ;
 .
 
-sdo:BikeStore
+schema:BikeStore
     rdfs:label "Bike Store" ;
     rdfs:comment "A bike store." ;
 .
 
-sdo:BioChemEntity
+schema:BioChemEntity
     rdfs:label "Bio  Chem Entity" ;
     rdfs:comment "Any biological, chemical, or biochemical thing. For example: a protein; a gene; a chemical; a synthetic chemical." ;
 .
 
-sdo:Blog
+schema:Blog
     rdfs:label "Blog" ;
     rdfs:comment "A [blog](https://en.wikipedia.org/wiki/Blog), sometimes known as a \"weblog\". Note that the individual posts ([[BlogPosting]]s) in a [[Blog]] are often colloqually referred to by the same term." ;
 .
 
-sdo:BlogPosting
+schema:BlogPosting
     rdfs:label "Blog Posting" ;
     rdfs:comment "A blog post." ;
 .
 
-sdo:BloodTest
+schema:BloodTest
     rdfs:label "Blood Test" ;
     rdfs:comment "A medical test performed on a sample of a patient's blood." ;
 .
 
-sdo:BoardingPolicyType
+schema:BoardingPolicyType
     rdfs:label "Boarding  Policy Type" ;
     rdfs:comment "A type of boarding policy used by an airline." ;
 .
 
-sdo:BoatReservation
+schema:BoatReservation
     rdfs:label "Boat Reservation" ;
     rdfs:comment """A reservation for boat travel.
 
 Note: This type is for information about actual reservations, e.g. in confirmation emails or HTML pages with individual confirmations of reservations. For offers of tickets, use [[Offer]].""" ;
 .
 
-sdo:BoatTerminal
+schema:BoatTerminal
     rdfs:label "Boat Terminal" ;
     rdfs:comment "A terminal for boats, ships, and other water vessels." ;
 .
 
-sdo:BoatTrip
+schema:BoatTrip
     rdfs:label "Boat Trip" ;
     rdfs:comment "A trip on a commercial ferry line." ;
 .
 
-sdo:BodyMeasurementArm
+schema:BodyMeasurementArm
     rdfs:label "Body  Measurement Arm" ;
     rdfs:comment "Arm length (measured between arms/shoulder line intersection and the prominent wrist bone). Used, for example, to fit shirts." ;
 .
 
-sdo:BodyMeasurementBust
+schema:BodyMeasurementBust
     rdfs:label "Body  Measurement Bust" ;
     rdfs:comment "Maximum girth of bust. Used, for example, to fit women's suits." ;
 .
 
-sdo:BodyMeasurementChest
+schema:BodyMeasurementChest
     rdfs:label "Body  Measurement Chest" ;
     rdfs:comment "Maximum girth of chest. Used, for example, to fit men's suits." ;
 .
 
-sdo:BodyMeasurementFoot
+schema:BodyMeasurementFoot
     rdfs:label "Body  Measurement Foot" ;
     rdfs:comment "Foot length (measured between end of the most prominent toe and the most prominent part of the heel). Used, for example, to measure socks." ;
 .
 
-sdo:BodyMeasurementHand
+schema:BodyMeasurementHand
     rdfs:label "Body  Measurement Hand" ;
     rdfs:comment "Maximum hand girth (measured over the knuckles of the open right hand excluding thumb, fingers together). Used, for example, to fit gloves." ;
 .
 
-sdo:BodyMeasurementHead
+schema:BodyMeasurementHead
     rdfs:label "Body  Measurement Head" ;
     rdfs:comment "Maximum girth of head above the ears. Used, for example, to fit hats." ;
 .
 
-sdo:BodyMeasurementHeight
+schema:BodyMeasurementHeight
     rdfs:label "Body  Measurement Height" ;
     rdfs:comment "Body height (measured between crown of head and soles of feet). Used, for example, to fit jackets." ;
 .
 
-sdo:BodyMeasurementHips
+schema:BodyMeasurementHips
     rdfs:label "Body  Measurement Hips" ;
     rdfs:comment "Girth of hips (measured around the buttocks). Used, for example, to fit skirts." ;
 .
 
-sdo:BodyMeasurementInsideLeg
+schema:BodyMeasurementInsideLeg
     rdfs:label "Body Measurement Inside Leg" ;
     rdfs:comment "Inside leg (measured between crotch and soles of feet). Used, for example, to fit pants." ;
 .
 
-sdo:BodyMeasurementNeck
+schema:BodyMeasurementNeck
     rdfs:label "Body  Measurement Neck" ;
     rdfs:comment "Girth of neck. Used, for example, to fit shirts." ;
 .
 
-sdo:BodyMeasurementTypeEnumeration
+schema:BodyMeasurementTypeEnumeration
     rdfs:label "Body Measurement Type Enumeration" ;
     rdfs:comment "Enumerates types (or dimensions) of a person's body measurements, for example for fitting of clothes." ;
 .
 
-sdo:BodyMeasurementUnderbust
+schema:BodyMeasurementUnderbust
     rdfs:label "Body  Measurement Underbust" ;
     rdfs:comment "Girth of body just below the bust. Used, for example, to fit women's swimwear." ;
 .
 
-sdo:BodyMeasurementWaist
+schema:BodyMeasurementWaist
     rdfs:label "Body  Measurement Waist" ;
     rdfs:comment "Girth of natural waistline (between hip bones and lower ribs). Used, for example, to fit pants." ;
 .
 
-sdo:BodyMeasurementWeight
+schema:BodyMeasurementWeight
     rdfs:label "Body  Measurement Weight" ;
     rdfs:comment "Body weight. Used, for example, to measure pantyhose." ;
 .
 
-sdo:BodyOfWater
+schema:BodyOfWater
     rdfs:label "Body  Of Water" ;
     rdfs:comment "A body of water, such as a sea, ocean, or lake." ;
 .
 
-sdo:Bone
+schema:Bone
     rdfs:label "Bone" ;
     rdfs:comment "Rigid connective tissue that comprises up the skeletal structure of the human body." ;
 .
 
-sdo:Book
+schema:Book
     rdfs:label "Book" ;
     rdfs:comment "A book." ;
 .
 
-sdo:BookFormatType
+schema:BookFormatType
     rdfs:label "Book  Format Type" ;
     rdfs:comment "The publication format of the book." ;
 .
 
-sdo:BookSeries
+schema:BookSeries
     rdfs:label "Book Series" ;
     rdfs:comment "A series of books. Included books can be indicated with the hasPart property." ;
 .
 
-sdo:BookStore
+schema:BookStore
     rdfs:label "Book Store" ;
     rdfs:comment "A bookstore." ;
 .
 
-sdo:BookmarkAction
+schema:BookmarkAction
     rdfs:label "Bookmark Action" ;
     rdfs:comment "An agent bookmarks/flags/labels/tags/marks an object." ;
 .
 
-sdo:Boolean
+schema:Boolean
     rdfs:label "Boolean" ;
     rdfs:comment "Boolean: True or False." ;
 .
 
-sdo:BorrowAction
+schema:BorrowAction
     rdfs:label "Borrow Action" ;
     rdfs:comment "The act of obtaining an object under an agreement to return it at a later date. Reciprocal of LendAction.\\n\\nRelated actions:\\n\\n* [[LendAction]]: Reciprocal of BorrowAction." ;
 .
 
-sdo:BowlingAlley
+schema:BowlingAlley
     rdfs:label "Bowling Alley" ;
     rdfs:comment "A bowling alley." ;
 .
 
-sdo:BrainStructure
+schema:BrainStructure
     rdfs:label "Brain Structure" ;
     rdfs:comment "Any anatomical structure which pertains to the soft nervous tissue functioning as the coordinating center of sensation and intellectual and nervous activity." ;
 .
 
-sdo:Brand
+schema:Brand
     rdfs:label "Brand" ;
     rdfs:comment "A brand is a name used by an organization or business person for labeling a product, product group, or similar." ;
 .
 
-sdo:BreadcrumbList
+schema:BreadcrumbList
     rdfs:label "Breadcrumb List" ;
     rdfs:comment """A BreadcrumbList is an ItemList consisting of a chain of linked Web pages, typically described using at least their URL and their name, and typically ending with the current page.\\n\\nThe [[position]] property is used to reconstruct the order of the items in a BreadcrumbList The convention is that a breadcrumb list has an [[itemListOrder]] of [[ItemListOrderAscending]] (lower values listed first), and that the first items in this list correspond to the "top" or beginning of the breadcrumb trail, e.g. with a site or section homepage. The specific values of 'position' are not assigned meaning for a BreadcrumbList, but they should be integers, e.g. beginning with '1' for the first item in the list.
       """ ;
 .
 
-sdo:Brewery
+schema:Brewery
     rdfs:label "Brewery" ;
     rdfs:comment "Brewery." ;
 .
 
-sdo:Bridge
+schema:Bridge
     rdfs:label "Bridge" ;
     rdfs:comment "A bridge." ;
 .
 
-sdo:BroadcastChannel
+schema:BroadcastChannel
     rdfs:label "Broadcast Channel" ;
     rdfs:comment "A unique instance of a BroadcastService on a CableOrSatelliteService lineup." ;
 .
 
-sdo:BroadcastEvent
+schema:BroadcastEvent
     rdfs:label "Broadcast Event" ;
     rdfs:comment "An over the air or online broadcast event." ;
 .
 
-sdo:BroadcastFrequencySpecification
+schema:BroadcastFrequencySpecification
     rdfs:label "Broadcast  Frequency Specification" ;
     rdfs:comment "The frequency in MHz and the modulation used for a particular BroadcastService." ;
 .
 
-sdo:BroadcastRelease
+schema:BroadcastRelease
     rdfs:label "Broadcast Release" ;
     rdfs:comment "BroadcastRelease." ;
 .
 
-sdo:BroadcastService
+schema:BroadcastService
     rdfs:label "Broadcast Service" ;
     rdfs:comment "A delivery service through which content is provided via broadcast over the air or online." ;
 .
 
-sdo:BrokerageAccount
+schema:BrokerageAccount
     rdfs:label "Brokerage Account" ;
     rdfs:comment "An account that allows an investor to deposit funds and place investment orders with a licensed broker or brokerage firm." ;
 .
 
-sdo:BuddhistTemple
+schema:BuddhistTemple
     rdfs:label "Buddhist Temple" ;
     rdfs:comment "A Buddhist temple." ;
 .
 
-sdo:BusOrCoach
+schema:BusOrCoach
     rdfs:label "Bus  Or Coach" ;
     rdfs:comment "A bus (also omnibus or autobus) is a road vehicle designed to carry passengers. Coaches are luxury busses, usually in service for long distance travel." ;
 .
 
-sdo:BusReservation
+schema:BusReservation
     rdfs:label "Bus Reservation" ;
     rdfs:comment "A reservation for bus travel. \\n\\nNote: This type is for information about actual reservations, e.g. in confirmation emails or HTML pages with individual confirmations of reservations. For offers of tickets, use [[Offer]]." ;
 .
 
-sdo:BusStation
+schema:BusStation
     rdfs:label "Bus Station" ;
     rdfs:comment "A bus station." ;
 .
 
-sdo:BusStop
+schema:BusStop
     rdfs:label "Bus Stop" ;
     rdfs:comment "A bus stop." ;
 .
 
-sdo:BusTrip
+schema:BusTrip
     rdfs:label "Bus Trip" ;
     rdfs:comment "A trip on a commercial bus line." ;
 .
 
-sdo:BusinessAudience
+schema:BusinessAudience
     rdfs:label "Business Audience" ;
     rdfs:comment "A set of characteristics belonging to businesses, e.g. who compose an item's target audience." ;
 .
 
-sdo:BusinessEntityType
+schema:BusinessEntityType
     rdfs:label "Business  Entity Type" ;
     rdfs:comment """A business entity type is a conceptual entity representing the legal form, the size, the main line of business, the position in the value chain, or any combination thereof, of an organization or business person.\\n\\nCommonly used values:\\n\\n* http://purl.org/goodrelations/v1#Business\\n* http://purl.org/goodrelations/v1#Enduser\\n* http://purl.org/goodrelations/v1#PublicInstitution\\n* http://purl.org/goodrelations/v1#Reseller
 	  """ ;
 .
 
-sdo:BusinessEvent
+schema:BusinessEvent
     rdfs:label "Business Event" ;
     rdfs:comment "Event type: Business event." ;
 .
 
-sdo:BusinessFunction
+schema:BusinessFunction
     rdfs:label "Business Function" ;
     rdfs:comment """The business function specifies the type of activity or access (i.e., the bundle of rights) offered by the organization or business person through the offer. Typical are sell, rental or lease, maintenance or repair, manufacture / produce, recycle / dispose, engineering / construction, or installation. Proprietary specifications of access rights are also instances of this class.\\n\\nCommonly used values:\\n\\n* http://purl.org/goodrelations/v1#ConstructionInstallation\\n* http://purl.org/goodrelations/v1#Dispose\\n* http://purl.org/goodrelations/v1#LeaseOut\\n* http://purl.org/goodrelations/v1#Maintain\\n* http://purl.org/goodrelations/v1#ProvideService\\n* http://purl.org/goodrelations/v1#Repair\\n* http://purl.org/goodrelations/v1#Sell\\n* http://purl.org/goodrelations/v1#Buy
         """ ;
 .
 
-sdo:BusinessSupport
+schema:BusinessSupport
     rdfs:label "Business Support" ;
     rdfs:comment "BusinessSupport: this is a benefit for supporting businesses." ;
 .
 
-sdo:BuyAction
+schema:BuyAction
     rdfs:label "Buy Action" ;
     rdfs:comment "The act of giving money to a seller in exchange for goods or services rendered. An agent buys an object, product, or service from a seller for a price. Reciprocal of SellAction." ;
 .
 
-sdo:CDCPMDRecord
+schema:CDCPMDRecord
     rdfs:label "CDCPMDRecord" ;
     rdfs:comment """A CDCPMDRecord is a data structure representing a record in a CDC tabular data format
       used for hospital data reporting. See [documentation](/docs/cdc-covid.html) for details, and the linked CDC materials for authoritative
@@ -3411,27 +3411,27 @@ sdo:CDCPMDRecord
       """ ;
 .
 
-sdo:CDFormat
+schema:CDFormat
     rdfs:label "CDFormat" ;
     rdfs:comment "CDFormat." ;
 .
 
-sdo:CT
+schema:CT
     rdfs:label "CT" ;
     rdfs:comment "X-ray computed tomography imaging." ;
 .
 
-sdo:CableOrSatelliteService
+schema:CableOrSatelliteService
     rdfs:label "Cable Or Satellite Service" ;
     rdfs:comment "A service which provides access to media programming like TV or radio. Access may be via cable or satellite." ;
 .
 
-sdo:CafeOrCoffeeShop
+schema:CafeOrCoffeeShop
     rdfs:label "Cafe Or Coffee Shop" ;
     rdfs:comment "A cafe or coffee shop." ;
 .
 
-sdo:Campground
+schema:Campground
     rdfs:label "Campground" ;
     rdfs:comment """A camping site, campsite, or [[Campground]] is a place used for overnight stay in the outdoors, typically containing individual [[CampingPitch]] locations. \\n\\n
 In British English a campsite is an area, usually divided into a number of pitches, where people can camp overnight using tents or camper vans or caravans; this British English use of the word is synonymous with the American English expression campground. In American English the term campsite generally means an area where an individual, family, group, or military unit can pitch a tent or park a camper; a campground may contain many campsites (Source: Wikipedia see [https://en.wikipedia.org/wiki/Campsite](https://en.wikipedia.org/wiki/Campsite)).\\n\\n
@@ -3440,7 +3440,7 @@ See also the dedicated [document on the use of schema.org for marking up hotels 
 """ ;
 .
 
-sdo:CampingPitch
+schema:CampingPitch
     rdfs:label "Camping Pitch" ;
     rdfs:comment """A [[CampingPitch]] is an individual place for overnight stay in the outdoors, typically being part of a larger camping site, or [[Campground]].\\n\\n
 In British English a campsite, or campground, is an area, usually divided into a number of pitches, where people can camp overnight using tents or camper vans or caravans; this British English use of the word is synonymous with the American English expression campground. In American English the term campsite generally means an area where an individual, family, group, or military unit can pitch a tent or park a camper; a campground may contain many campsites.
@@ -3449,152 +3449,152 @@ See also the dedicated [document on the use of schema.org for marking up hotels 
 """ ;
 .
 
-sdo:Canal
+schema:Canal
     rdfs:label "Canal" ;
     rdfs:comment "A canal, like the Panama Canal." ;
 .
 
-sdo:CancelAction
+schema:CancelAction
     rdfs:label "Cancel Action" ;
     rdfs:comment "The act of asserting that a future event/action is no longer going to happen.\\n\\nRelated actions:\\n\\n* [[ConfirmAction]]: The antonym of CancelAction." ;
 .
 
-sdo:Car
+schema:Car
     rdfs:label "Car" ;
     rdfs:comment "A car is a wheeled, self-powered motor vehicle used for transportation." ;
 .
 
-sdo:CarUsageType
+schema:CarUsageType
     rdfs:label "Car  Usage Type" ;
     rdfs:comment "A value indicating a special usage of a car, e.g. commercial rental, driving school, or as a taxi." ;
 .
 
-sdo:Cardiovascular
+schema:Cardiovascular
     rdfs:label "Cardiovascular" ;
     rdfs:comment "A specific branch of medical science that pertains to diagnosis and treatment of disorders of heart and vasculature." ;
 .
 
-sdo:CardiovascularExam
+schema:CardiovascularExam
     rdfs:label "Cardiovascular Exam" ;
     rdfs:comment "Cardiovascular system assessment withclinical examination." ;
 .
 
-sdo:CaseSeries
+schema:CaseSeries
     rdfs:label "Case Series" ;
     rdfs:comment "A case series (also known as a clinical series) is a medical research study that tracks patients with a known exposure given similar treatment or examines their medical records for exposure and outcome. A case series can be retrospective or prospective and usually involves a smaller number of patients than the more powerful case-control studies or randomized controlled trials. Case series may be consecutive or non-consecutive, depending on whether all cases presenting to the reporting authors over a period of time were included, or only a selection." ;
 .
 
-sdo:Casino
+schema:Casino
     rdfs:label "Casino" ;
     rdfs:comment "A casino." ;
 .
 
-sdo:CassetteFormat
+schema:CassetteFormat
     rdfs:label "Cassette Format" ;
     rdfs:comment "CassetteFormat." ;
 .
 
-sdo:CategoryCode
+schema:CategoryCode
     rdfs:label "Category Code" ;
     rdfs:comment "A Category Code." ;
 .
 
-sdo:CategoryCodeSet
+schema:CategoryCodeSet
     rdfs:label "Category  Code Set" ;
     rdfs:comment "A set of Category Code values." ;
 .
 
-sdo:CatholicChurch
+schema:CatholicChurch
     rdfs:label "Catholic Church" ;
     rdfs:comment "A Catholic church." ;
 .
 
-sdo:CausesHealthAspect
+schema:CausesHealthAspect
     rdfs:label "Causes  Health Aspect" ;
     rdfs:comment "Information about the causes and main actions that gave rise to the topic." ;
 .
 
-sdo:Cemetery
+schema:Cemetery
     rdfs:label "Cemetery" ;
     rdfs:comment "A graveyard." ;
 .
 
-sdo:Chapter
+schema:Chapter
     rdfs:label "Chapter" ;
     rdfs:comment "One of the sections into which a book is divided. A chapter usually has a section number or a name." ;
 .
 
-sdo:CharitableIncorporatedOrganization
+schema:CharitableIncorporatedOrganization
     rdfs:label "Charitable  Incorporated Organization" ;
     rdfs:comment "CharitableIncorporatedOrganization: Non-profit type referring to a Charitable Incorporated Organization (UK)." ;
 .
 
-sdo:CheckAction
+schema:CheckAction
     rdfs:label "Check Action" ;
     rdfs:comment "An agent inspects, determines, investigates, inquires, or examines an object's accuracy, quality, condition, or state." ;
 .
 
-sdo:CheckInAction
+schema:CheckInAction
     rdfs:label "Check  In Action" ;
     rdfs:comment "The act of an agent communicating (service provider, social media, etc) their arrival by registering/confirming for a previously reserved service (e.g. flight check in) or at a place (e.g. hotel), possibly resulting in a result (boarding pass, etc).\\n\\nRelated actions:\\n\\n* [[CheckOutAction]]: The antonym of CheckInAction.\\n* [[ArriveAction]]: Unlike ArriveAction, CheckInAction implies that the agent is informing/confirming the start of a previously reserved service.\\n* [[ConfirmAction]]: Unlike ConfirmAction, CheckInAction implies that the agent is informing/confirming the *start* of a previously reserved service rather than its validity/existence." ;
 .
 
-sdo:CheckOutAction
+schema:CheckOutAction
     rdfs:label "Check  Out Action" ;
     rdfs:comment "The act of an agent communicating (service provider, social media, etc) their departure of a previously reserved service (e.g. flight check in) or place (e.g. hotel).\\n\\nRelated actions:\\n\\n* [[CheckInAction]]: The antonym of CheckOutAction.\\n* [[DepartAction]]: Unlike DepartAction, CheckOutAction implies that the agent is informing/confirming the end of a previously reserved service.\\n* [[CancelAction]]: Unlike CancelAction, CheckOutAction implies that the agent is informing/confirming the end of a previously reserved service." ;
 .
 
-sdo:CheckoutPage
+schema:CheckoutPage
     rdfs:label "Checkout Page" ;
     rdfs:comment "Web page type: Checkout page." ;
 .
 
-sdo:ChemicalSubstance
+schema:ChemicalSubstance
     rdfs:label "Chemical Substance" ;
     rdfs:comment "A chemical substance is 'a portion of matter of constant composition, composed of molecular entities of the same type or of different types' (source: [ChEBI:59999](https://www.ebi.ac.uk/chebi/searchId.do?chebiId=59999))." ;
 .
 
-sdo:ChildCare
+schema:ChildCare
     rdfs:label "Child Care" ;
     rdfs:comment "A Childcare center." ;
 .
 
-sdo:ChildrensEvent
+schema:ChildrensEvent
     rdfs:label "Childrens Event" ;
     rdfs:comment "Event type: Children's event." ;
 .
 
-sdo:Chiropractic
+schema:Chiropractic
     rdfs:label "Chiropractic" ;
     rdfs:comment "A system of medicine focused on the relationship between the body's structure, mainly the spine, and its functioning." ;
 .
 
-sdo:ChooseAction
+schema:ChooseAction
     rdfs:label "Choose Action" ;
     rdfs:comment "The act of expressing a preference from a set of options or a large or unbounded set of choices/options." ;
 .
 
-sdo:Church
+schema:Church
     rdfs:label "Church" ;
     rdfs:comment "A church." ;
 .
 
-sdo:City
+schema:City
     rdfs:label "City" ;
     rdfs:comment "A city or town." ;
 .
 
-sdo:CityHall
+schema:CityHall
     rdfs:label "City Hall" ;
     rdfs:comment "A city hall." ;
 .
 
-sdo:CivicStructure
+schema:CivicStructure
     rdfs:label "Civic Structure" ;
     rdfs:comment "A public structure, such as a town hall or concert hall." ;
 .
 
-sdo:Claim
+schema:Claim
     rdfs:label "Claim" ;
     rdfs:comment """A [[Claim]] in Schema.org represents a specific, factually-oriented claim that could be the [[itemReviewed]] in a [[ClaimReview]]. The content of a claim can be summarized with the [[text]] property. Variations on well known claims can have their common identity indicated via [[sameAs]] links, and summarized with a [[name]]. Ideally, a [[Claim]] description includes enough contextual information to minimize the risk of ambiguity or inclarity. In practice, many claims are better understood in the context in which they appear or the interpretations provided by claim reviews.
 
@@ -3604,82 +3604,82 @@ sdo:Claim
   """ ;
 .
 
-sdo:ClaimReview
+schema:ClaimReview
     rdfs:label "Claim Review" ;
     rdfs:comment "A fact-checking review of claims made (or reported) in some creative work (referenced via itemReviewed)." ;
 .
 
-sdo:Class
+schema:Class
     rdfs:label "Class" ;
     rdfs:comment "A class, also often called a 'Type'; equivalent to rdfs:Class." ;
 .
 
-sdo:CleaningFee
+schema:CleaningFee
     rdfs:label "Cleaning Fee" ;
     rdfs:comment "Represents the cleaning fee part of the total price for an offered product, for example a vacation rental." ;
 .
 
-sdo:Clinician
+schema:Clinician
     rdfs:label "Clinician" ;
     rdfs:comment "Medical clinicians, including practicing physicians and other medical professionals involved in clinical practice." ;
 .
 
-sdo:Clip
+schema:Clip
     rdfs:label "Clip" ;
     rdfs:comment "A short TV or radio program or a segment/part of a program." ;
 .
 
-sdo:ClothingStore
+schema:ClothingStore
     rdfs:label "Clothing Store" ;
     rdfs:comment "A clothing store." ;
 .
 
-sdo:CoOp
+schema:CoOp
     rdfs:label "Co Op" ;
     rdfs:comment "Play mode: CoOp. Co-operative games, where you play on the same team with friends." ;
 .
 
-sdo:Code
+schema:Code
     rdfs:label "Code" ;
     rdfs:comment "Computer programming source code. Example: Full (compile ready) solutions, code snippet samples, scripts, templates." ;
 .
 
-sdo:CohortStudy
+schema:CohortStudy
     rdfs:label "Cohort Study" ;
     rdfs:comment "Also known as a panel study. A cohort study is a form of longitudinal study used in medicine and social science. It is one type of study design and should be compared with a cross-sectional study.  A cohort is a group of people who share a common characteristic or experience within a defined period (e.g., are born, leave school, lose their job, are exposed to a drug or a vaccine, etc.). The comparison group may be the general population from which the cohort is drawn, or it may be another cohort of persons thought to have had little or no exposure to the substance under investigation, but otherwise similar. Alternatively, subgroups within the cohort may be compared with each other." ;
 .
 
-sdo:Collection
+schema:Collection
     rdfs:label "Collection" ;
     rdfs:comment "A collection of items e.g. creative works or products." ;
 .
 
-sdo:CollectionPage
+schema:CollectionPage
     rdfs:label "Collection Page" ;
     rdfs:comment "Web page type: Collection page." ;
 .
 
-sdo:CollegeOrUniversity
+schema:CollegeOrUniversity
     rdfs:label "College  Or University" ;
     rdfs:comment "A college, university, or other third-level educational institution." ;
 .
 
-sdo:ComedyClub
+schema:ComedyClub
     rdfs:label "Comedy Club" ;
     rdfs:comment "A comedy club." ;
 .
 
-sdo:ComedyEvent
+schema:ComedyEvent
     rdfs:label "Comedy Event" ;
     rdfs:comment "Event type: Comedy event." ;
 .
 
-sdo:ComicCoverArt
+schema:ComicCoverArt
     rdfs:label "Comic  Cover Art" ;
     rdfs:comment "The artwork on the cover of a comic." ;
 .
 
-sdo:ComicIssue
+schema:ComicIssue
     rdfs:label "Comic Issue" ;
     rdfs:comment """Individual comic issues are serially published as
     	part of a larger series. For the sake of consistency, even one-shot issues
@@ -3689,178 +3689,178 @@ sdo:ComicIssue
     	description of the issue (if any).""" ;
 .
 
-sdo:ComicSeries
+schema:ComicSeries
     rdfs:label "Comic Series" ;
     rdfs:comment """A sequential publication of comic stories under a
     	unifying title, for example "The Amazing Spider-Man" or "Groo the
     	Wanderer".""" ;
 .
 
-sdo:ComicStory
+schema:ComicStory
     rdfs:label "Comic Story" ;
     rdfs:comment """The term "story" is any indivisible, re-printable
     	unit of a comic, including the interior stories, covers, and backmatter. Most
     	comics have at least two stories: a cover (ComicCoverArt) and an interior story.""" ;
 .
 
-sdo:Comment
+schema:Comment
     rdfs:label "Comment" ;
     rdfs:comment "A comment on an item - for example, a comment on a blog post. The comment's content is expressed via the [[text]] property, and its topic via [[about]], properties shared with all CreativeWorks." ;
 .
 
-sdo:CommentAction
+schema:CommentAction
     rdfs:label "Comment Action" ;
     rdfs:comment "The act of generating a comment about a subject." ;
 .
 
-sdo:CommentPermission
+schema:CommentPermission
     rdfs:label "Comment Permission" ;
     rdfs:comment "Permission to add comments to the document." ;
 .
 
-sdo:CommunicateAction
+schema:CommunicateAction
     rdfs:label "Communicate Action" ;
     rdfs:comment "The act of conveying information to another person via a communication medium (instrument) such as speech, email, or telephone conversation." ;
 .
 
-sdo:CommunityHealth
+schema:CommunityHealth
     rdfs:label "Community Health" ;
     rdfs:comment "A field of public health focusing on improving health characteristics of a defined population in relation with their geographical or environment areas." ;
 .
 
-sdo:CompilationAlbum
+schema:CompilationAlbum
     rdfs:label "Compilation Album" ;
     rdfs:comment "CompilationAlbum." ;
 .
 
-sdo:CompleteDataFeed
+schema:CompleteDataFeed
     rdfs:label "Complete  Data Feed" ;
     rdfs:comment """A [[CompleteDataFeed]] is a [[DataFeed]] whose standard representation includes content for every item currently in the feed.
 
 This is the equivalent of Atom's element as defined in Feed Paging and Archiving [RFC 5005](https://tools.ietf.org/html/rfc5005), For example (and as defined for Atom), when using data from a feed that represents a collection of items that varies over time (e.g. "Top Twenty Records") there is no need to have newer entries mixed in alongside older, obsolete entries. By marking this feed as a CompleteDataFeed, old entries can be safely discarded when the feed is refreshed, since we can assume the feed has provided descriptions for all current items.""" ;
 .
 
-sdo:Completed
+schema:Completed
     rdfs:label "Completed" ;
     rdfs:comment "Completed." ;
 .
 
-sdo:CompletedActionStatus
+schema:CompletedActionStatus
     rdfs:label "Completed  Action Status" ;
     rdfs:comment "An action that has already taken place." ;
 .
 
-sdo:CompoundPriceSpecification
+schema:CompoundPriceSpecification
     rdfs:label "Compound  Price Specification" ;
     rdfs:comment "A compound price specification is one that bundles multiple prices that all apply in combination for different dimensions of consumption. Use the name property of the attached unit price specification for indicating the dimension of a price component (e.g. \"electricity\" or \"final cleaning\")." ;
 .
 
-sdo:ComputerLanguage
+schema:ComputerLanguage
     rdfs:label "Computer Language" ;
     rdfs:comment "This type covers computer programming languages such as Scheme and Lisp, as well as other language-like computer representations. Natural languages are best represented with the [[Language]] type." ;
 .
 
-sdo:ComputerStore
+schema:ComputerStore
     rdfs:label "Computer Store" ;
     rdfs:comment "A computer store." ;
 .
 
-sdo:ConfirmAction
+schema:ConfirmAction
     rdfs:label "Confirm Action" ;
     rdfs:comment "The act of notifying someone that a future event/action is going to happen as expected.\\n\\nRelated actions:\\n\\n* [[CancelAction]]: The antonym of ConfirmAction." ;
 .
 
-sdo:Consortium
+schema:Consortium
     rdfs:label "Consortium" ;
     rdfs:comment "A Consortium is a membership [[Organization]] whose members are typically Organizations." ;
 .
 
-sdo:ConsumeAction
+schema:ConsumeAction
     rdfs:label "Consume Action" ;
     rdfs:comment "The act of ingesting information/resources/food." ;
 .
 
-sdo:ContactPage
+schema:ContactPage
     rdfs:label "Contact Page" ;
     rdfs:comment "Web page type: Contact page." ;
 .
 
-sdo:ContactPoint
+schema:ContactPoint
     rdfs:label "Contact Point" ;
     rdfs:comment "A contact point—for example, a Customer Complaints department." ;
 .
 
-sdo:ContactPointOption
+schema:ContactPointOption
     rdfs:label "Contact  Point Option" ;
     rdfs:comment "Enumerated options related to a ContactPoint." ;
 .
 
-sdo:ContagiousnessHealthAspect
+schema:ContagiousnessHealthAspect
     rdfs:label "Contagiousness  Health Aspect" ;
     rdfs:comment "Content about contagion mechanisms and contagiousness information over the topic." ;
 .
 
-sdo:Continent
+schema:Continent
     rdfs:label "Continent" ;
     rdfs:comment "One of the continents (for example, Europe or Africa)." ;
 .
 
-sdo:ControlAction
+schema:ControlAction
     rdfs:label "Control Action" ;
     rdfs:comment "An agent controls a device or application." ;
 .
 
-sdo:ConvenienceStore
+schema:ConvenienceStore
     rdfs:label "Convenience Store" ;
     rdfs:comment "A convenience store." ;
 .
 
-sdo:Conversation
+schema:Conversation
     rdfs:label "Conversation" ;
     rdfs:comment "One or more messages between organizations or people on a particular topic. Individual messages can be linked to the conversation with isPartOf or hasPart properties." ;
 .
 
-sdo:CookAction
+schema:CookAction
     rdfs:label "Cook Action" ;
     rdfs:comment "The act of producing/preparing food." ;
 .
 
-sdo:Corporation
+schema:Corporation
     rdfs:label "Corporation" ;
     rdfs:comment "Organization: A business corporation." ;
 .
 
-sdo:CorrectionComment
+schema:CorrectionComment
     rdfs:label "Correction Comment" ;
     rdfs:comment "A [[comment]] that corrects [[CreativeWork]]." ;
 .
 
-sdo:Country
+schema:Country
     rdfs:label "Country" ;
     rdfs:comment "A country." ;
 .
 
-sdo:Course
+schema:Course
     rdfs:label "Course" ;
     rdfs:comment "A description of an educational course which may be offered as distinct instances at which take place at different times or take place at different locations, or be offered through different media or modes of study. An educational course is a sequence of one or more educational events and/or creative works which aims to build knowledge, competence or ability of learners." ;
 .
 
-sdo:CourseInstance
+schema:CourseInstance
     rdfs:label "Course Instance" ;
     rdfs:comment "An instance of a [[Course]] which is distinct from other instances because it is offered at a different time or location or through different media or modes of study or to a specific section of students." ;
 .
 
-sdo:Courthouse
+schema:Courthouse
     rdfs:label "Courthouse" ;
     rdfs:comment "A courthouse." ;
 .
 
-sdo:CoverArt
+schema:CoverArt
     rdfs:label "Cover Art" ;
     rdfs:comment "The artwork on the outer surface of a CreativeWork." ;
 .
 
-sdo:CovidTestingFacility
+schema:CovidTestingFacility
     rdfs:label "Covid  Testing Facility" ;
     rdfs:comment """A CovidTestingFacility is a [[MedicalClinic]] where testing for the COVID-19 Coronavirus
       disease is available. If the facility is being made available from an established [[Pharmacy]], [[Hotel]], or other
@@ -3869,134 +3869,134 @@ sdo:CovidTestingFacility
       """ ;
 .
 
-sdo:CreateAction
+schema:CreateAction
     rdfs:label "Create Action" ;
     rdfs:comment "The act of deliberately creating/producing/generating/building a result out of the agent." ;
 .
 
-sdo:CreativeWork
+schema:CreativeWork
     rdfs:label "Creative Work" ;
     rdfs:comment "The most generic kind of creative work, including books, movies, photographs, software programs, etc." ;
 .
 
-sdo:CreativeWorkSeason
+schema:CreativeWorkSeason
     rdfs:label "Creative  Work Season" ;
     rdfs:comment "A media season e.g. tv, radio, video game etc." ;
 .
 
-sdo:CreativeWorkSeries
+schema:CreativeWorkSeries
     rdfs:label "Creative  Work Series" ;
     rdfs:comment """A CreativeWorkSeries in schema.org is a group of related items, typically but not necessarily of the same kind. CreativeWorkSeries are usually organized into some order, often chronological. Unlike [[ItemList]] which is a general purpose data structure for lists of things, the emphasis with CreativeWorkSeries is on published materials (written e.g. books and periodicals, or media such as tv, radio and games).\\n\\nSpecific subtypes are available for describing [[TVSeries]], [[RadioSeries]], [[MovieSeries]], [[BookSeries]], [[Periodical]] and [[VideoGameSeries]]. In each case, the [[hasPart]] / [[isPartOf]] properties can be used to relate the CreativeWorkSeries to its parts. The general CreativeWorkSeries type serves largely just to organize these more specific and practical subtypes.\\n\\nIt is common for properties applicable to an item from the series to be usefully applied to the containing group. Schema.org attempts to anticipate some of these cases, but publishers should be free to apply properties of the series parts to the series as a whole wherever they seem appropriate.
 	  """ ;
 .
 
-sdo:CreditCard
+schema:CreditCard
     rdfs:label "Credit Card" ;
     rdfs:comment """A card payment method of a particular brand or name.  Used to mark up a particular payment method and/or the financial product/service that supplies the card account.\\n\\nCommonly used values:\\n\\n* http://purl.org/goodrelations/v1#AmericanExpress\\n* http://purl.org/goodrelations/v1#DinersClub\\n* http://purl.org/goodrelations/v1#Discover\\n* http://purl.org/goodrelations/v1#JCB\\n* http://purl.org/goodrelations/v1#MasterCard\\n* http://purl.org/goodrelations/v1#VISA
        """ ;
 .
 
-sdo:Crematorium
+schema:Crematorium
     rdfs:label "Crematorium" ;
     rdfs:comment "A crematorium." ;
 .
 
-sdo:CriticReview
+schema:CriticReview
     rdfs:label "Critic Review" ;
     rdfs:comment "A [[CriticReview]] is a more specialized form of Review written or published by a source that is recognized for its reviewing activities. These can include online columns, travel and food guides, TV and radio shows, blogs and other independent Web sites. [[CriticReview]]s are typically more in-depth and professionally written. For simpler, casually written user/visitor/viewer/customer reviews, it is more appropriate to use the [[UserReview]] type. Review aggregator sites such as Metacritic already separate out the site's user reviews from selected critic reviews that originate from third-party sources." ;
 .
 
-sdo:CrossSectional
+schema:CrossSectional
     rdfs:label "Cross Sectional" ;
     rdfs:comment "Studies carried out on pre-existing data (usually from 'snapshot' surveys), such as that collected by the Census Bureau. Sometimes called Prevalence Studies." ;
 .
 
-sdo:CssSelectorType
+schema:CssSelectorType
     rdfs:label "Css  Selector Type" ;
     rdfs:comment "Text representing a CSS selector." ;
 .
 
-sdo:CurrencyConversionService
+schema:CurrencyConversionService
     rdfs:label "Currency  Conversion Service" ;
     rdfs:comment "A service to convert funds from one currency to another currency." ;
 .
 
-sdo:DDxElement
+schema:DDxElement
     rdfs:label "D Dx Element" ;
     rdfs:comment "An alternative, closely-related condition typically considered later in the differential diagnosis process along with the signs that are used to distinguish it." ;
 .
 
-sdo:DJMixAlbum
+schema:DJMixAlbum
     rdfs:label "DJ Mix Album" ;
     rdfs:comment "DJMixAlbum." ;
 .
 
-sdo:DVDFormat
+schema:DVDFormat
     rdfs:label "DVDFormat" ;
     rdfs:comment "DVDFormat." ;
 .
 
-sdo:DamagedCondition
+schema:DamagedCondition
     rdfs:label "Damaged Condition" ;
     rdfs:comment "Indicates that the item is damaged." ;
 .
 
-sdo:DanceEvent
+schema:DanceEvent
     rdfs:label "Dance Event" ;
     rdfs:comment "Event type: A social dance." ;
 .
 
-sdo:DanceGroup
+schema:DanceGroup
     rdfs:label "Dance Group" ;
     rdfs:comment "A dance group—for example, the Alvin Ailey Dance Theater or Riverdance." ;
 .
 
-sdo:DataCatalog
+schema:DataCatalog
     rdfs:label "Data Catalog" ;
     rdfs:comment "A collection of datasets." ;
 .
 
-sdo:DataDownload
+schema:DataDownload
     rdfs:label "Data Download" ;
     rdfs:comment "A dataset in downloadable form." ;
 .
 
-sdo:DataFeed
+schema:DataFeed
     rdfs:label "Data Feed" ;
     rdfs:comment "A single feed providing structured information about one or more entities or topics." ;
 .
 
-sdo:DataFeedItem
+schema:DataFeedItem
     rdfs:label "Data  Feed Item" ;
     rdfs:comment "A single item within a larger data feed." ;
 .
 
-sdo:DataType
+schema:DataType
     rdfs:label "Data Type" ;
     rdfs:comment "The basic data types such as Integers, Strings, etc." ;
 .
 
-sdo:Dataset
+schema:Dataset
     rdfs:label "Dataset" ;
     rdfs:comment "A body of structured information describing some topic(s) of interest." ;
 .
 
-sdo:Date
+schema:Date
     rdfs:label "Date" ;
     rdfs:comment "A date value in [ISO 8601 date format](http://en.wikipedia.org/wiki/ISO_8601)." ;
 .
 
-sdo:DateTime
+schema:DateTime
     rdfs:label "Date Time" ;
     rdfs:comment "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm] (see Chapter 5.4 of ISO 8601)." ;
 .
 
-sdo:DatedMoneySpecification
+schema:DatedMoneySpecification
     rdfs:label "Dated  Money Specification" ;
     rdfs:comment "A DatedMoneySpecification represents monetary values with optional start and end dates. For example, this could represent an employee's salary over a specific period of time. __Note:__ This type has been superseded by [[MonetaryAmount]] use of that type is recommended" ;
 .
 
-sdo:DayOfWeek
+schema:DayOfWeek
     rdfs:label "Day  Of Week" ;
     rdfs:comment """The day of the week, e.g. used to specify to which day the opening hours of an OpeningHoursSpecification refer.
 
@@ -4004,17 +4004,17 @@ Originally, URLs from [GoodRelations](http://purl.org/goodrelations/v1) were use
       """ ;
 .
 
-sdo:DaySpa
+schema:DaySpa
     rdfs:label "Day Spa" ;
     rdfs:comment "A day spa." ;
 .
 
-sdo:DeactivateAction
+schema:DeactivateAction
     rdfs:label "Deactivate Action" ;
     rdfs:comment "The act of stopping or deactivating a device or application (e.g. stopping a timer or turning off a flashlight)." ;
 .
 
-sdo:DecontextualizedContent
+schema:DecontextualizedContent
     rdfs:label "Decontextualized Content" ;
     rdfs:comment """Content coded 'missing context' in a [[MediaReview]], considered in the context of how it was published or shared.
 
@@ -4028,12 +4028,12 @@ For an [[AudioObject]] to be 'missing context': Unaltered audio presented in an 
 """ ;
 .
 
-sdo:DefenceEstablishment
+schema:DefenceEstablishment
     rdfs:label "Defence Establishment" ;
     rdfs:comment "A defence establishment, such as an army or navy base." ;
 .
 
-sdo:DefinedRegion
+schema:DefinedRegion
     rdfs:label "Defined Region" ;
     rdfs:comment """A DefinedRegion is a geographic area defined by potentially arbitrary (rather than political, administrative or natural geographical) criteria. Properties are provided for defining a region by reference to sets of postal codes.
 
@@ -4051,374 +4051,374 @@ Region = state, canton, prefecture, autonomous community...
 """ ;
 .
 
-sdo:DefinedTerm
+schema:DefinedTerm
     rdfs:label "Defined Term" ;
     rdfs:comment "A word, name, acronym, phrase, etc. with a formal definition. Often used in the context of category or subject classification, glossaries or dictionaries, product or creative work types, etc. Use the name property for the term being defined, use termCode if the term has an alpha-numeric code allocated, use description to provide the definition of the term." ;
 .
 
-sdo:DefinedTermSet
+schema:DefinedTermSet
     rdfs:label "Defined  Term Set" ;
     rdfs:comment "A set of defined terms for example a set of categories or a classification scheme, a glossary, dictionary or enumeration." ;
 .
 
-sdo:DefinitiveLegalValue
+schema:DefinitiveLegalValue
     rdfs:label "Definitive  Legal Value" ;
     rdfs:comment """Indicates a document for which the text is conclusively what the law says and is legally binding. (e.g. The digitally signed version of an Official Journal.)
   Something "Definitive" is considered to be also [[AuthoritativeLegalValue]].""" ;
 .
 
-sdo:DeleteAction
+schema:DeleteAction
     rdfs:label "Delete Action" ;
     rdfs:comment "The act of editing a recipient by removing one of its objects." ;
 .
 
-sdo:DeliveryChargeSpecification
+schema:DeliveryChargeSpecification
     rdfs:label "Delivery  Charge Specification" ;
     rdfs:comment "The price for the delivery of an offer using a particular delivery method." ;
 .
 
-sdo:DeliveryEvent
+schema:DeliveryEvent
     rdfs:label "Delivery Event" ;
     rdfs:comment "An event involving the delivery of an item." ;
 .
 
-sdo:DeliveryMethod
+schema:DeliveryMethod
     rdfs:label "Delivery Method" ;
     rdfs:comment """A delivery method is a standardized procedure for transferring the product or service to the destination of fulfillment chosen by the customer. Delivery methods are characterized by the means of transportation used, and by the organization or group that is the contracting party for the sending organization or person.\\n\\nCommonly used values:\\n\\n* http://purl.org/goodrelations/v1#DeliveryModeDirectDownload\\n* http://purl.org/goodrelations/v1#DeliveryModeFreight\\n* http://purl.org/goodrelations/v1#DeliveryModeMail\\n* http://purl.org/goodrelations/v1#DeliveryModeOwnFleet\\n* http://purl.org/goodrelations/v1#DeliveryModePickUp\\n* http://purl.org/goodrelations/v1#DHL\\n* http://purl.org/goodrelations/v1#FederalExpress\\n* http://purl.org/goodrelations/v1#UPS
         """ ;
 .
 
-sdo:DeliveryTimeSettings
+schema:DeliveryTimeSettings
     rdfs:label "Delivery  Time Settings" ;
     rdfs:comment "A DeliveryTimeSettings represents re-usable pieces of shipping information, relating to timing. It is designed for publication on an URL that may be referenced via the [[shippingSettingsLink]] property of a [[OfferShippingDetails]]. Several occurrences can be published, distinguished (and identified/referenced) by their different values for [[transitTimeLabel]]." ;
 .
 
-sdo:Demand
+schema:Demand
     rdfs:label "Demand" ;
     rdfs:comment "A demand entity represents the public, not necessarily binding, not necessarily exclusive, announcement by an organization or person to seek a certain type of goods or services. For describing demand using this type, the very same properties used for Offer apply." ;
 .
 
-sdo:DemoAlbum
+schema:DemoAlbum
     rdfs:label "Demo Album" ;
     rdfs:comment "DemoAlbum." ;
 .
 
-sdo:Dentist
+schema:Dentist
     rdfs:label "Dentist" ;
     rdfs:comment "A dentist." ;
 .
 
-sdo:Dentistry
+schema:Dentistry
     rdfs:label "Dentistry" ;
     rdfs:comment "A branch of medicine that is involved in the dental care." ;
 .
 
-sdo:DepartAction
+schema:DepartAction
     rdfs:label "Depart Action" ;
     rdfs:comment "The act of  departing from a place. An agent departs from an fromLocation for a destination, optionally with participants." ;
 .
 
-sdo:DepartmentStore
+schema:DepartmentStore
     rdfs:label "Department Store" ;
     rdfs:comment "A department store." ;
 .
 
-sdo:DepositAccount
+schema:DepositAccount
     rdfs:label "Deposit Account" ;
     rdfs:comment "A type of Bank Account with a main purpose of depositing funds to gain interest or other benefits." ;
 .
 
-sdo:Dermatologic
+schema:Dermatologic
     rdfs:label "Dermatologic" ;
     rdfs:comment "Something relating to or practicing dermatology." ;
 .
 
-sdo:Dermatology
+schema:Dermatology
     rdfs:label "Dermatology" ;
     rdfs:comment "A specific branch of medical science that pertains to diagnosis and treatment of disorders of skin." ;
 .
 
-sdo:DiabeticDiet
+schema:DiabeticDiet
     rdfs:label "Diabetic Diet" ;
     rdfs:comment "A diet appropriate for people with diabetes." ;
 .
 
-sdo:Diagnostic
+schema:Diagnostic
     rdfs:label "Diagnostic" ;
     rdfs:comment "A medical device used for diagnostic purposes." ;
 .
 
-sdo:DiagnosticLab
+schema:DiagnosticLab
     rdfs:label "Diagnostic Lab" ;
     rdfs:comment "A medical laboratory that offers on-site or off-site diagnostic services." ;
 .
 
-sdo:DiagnosticProcedure
+schema:DiagnosticProcedure
     rdfs:label "Diagnostic Procedure" ;
     rdfs:comment "A medical procedure intended primarily for diagnostic, as opposed to therapeutic, purposes." ;
 .
 
-sdo:Diet
+schema:Diet
     rdfs:label "Diet" ;
     rdfs:comment "A strategy of regulating the intake of food to achieve or maintain a specific health-related goal." ;
 .
 
-sdo:DietNutrition
+schema:DietNutrition
     rdfs:label "Diet Nutrition" ;
     rdfs:comment "Dietetic and nutrition as a medical specialty." ;
 .
 
-sdo:DietarySupplement
+schema:DietarySupplement
     rdfs:label "Dietary Supplement" ;
     rdfs:comment "A product taken by mouth that contains a dietary ingredient intended to supplement the diet. Dietary ingredients may include vitamins, minerals, herbs or other botanicals, amino acids, and substances such as enzymes, organ tissues, glandulars and metabolites." ;
 .
 
-sdo:DigitalAudioTapeFormat
+schema:DigitalAudioTapeFormat
     rdfs:label "Digital Audio Tape Format" ;
     rdfs:comment "DigitalAudioTapeFormat." ;
 .
 
-sdo:DigitalDocument
+schema:DigitalDocument
     rdfs:label "Digital Document" ;
     rdfs:comment "An electronic file or document." ;
 .
 
-sdo:DigitalDocumentPermission
+schema:DigitalDocumentPermission
     rdfs:label "Digital  Document Permission" ;
     rdfs:comment "A permission for a particular person or group to access a particular file." ;
 .
 
-sdo:DigitalDocumentPermissionType
+schema:DigitalDocumentPermissionType
     rdfs:label "Digital Document Permission Type" ;
     rdfs:comment "A type of permission which can be granted for accessing a digital document." ;
 .
 
-sdo:DigitalFormat
+schema:DigitalFormat
     rdfs:label "Digital Format" ;
     rdfs:comment "DigitalFormat." ;
 .
 
-sdo:DisabilitySupport
+schema:DisabilitySupport
     rdfs:label "Disability Support" ;
     rdfs:comment "DisabilitySupport: this is a benefit for disability support." ;
 .
 
-sdo:DisagreeAction
+schema:DisagreeAction
     rdfs:label "Disagree Action" ;
     rdfs:comment "The act of expressing a difference of opinion with the object. An agent disagrees to/about an object (a proposition, topic or theme) with participants." ;
 .
 
-sdo:Discontinued
+schema:Discontinued
     rdfs:label "Discontinued" ;
     rdfs:comment "Indicates that the item has been discontinued." ;
 .
 
-sdo:DiscoverAction
+schema:DiscoverAction
     rdfs:label "Discover Action" ;
     rdfs:comment "The act of discovering/finding an object." ;
 .
 
-sdo:DiscussionForumPosting
+schema:DiscussionForumPosting
     rdfs:label "Discussion  Forum Posting" ;
     rdfs:comment "A posting to a discussion forum." ;
 .
 
-sdo:DislikeAction
+schema:DislikeAction
     rdfs:label "Dislike Action" ;
     rdfs:comment "The act of expressing a negative sentiment about the object. An agent dislikes an object (a proposition, topic or theme) with participants." ;
 .
 
-sdo:Distance
+schema:Distance
     rdfs:label "Distance" ;
     rdfs:comment "Properties that take Distances as values are of the form '<Number> <Length unit of measure>'. E.g., '7 ft'." ;
 .
 
-sdo:DistanceFee
+schema:DistanceFee
     rdfs:label "Distance Fee" ;
     rdfs:comment "Represents the distance fee (e.g., price per km or mile) part of the total price for an offered product, for example a car rental." ;
 .
 
-sdo:Distillery
+schema:Distillery
     rdfs:label "Distillery" ;
     rdfs:comment "A distillery." ;
 .
 
-sdo:DonateAction
+schema:DonateAction
     rdfs:label "Donate Action" ;
     rdfs:comment "The act of providing goods, services, or money without compensation, often for philanthropic reasons." ;
 .
 
-sdo:DoseSchedule
+schema:DoseSchedule
     rdfs:label "Dose Schedule" ;
     rdfs:comment "A specific dosing schedule for a drug or supplement." ;
 .
 
-sdo:DoubleBlindedTrial
+schema:DoubleBlindedTrial
     rdfs:label "Double  Blinded Trial" ;
     rdfs:comment "A trial design in which neither the researcher nor the patient knows the details of the treatment the patient was randomly assigned to." ;
 .
 
-sdo:DownloadAction
+schema:DownloadAction
     rdfs:label "Download Action" ;
     rdfs:comment "The act of downloading an object." ;
 .
 
-sdo:Downpayment
+schema:Downpayment
     rdfs:label "Downpayment" ;
     rdfs:comment "Represents the downpayment (up-front payment) price component of the total price for an offered product that has additional installment payments." ;
 .
 
-sdo:DrawAction
+schema:DrawAction
     rdfs:label "Draw Action" ;
     rdfs:comment "The act of producing a visual/graphical representation of an object, typically with a pen/pencil and paper as instruments." ;
 .
 
-sdo:Drawing
+schema:Drawing
     rdfs:label "Drawing" ;
     rdfs:comment "A picture or diagram made with a pencil, pen, or crayon rather than paint." ;
 .
 
-sdo:DrinkAction
+schema:DrinkAction
     rdfs:label "Drink Action" ;
     rdfs:comment "The act of swallowing liquids." ;
 .
 
-sdo:DriveWheelConfigurationValue
+schema:DriveWheelConfigurationValue
     rdfs:label "Drive Wheel Configuration Value" ;
     rdfs:comment "A value indicating which roadwheels will receive torque." ;
 .
 
-sdo:DrivingSchoolVehicleUsage
+schema:DrivingSchoolVehicleUsage
     rdfs:label "Driving School Vehicle Usage" ;
     rdfs:comment "Indicates the usage of the vehicle for driving school." ;
 .
 
-sdo:Drug
+schema:Drug
     rdfs:label "Drug" ;
     rdfs:comment "A chemical or biologic substance, used as a medical therapy, that has a physiological effect on an organism. Here the term drug is used interchangeably with the term medicine although clinical knowledge make a clear difference between them." ;
 .
 
-sdo:DrugClass
+schema:DrugClass
     rdfs:label "Drug Class" ;
     rdfs:comment "A class of medical drugs, e.g., statins. Classes can represent general pharmacological class, common mechanisms of action, common physiological effects, etc." ;
 .
 
-sdo:DrugCost
+schema:DrugCost
     rdfs:label "Drug Cost" ;
     rdfs:comment "The cost per unit of a medical drug. Note that this type is not meant to represent the price in an offer of a drug for sale; see the Offer type for that. This type will typically be used to tag wholesale or average retail cost of a drug, or maximum reimbursable cost. Costs of medical drugs vary widely depending on how and where they are paid for, so while this type captures some of the variables, costs should be used with caution by consumers of this schema's markup." ;
 .
 
-sdo:DrugCostCategory
+schema:DrugCostCategory
     rdfs:label "Drug  Cost Category" ;
     rdfs:comment "Enumerated categories of medical drug costs." ;
 .
 
-sdo:DrugLegalStatus
+schema:DrugLegalStatus
     rdfs:label "Drug  Legal Status" ;
     rdfs:comment "The legal availability status of a medical drug." ;
 .
 
-sdo:DrugPregnancyCategory
+schema:DrugPregnancyCategory
     rdfs:label "Drug  Pregnancy Category" ;
     rdfs:comment "Categories that represent an assessment of the risk of fetal injury due to a drug or pharmaceutical used as directed by the mother during pregnancy." ;
 .
 
-sdo:DrugPrescriptionStatus
+schema:DrugPrescriptionStatus
     rdfs:label "Drug  Prescription Status" ;
     rdfs:comment "Indicates whether this drug is available by prescription or over-the-counter." ;
 .
 
-sdo:DrugStrength
+schema:DrugStrength
     rdfs:label "Drug Strength" ;
     rdfs:comment "A specific strength in which a medical drug is available in a specific country." ;
 .
 
-sdo:DryCleaningOrLaundry
+schema:DryCleaningOrLaundry
     rdfs:label "Dry Cleaning Or Laundry" ;
     rdfs:comment "A dry-cleaning business." ;
 .
 
-sdo:Duration
+schema:Duration
     rdfs:label "Duration" ;
     rdfs:comment "Quantity: Duration (use [ISO 8601 duration format](http://en.wikipedia.org/wiki/ISO_8601))." ;
 .
 
-sdo:EBook
+schema:EBook
     rdfs:label "EBook" ;
     rdfs:comment "Book format: Ebook." ;
 .
 
-sdo:EPRelease
+schema:EPRelease
     rdfs:label "EPRelease" ;
     rdfs:comment "EPRelease." ;
 .
 
-sdo:EUEnergyEfficiencyCategoryA
+schema:EUEnergyEfficiencyCategoryA
     rdfs:label "EUEnergy Efficiency CategoryA" ;
     rdfs:comment "Represents EU Energy Efficiency Class A as defined in EU energy labeling regulations." ;
 .
 
-sdo:EUEnergyEfficiencyCategoryA1Plus
+schema:EUEnergyEfficiencyCategoryA1Plus
     rdfs:label "EUEnergy Efficiency CategoryA1Plus" ;
     rdfs:comment "Represents EU Energy Efficiency Class A+ as defined in EU energy labeling regulations." ;
 .
 
-sdo:EUEnergyEfficiencyCategoryA2Plus
+schema:EUEnergyEfficiencyCategoryA2Plus
     rdfs:label "EUEnergy Efficiency CategoryA2Plus" ;
     rdfs:comment "Represents EU Energy Efficiency Class A++ as defined in EU energy labeling regulations." ;
 .
 
-sdo:EUEnergyEfficiencyCategoryA3Plus
+schema:EUEnergyEfficiencyCategoryA3Plus
     rdfs:label "EUEnergy Efficiency CategoryA3Plus" ;
     rdfs:comment "Represents EU Energy Efficiency Class A+++ as defined in EU energy labeling regulations." ;
 .
 
-sdo:EUEnergyEfficiencyCategoryB
+schema:EUEnergyEfficiencyCategoryB
     rdfs:label "EUEnergy Efficiency CategoryB" ;
     rdfs:comment "Represents EU Energy Efficiency Class B as defined in EU energy labeling regulations." ;
 .
 
-sdo:EUEnergyEfficiencyCategoryC
+schema:EUEnergyEfficiencyCategoryC
     rdfs:label "EUEnergy Efficiency CategoryC" ;
     rdfs:comment "Represents EU Energy Efficiency Class C as defined in EU energy labeling regulations." ;
 .
 
-sdo:EUEnergyEfficiencyCategoryD
+schema:EUEnergyEfficiencyCategoryD
     rdfs:label "EUEnergy Efficiency CategoryD" ;
     rdfs:comment "Represents EU Energy Efficiency Class D as defined in EU energy labeling regulations." ;
 .
 
-sdo:EUEnergyEfficiencyCategoryE
+schema:EUEnergyEfficiencyCategoryE
     rdfs:label "EUEnergy Efficiency CategoryE" ;
     rdfs:comment "Represents EU Energy Efficiency Class E as defined in EU energy labeling regulations." ;
 .
 
-sdo:EUEnergyEfficiencyCategoryF
+schema:EUEnergyEfficiencyCategoryF
     rdfs:label "EUEnergy Efficiency CategoryF" ;
     rdfs:comment "Represents EU Energy Efficiency Class F as defined in EU energy labeling regulations." ;
 .
 
-sdo:EUEnergyEfficiencyCategoryG
+schema:EUEnergyEfficiencyCategoryG
     rdfs:label "EUEnergy Efficiency CategoryG" ;
     rdfs:comment "Represents EU Energy Efficiency Class G as defined in EU energy labeling regulations." ;
 .
 
-sdo:EUEnergyEfficiencyEnumeration
+schema:EUEnergyEfficiencyEnumeration
     rdfs:label "EUEnergy Efficiency Enumeration" ;
     rdfs:comment "Enumerates the EU energy efficiency classes A-G as well as A+, A++, and A+++ as defined in EU directive 2017/1369." ;
 .
 
-sdo:Ear
+schema:Ear
     rdfs:label "Ear" ;
     rdfs:comment "Ear function assessment with clinical examination." ;
 .
 
-sdo:EatAction
+schema:EatAction
     rdfs:label "Eat Action" ;
     rdfs:comment "The act of swallowing solid objects." ;
 .
 
-sdo:EditedOrCroppedContent
+schema:EditedOrCroppedContent
     rdfs:label "Edited Or Cropped Content" ;
     rdfs:comment """Content coded 'edited or cropped content' in a [[MediaReview]], considered in the context of how it was published or shared.
 
@@ -4432,102 +4432,102 @@ For an [[AudioObject]] to be 'edited or cropped content': The audio has been edi
 """ ;
 .
 
-sdo:EducationEvent
+schema:EducationEvent
     rdfs:label "Education Event" ;
     rdfs:comment "Event type: Education event." ;
 .
 
-sdo:EducationalAudience
+schema:EducationalAudience
     rdfs:label "Educational Audience" ;
     rdfs:comment "An EducationalAudience." ;
 .
 
-sdo:EducationalOccupationalCredential
+schema:EducationalOccupationalCredential
     rdfs:label "Educational  Occupational Credential" ;
     rdfs:comment "An educational or occupational credential. A diploma, academic degree, certification, qualification, badge, etc., that may be awarded to a person or other entity that meets the requirements defined by the credentialer." ;
 .
 
-sdo:EducationalOccupationalProgram
+schema:EducationalOccupationalProgram
     rdfs:label "Educational  Occupational Program" ;
     rdfs:comment "A program offered by an institution which determines the learning progress to achieve an outcome, usually a credential like a degree or certificate. This would define a discrete set of opportunities (e.g., job, courses) that together constitute a program with a clear start, end, set of requirements, and transition to a new occupational opportunity (e.g., a job), or sometimes a higher educational opportunity (e.g., an advanced degree)." ;
 .
 
-sdo:EducationalOrganization
+schema:EducationalOrganization
     rdfs:label "Educational Organization" ;
     rdfs:comment "An educational organization." ;
 .
 
-sdo:EffectivenessHealthAspect
+schema:EffectivenessHealthAspect
     rdfs:label "Effectiveness  Health Aspect" ;
     rdfs:comment "Content about the effectiveness-related aspects of a health topic." ;
 .
 
-sdo:Electrician
+schema:Electrician
     rdfs:label "Electrician" ;
     rdfs:comment "An electrician." ;
 .
 
-sdo:ElectronicsStore
+schema:ElectronicsStore
     rdfs:label "Electronics Store" ;
     rdfs:comment "An electronics store." ;
 .
 
-sdo:ElementarySchool
+schema:ElementarySchool
     rdfs:label "Elementary School" ;
     rdfs:comment "An elementary school." ;
 .
 
-sdo:EmailMessage
+schema:EmailMessage
     rdfs:label "Email Message" ;
     rdfs:comment "An email message." ;
 .
 
-sdo:Embassy
+schema:Embassy
     rdfs:label "Embassy" ;
     rdfs:comment "An embassy." ;
 .
 
-sdo:Emergency
+schema:Emergency
     rdfs:label "Emergency" ;
     rdfs:comment "A specific branch of medical science that deals with the evaluation and initial treatment of medical conditions caused by trauma or sudden illness." ;
 .
 
-sdo:EmergencyService
+schema:EmergencyService
     rdfs:label "Emergency Service" ;
     rdfs:comment "An emergency service, such as a fire station or ER." ;
 .
 
-sdo:EmployeeRole
+schema:EmployeeRole
     rdfs:label "Employee Role" ;
     rdfs:comment "A subclass of OrganizationRole used to describe employee relationships." ;
 .
 
-sdo:EmployerAggregateRating
+schema:EmployerAggregateRating
     rdfs:label "Employer  Aggregate Rating" ;
     rdfs:comment "An aggregate rating of an Organization related to its role as an employer." ;
 .
 
-sdo:EmployerReview
+schema:EmployerReview
     rdfs:label "Employer Review" ;
     rdfs:comment "An [[EmployerReview]] is a review of an [[Organization]] regarding its role as an employer, written by a current or former employee of that organization." ;
 .
 
-sdo:EmploymentAgency
+schema:EmploymentAgency
     rdfs:label "Employment Agency" ;
     rdfs:comment "An employment agency." ;
 .
 
-sdo:Endocrine
+schema:Endocrine
     rdfs:label "Endocrine" ;
     rdfs:comment "A specific branch of medical science that pertains to diagnosis and treatment of disorders of endocrine glands and their secretions." ;
 .
 
-sdo:EndorseAction
+schema:EndorseAction
     rdfs:label "Endorse Action" ;
     rdfs:comment "An agent approves/certifies/likes/supports/sanction an object." ;
 .
 
-sdo:EndorsementRating
+schema:EndorsementRating
     rdfs:label "Endorsement Rating" ;
     rdfs:comment """An EndorsementRating is a rating that expresses some level of endorsement, for example inclusion in a "critic's pick" blog, a
 "Like" or "+1" on a social network. It can be considered the [[result]] of an [[EndorseAction]] in which the [[object]] of the action is rated positively by
@@ -4538,102 +4538,102 @@ endorsement rating is particularly useful in the absence of numeric scales as it
 """ ;
 .
 
-sdo:Energy
+schema:Energy
     rdfs:label "Energy" ;
     rdfs:comment "Properties that take Energy as values are of the form '<Number> <Energy unit of measure>'." ;
 .
 
-sdo:EnergyConsumptionDetails
+schema:EnergyConsumptionDetails
     rdfs:label "Energy  Consumption Details" ;
     rdfs:comment "EnergyConsumptionDetails represents information related to the energy efficiency of a product that consumes energy. The information that can be provided is based on international regulations such as for example [EU directive 2017/1369](https://eur-lex.europa.eu/eli/reg/2017/1369/oj) for energy labeling and the [Energy labeling rule](https://www.ftc.gov/enforcement/rules/rulemaking-regulatory-reform-proceedings/energy-water-use-labeling-consumer) under the Energy Policy and Conservation Act (EPCA) in the US." ;
 .
 
-sdo:EnergyEfficiencyEnumeration
+schema:EnergyEfficiencyEnumeration
     rdfs:label "Energy  Efficiency Enumeration" ;
     rdfs:comment "Enumerates energy efficiency levels (also known as \"classes\" or \"ratings\") and certifications that are part of several international energy efficiency standards." ;
 .
 
-sdo:EnergyStarCertified
+schema:EnergyStarCertified
     rdfs:label "Energy  Star Certified" ;
     rdfs:comment "Represents EnergyStar certification." ;
 .
 
-sdo:EnergyStarEnergyEfficiencyEnumeration
+schema:EnergyStarEnergyEfficiencyEnumeration
     rdfs:label "Energy StarEnergy Efficiency Enumeration" ;
     rdfs:comment "Used to indicate whether a product is EnergyStar certified." ;
 .
 
-sdo:EngineSpecification
+schema:EngineSpecification
     rdfs:label "Engine Specification" ;
     rdfs:comment "Information about the engine of the vehicle. A vehicle can have multiple engines represented by multiple engine specification entities." ;
 .
 
-sdo:EnrollingByInvitation
+schema:EnrollingByInvitation
     rdfs:label "Enrolling  By Invitation" ;
     rdfs:comment "Enrolling participants by invitation only." ;
 .
 
-sdo:EntertainmentBusiness
+schema:EntertainmentBusiness
     rdfs:label "Entertainment Business" ;
     rdfs:comment "A business providing entertainment." ;
 .
 
-sdo:EntryPoint
+schema:EntryPoint
     rdfs:label "Entry Point" ;
     rdfs:comment "An entry point, within some Web-based protocol." ;
 .
 
-sdo:Enumeration
+schema:Enumeration
     rdfs:label "Enumeration" ;
     rdfs:comment "Lists or enumerations—for example, a list of cuisines or music genres, etc." ;
 .
 
-sdo:Episode
+schema:Episode
     rdfs:label "Episode" ;
     rdfs:comment "A media episode (e.g. TV, radio, video game) which can be part of a series or season." ;
 .
 
-sdo:Event
+schema:Event
     rdfs:label "Event" ;
     rdfs:comment "An event happening at a certain time and location, such as a concert, lecture, or festival. Ticketing information may be added via the [[offers]] property. Repeated events may be structured as separate Event objects." ;
 .
 
-sdo:EventAttendanceModeEnumeration
+schema:EventAttendanceModeEnumeration
     rdfs:label "Event Attendance Mode Enumeration" ;
     rdfs:comment "An EventAttendanceModeEnumeration value is one of potentially several modes of organising an event, relating to whether it is online or offline." ;
 .
 
-sdo:EventCancelled
+schema:EventCancelled
     rdfs:label "Event Cancelled" ;
     rdfs:comment "The event has been cancelled. If the event has multiple startDate values, all are assumed to be cancelled. Either startDate or previousStartDate may be used to specify the event's cancelled date(s)." ;
 .
 
-sdo:EventMovedOnline
+schema:EventMovedOnline
     rdfs:label "Event  Moved Online" ;
     rdfs:comment "Indicates that the event was changed to allow online participation. See [[eventAttendanceMode]] for specifics of whether it is now fully or partially online." ;
 .
 
-sdo:EventPostponed
+schema:EventPostponed
     rdfs:label "Event Postponed" ;
     rdfs:comment "The event has been postponed and no new date has been set. The event's previousStartDate should be set." ;
 .
 
-sdo:EventRescheduled
+schema:EventRescheduled
     rdfs:label "Event Rescheduled" ;
     rdfs:comment "The event has been rescheduled. The event's previousStartDate should be set to the old date and the startDate should be set to the event's new date. (If the event has been rescheduled multiple times, the previousStartDate property may be repeated)." ;
 .
 
-sdo:EventReservation
+schema:EventReservation
     rdfs:label "Event Reservation" ;
     rdfs:comment "A reservation for an event like a concert, sporting event, or lecture.\\n\\nNote: This type is for information about actual reservations, e.g. in confirmation emails or HTML pages with individual confirmations of reservations. For offers of tickets, use [[Offer]]." ;
 .
 
-sdo:EventScheduled
+schema:EventScheduled
     rdfs:label "Event Scheduled" ;
     rdfs:comment "The event is taking place or has taken place on the startDate as scheduled. Use of this value is optional, as it is assumed by default." ;
 .
 
-sdo:EventSeries
+schema:EventSeries
     rdfs:label "Event Series" ;
     rdfs:comment """A series of [[Event]]s. Included events can relate with the series using the [[superEvent]] property.
 
@@ -4651,237 +4651,237 @@ it may also sometimes prove useful to describe a longer-term series as an Event.
    """ ;
 .
 
-sdo:EventStatusType
+schema:EventStatusType
     rdfs:label "Event  Status Type" ;
     rdfs:comment "EventStatusType is an enumeration type whose instances represent several states that an Event may be in." ;
 .
 
-sdo:EventVenue
+schema:EventVenue
     rdfs:label "Event Venue" ;
     rdfs:comment "An event venue." ;
 .
 
-sdo:EvidenceLevelA
+schema:EvidenceLevelA
     rdfs:label "Evidence LevelA" ;
     rdfs:comment "Data derived from multiple randomized clinical trials or meta-analyses." ;
 .
 
-sdo:EvidenceLevelB
+schema:EvidenceLevelB
     rdfs:label "Evidence LevelB" ;
     rdfs:comment "Data derived from a single randomized trial, or nonrandomized studies." ;
 .
 
-sdo:EvidenceLevelC
+schema:EvidenceLevelC
     rdfs:label "Evidence LevelC" ;
     rdfs:comment "Only consensus opinion of experts, case studies, or standard-of-care." ;
 .
 
-sdo:ExchangeRateSpecification
+schema:ExchangeRateSpecification
     rdfs:label "Exchange  Rate Specification" ;
     rdfs:comment "A structured value representing exchange rate." ;
 .
 
-sdo:ExchangeRefund
+schema:ExchangeRefund
     rdfs:label "Exchange Refund" ;
     rdfs:comment "Specifies that a refund can be done as an exchange for the same product." ;
 .
 
-sdo:ExerciseAction
+schema:ExerciseAction
     rdfs:label "Exercise Action" ;
     rdfs:comment "The act of participating in exertive activity for the purposes of improving health and fitness." ;
 .
 
-sdo:ExerciseGym
+schema:ExerciseGym
     rdfs:label "Exercise Gym" ;
     rdfs:comment "A gym." ;
 .
 
-sdo:ExercisePlan
+schema:ExercisePlan
     rdfs:label "Exercise Plan" ;
     rdfs:comment "Fitness-related activity designed for a specific health-related purpose, including defined exercise routines as well as activity prescribed by a clinician." ;
 .
 
-sdo:ExhibitionEvent
+schema:ExhibitionEvent
     rdfs:label "Exhibition Event" ;
     rdfs:comment "Event type: Exhibition event, e.g. at a museum, library, archive, tradeshow, ..." ;
 .
 
-sdo:Eye
+schema:Eye
     rdfs:label "Eye" ;
     rdfs:comment "Eye or ophtalmological function assessment with clinical examination." ;
 .
 
-sdo:FAQPage
+schema:FAQPage
     rdfs:label "FAQPage" ;
     rdfs:comment "A [[FAQPage]] is a [[WebPage]] presenting one or more \"[Frequently asked questions](https://en.wikipedia.org/wiki/FAQ)\" (see also [[QAPage]])." ;
 .
 
-sdo:FDAcategoryA
+schema:FDAcategoryA
     rdfs:label "FDAcategoryA" ;
     rdfs:comment "A designation by the US FDA signifying that adequate and well-controlled studies have failed to demonstrate a risk to the fetus in the first trimester of pregnancy (and there is no evidence of risk in later trimesters)." ;
 .
 
-sdo:FDAcategoryB
+schema:FDAcategoryB
     rdfs:label "FDAcategoryB" ;
     rdfs:comment "A designation by the US FDA signifying that animal reproduction studies have failed to demonstrate a risk to the fetus and there are no adequate and well-controlled studies in pregnant women." ;
 .
 
-sdo:FDAcategoryC
+schema:FDAcategoryC
     rdfs:label "FDAcategoryC" ;
     rdfs:comment "A designation by the US FDA signifying that animal reproduction studies have shown an adverse effect on the fetus and there are no adequate and well-controlled studies in humans, but potential benefits may warrant use of the drug in pregnant women despite potential risks." ;
 .
 
-sdo:FDAcategoryD
+schema:FDAcategoryD
     rdfs:label "FDAcategoryD" ;
     rdfs:comment "A designation by the US FDA signifying that there is positive evidence of human fetal risk based on adverse reaction data from investigational or marketing experience or studies in humans, but potential benefits may warrant use of the drug in pregnant women despite potential risks." ;
 .
 
-sdo:FDAcategoryX
+schema:FDAcategoryX
     rdfs:label "FDAcategoryX" ;
     rdfs:comment "A designation by the US FDA signifying that studies in animals or humans have demonstrated fetal abnormalities and/or there is positive evidence of human fetal risk based on adverse reaction data from investigational or marketing experience, and the risks involved in use of the drug in pregnant women clearly outweigh potential benefits." ;
 .
 
-sdo:FDAnotEvaluated
+schema:FDAnotEvaluated
     rdfs:label "FD Anot Evaluated" ;
     rdfs:comment "A designation that the drug in question has not been assigned a pregnancy category designation by the US FDA." ;
 .
 
-sdo:FMRadioChannel
+schema:FMRadioChannel
     rdfs:label "FM Radio Channel" ;
     rdfs:comment "A radio channel that uses FM." ;
 .
 
-sdo:FailedActionStatus
+schema:FailedActionStatus
     rdfs:label "Failed  Action Status" ;
     rdfs:comment "An action that failed to complete. The action's error property and the HTTP return code contain more information about the failure." ;
 .
 
-sdo:False
+schema:False
     rdfs:label "False" ;
     rdfs:comment "The boolean value false." ;
 .
 
-sdo:FastFoodRestaurant
+schema:FastFoodRestaurant
     rdfs:label "Fast  Food Restaurant" ;
     rdfs:comment "A fast-food restaurant." ;
 .
 
-sdo:Female
+schema:Female
     rdfs:label "Female" ;
     rdfs:comment "The female gender." ;
 .
 
-sdo:Festival
+schema:Festival
     rdfs:label "Festival" ;
     rdfs:comment "Event type: Festival." ;
 .
 
-sdo:FilmAction
+schema:FilmAction
     rdfs:label "Film Action" ;
     rdfs:comment "The act of capturing sound and moving images on film, video, or digitally." ;
 .
 
-sdo:FinancialProduct
+schema:FinancialProduct
     rdfs:label "Financial Product" ;
     rdfs:comment "A product provided to consumers and businesses by financial institutions such as banks, insurance companies, brokerage firms, consumer finance companies, and investment companies which comprise the financial services industry." ;
 .
 
-sdo:FinancialService
+schema:FinancialService
     rdfs:label "Financial Service" ;
     rdfs:comment "Financial services business." ;
 .
 
-sdo:FindAction
+schema:FindAction
     rdfs:label "Find Action" ;
     rdfs:comment "The act of finding an object.\\n\\nRelated actions:\\n\\n* [[SearchAction]]: FindAction is generally lead by a SearchAction, but not necessarily." ;
 .
 
-sdo:FireStation
+schema:FireStation
     rdfs:label "Fire Station" ;
     rdfs:comment "A fire station. With firemen." ;
 .
 
-sdo:Flexibility
+schema:Flexibility
     rdfs:label "Flexibility" ;
     rdfs:comment "Physical activity that is engaged in to improve joint and muscle flexibility." ;
 .
 
-sdo:Flight
+schema:Flight
     rdfs:label "Flight" ;
     rdfs:comment "An airline flight." ;
 .
 
-sdo:FlightReservation
+schema:FlightReservation
     rdfs:label "Flight Reservation" ;
     rdfs:comment "A reservation for air travel.\\n\\nNote: This type is for information about actual reservations, e.g. in confirmation emails or HTML pages with individual confirmations of reservations. For offers of tickets, use [[Offer]]." ;
 .
 
-sdo:Float
+schema:Float
     rdfs:label "Float" ;
     rdfs:comment "Data type: Floating number." ;
 .
 
-sdo:FloorPlan
+schema:FloorPlan
     rdfs:label "Floor Plan" ;
     rdfs:comment "A FloorPlan is an explicit representation of a collection of similar accommodations, allowing the provision of common information (room counts, sizes, layout diagrams) and offers for rental or sale. In typical use, some [[ApartmentComplex]] has an [[accommodationFloorPlan]] which is a [[FloorPlan]].  A FloorPlan is always in the context of a particular place, either a larger [[ApartmentComplex]] or a single [[Apartment]]. The visual/spatial aspects of a floor plan (i.e. room layout, [see wikipedia](https://en.wikipedia.org/wiki/Floor_plan)) can be indicated using [[image]]. " ;
 .
 
-sdo:Florist
+schema:Florist
     rdfs:label "Florist" ;
     rdfs:comment "A florist." ;
 .
 
-sdo:FollowAction
+schema:FollowAction
     rdfs:label "Follow Action" ;
     rdfs:comment "The act of forming a personal connection with someone/something (object) unidirectionally/asymmetrically to get updates polled from.\\n\\nRelated actions:\\n\\n* [[BefriendAction]]: Unlike BefriendAction, FollowAction implies that the connection is *not* necessarily reciprocal.\\n* [[SubscribeAction]]: Unlike SubscribeAction, FollowAction implies that the follower acts as an active agent constantly/actively polling for updates.\\n* [[RegisterAction]]: Unlike RegisterAction, FollowAction implies that the agent is interested in continuing receiving updates from the object.\\n* [[JoinAction]]: Unlike JoinAction, FollowAction implies that the agent is interested in getting updates from the object.\\n* [[TrackAction]]: Unlike TrackAction, FollowAction refers to the polling of updates of all aspects of animate objects rather than the location of inanimate objects (e.g. you track a package, but you don't follow it)." ;
 .
 
-sdo:FoodEstablishment
+schema:FoodEstablishment
     rdfs:label "Food Establishment" ;
     rdfs:comment "A food-related business." ;
 .
 
-sdo:FoodEstablishmentReservation
+schema:FoodEstablishmentReservation
     rdfs:label "Food  Establishment Reservation" ;
     rdfs:comment "A reservation to dine at a food-related business.\\n\\nNote: This type is for information about actual reservations, e.g. in confirmation emails or HTML pages with individual confirmations of reservations." ;
 .
 
-sdo:FoodEvent
+schema:FoodEvent
     rdfs:label "Food Event" ;
     rdfs:comment "Event type: Food event." ;
 .
 
-sdo:FoodService
+schema:FoodService
     rdfs:label "Food Service" ;
     rdfs:comment "A food service, like breakfast, lunch, or dinner." ;
 .
 
-sdo:FourWheelDriveConfiguration
+schema:FourWheelDriveConfiguration
     rdfs:label "Four Wheel Drive Configuration" ;
     rdfs:comment "Four-wheel drive is a transmission layout where the engine primarily drives two wheels with a part-time four-wheel drive capability." ;
 .
 
-sdo:FreeReturn
+schema:FreeReturn
     rdfs:label "Free Return" ;
     rdfs:comment "Specifies that product returns are free of charge for the customer." ;
 .
 
-sdo:Friday
+schema:Friday
     rdfs:label "Friday" ;
     rdfs:comment "The day of the week between Thursday and Saturday." ;
 .
 
-sdo:FrontWheelDriveConfiguration
+schema:FrontWheelDriveConfiguration
     rdfs:label "Front Wheel Drive Configuration" ;
     rdfs:comment "Front-wheel drive is a transmission layout where the engine drives the front wheels." ;
 .
 
-sdo:FullRefund
+schema:FullRefund
     rdfs:label "Full Refund" ;
     rdfs:comment "Specifies that a refund can be done in the full amount the customer paid for the product" ;
 .
 
-sdo:FundingAgency
+schema:FundingAgency
     rdfs:label "Funding Agency" ;
     rdfs:comment """A FundingAgency is an organization that implements one or more [[FundingScheme]]s and manages
     the granting process (via [[Grant]]s, typically [[MonetaryGrant]]s).
@@ -4891,89 +4891,89 @@ Examples of funding agencies include ERC, REA, NIH, Bill and Melinda Gates Found
     """ ;
 .
 
-sdo:FundingScheme
+schema:FundingScheme
     rdfs:label "Funding Scheme" ;
     rdfs:comment """A FundingScheme combines organizational, project and policy aspects of grant-based funding
     that sets guidelines, principles and mechanisms to support other kinds of projects and activities.
     Funding is typically organized via [[Grant]] funding. Examples of funding schemes: Swiss Priority Programmes (SPPs); EU Framework 7 (FP7); Horizon 2020; the NIH-R01 Grant Program; Wellcome institutional strategic support fund. For large scale public sector funding, the management and administration of grant awards is often handled by other, dedicated, organizations - [[FundingAgency]]s such as ERC, REA, ...""" ;
 .
 
-sdo:Fungus
+schema:Fungus
     rdfs:label "Fungus" ;
     rdfs:comment "Pathogenic fungus." ;
 .
 
-sdo:FurnitureStore
+schema:FurnitureStore
     rdfs:label "Furniture Store" ;
     rdfs:comment "A furniture store." ;
 .
 
-sdo:Game
+schema:Game
     rdfs:label "Game" ;
     rdfs:comment "The Game type represents things which are games. These are typically rule-governed recreational activities, e.g. role-playing games in which players assume the role of characters in a fictional setting." ;
 .
 
-sdo:GamePlayMode
+schema:GamePlayMode
     rdfs:label "Game  Play Mode" ;
     rdfs:comment "Indicates whether this game is multi-player, co-op or single-player." ;
 .
 
-sdo:GameServer
+schema:GameServer
     rdfs:label "Game Server" ;
     rdfs:comment "Server that provides game interaction in a multiplayer game." ;
 .
 
-sdo:GameServerStatus
+schema:GameServerStatus
     rdfs:label "Game  Server Status" ;
     rdfs:comment "Status of a game server." ;
 .
 
-sdo:GardenStore
+schema:GardenStore
     rdfs:label "Garden Store" ;
     rdfs:comment "A garden store." ;
 .
 
-sdo:GasStation
+schema:GasStation
     rdfs:label "Gas Station" ;
     rdfs:comment "A gas station." ;
 .
 
-sdo:Gastroenterologic
+schema:Gastroenterologic
     rdfs:label "Gastroenterologic" ;
     rdfs:comment "A specific branch of medical science that pertains to diagnosis and treatment of disorders of digestive system." ;
 .
 
-sdo:GatedResidenceCommunity
+schema:GatedResidenceCommunity
     rdfs:label "Gated  Residence Community" ;
     rdfs:comment "Residence type: Gated community." ;
 .
 
-sdo:GenderType
+schema:GenderType
     rdfs:label "Gender Type" ;
     rdfs:comment "An enumeration of genders." ;
 .
 
-sdo:Gene
+schema:Gene
     rdfs:label "Gene" ;
     rdfs:comment "A discrete unit of inheritance which affects one or more biological traits (Source: [https://en.wikipedia.org/wiki/Gene](https://en.wikipedia.org/wiki/Gene)). Examples include FOXP2 (Forkhead box protein P2), SCARNA21 (small Cajal body-specific RNA 21), A- (agouti genotype)." ;
 .
 
-sdo:GeneralContractor
+schema:GeneralContractor
     rdfs:label "General Contractor" ;
     rdfs:comment "A general contractor." ;
 .
 
-sdo:Genetic
+schema:Genetic
     rdfs:label "Genetic" ;
     rdfs:comment "A specific branch of medical science that pertains to hereditary transmission and the variation of inherited characteristics and disorders." ;
 .
 
-sdo:Genitourinary
+schema:Genitourinary
     rdfs:label "Genitourinary" ;
     rdfs:comment "Genitourinary system function assessment with clinical examination." ;
 .
 
-sdo:GeoCircle
+schema:GeoCircle
     rdfs:label "Geo Circle" ;
     rdfs:comment """A GeoCircle is a GeoShape representing a circular geographic area. As it is a GeoShape
           it provides the simple textual property 'circle', but also allows the combination of postalCode alongside geoRadius.
@@ -4981,77 +4981,77 @@ sdo:GeoCircle
        """ ;
 .
 
-sdo:GeoCoordinates
+schema:GeoCoordinates
     rdfs:label "Geo Coordinates" ;
     rdfs:comment "The geographic coordinates of a place or event." ;
 .
 
-sdo:GeoShape
+schema:GeoShape
     rdfs:label "Geo Shape" ;
     rdfs:comment "The geographic shape of a place. A GeoShape can be described using several properties whose values are based on latitude/longitude pairs. Either whitespace or commas can be used to separate latitude and longitude; whitespace should be used when writing a list of several such points." ;
 .
 
-sdo:GeospatialGeometry
+schema:GeospatialGeometry
     rdfs:label "Geospatial Geometry" ;
     rdfs:comment "(Eventually to be defined as) a supertype of GeoShape designed to accommodate definitions from Geo-Spatial best practices." ;
 .
 
-sdo:Geriatric
+schema:Geriatric
     rdfs:label "Geriatric" ;
     rdfs:comment "A specific branch of medical science that is concerned with the diagnosis and treatment of diseases, debilities and provision of care to the aged." ;
 .
 
-sdo:GettingAccessHealthAspect
+schema:GettingAccessHealthAspect
     rdfs:label "Getting Access Health Aspect" ;
     rdfs:comment "Content that discusses practical and policy aspects for getting access to specific kinds of healthcare (e.g. distribution mechanisms for vaccines)." ;
 .
 
-sdo:GiveAction
+schema:GiveAction
     rdfs:label "Give Action" ;
     rdfs:comment "The act of transferring ownership of an object to a destination. Reciprocal of TakeAction.\\n\\nRelated actions:\\n\\n* [[TakeAction]]: Reciprocal of GiveAction.\\n* [[SendAction]]: Unlike SendAction, GiveAction implies that ownership is being transferred (e.g. I may send my laptop to you, but that doesn't mean I'm giving it to you)." ;
 .
 
-sdo:GlutenFreeDiet
+schema:GlutenFreeDiet
     rdfs:label "Gluten  Free Diet" ;
     rdfs:comment "A diet exclusive of gluten." ;
 .
 
-sdo:GolfCourse
+schema:GolfCourse
     rdfs:label "Golf Course" ;
     rdfs:comment "A golf course." ;
 .
 
-sdo:GovernmentBenefitsType
+schema:GovernmentBenefitsType
     rdfs:label "Government  Benefits Type" ;
     rdfs:comment "GovernmentBenefitsType enumerates several kinds of government benefits to support the COVID-19 situation. Note that this structure may not capture all benefits offered." ;
 .
 
-sdo:GovernmentBuilding
+schema:GovernmentBuilding
     rdfs:label "Government Building" ;
     rdfs:comment "A government building." ;
 .
 
-sdo:GovernmentOffice
+schema:GovernmentOffice
     rdfs:label "Government Office" ;
     rdfs:comment "A government office—for example, an IRS or DMV office." ;
 .
 
-sdo:GovernmentOrganization
+schema:GovernmentOrganization
     rdfs:label "Government Organization" ;
     rdfs:comment "A governmental organization or agency." ;
 .
 
-sdo:GovernmentPermit
+schema:GovernmentPermit
     rdfs:label "Government Permit" ;
     rdfs:comment "A permit issued by a government agency." ;
 .
 
-sdo:GovernmentService
+schema:GovernmentService
     rdfs:label "Government Service" ;
     rdfs:comment "A service provided by a government organization, e.g. food stamps, veterans benefits, etc." ;
 .
 
-sdo:Grant
+schema:Grant
     rdfs:label "Grant" ;
     rdfs:comment """A grant, typically financial or otherwise quantifiable, of resources. Typically a [[funder]] sponsors some [[MonetaryAmount]] to an [[Organization]] or [[Person]],
     sometimes not necessarily via a dedicated or long-lived [[Project]], resulting in one or more outputs, or [[fundedItem]]s. For financial sponsorship, indicate the [[funder]] of a [[MonetaryGrant]]. For non-financial support, indicate [[sponsor]] of [[Grant]]s of resources (e.g. office space).
@@ -5062,163 +5062,163 @@ The amount of a [[Grant]] is represented using [[amount]] as a [[MonetaryAmount]
     """ ;
 .
 
-sdo:GraphicNovel
+schema:GraphicNovel
     rdfs:label "Graphic Novel" ;
     rdfs:comment "Book format: GraphicNovel. May represent a bound collection of ComicIssue instances." ;
 .
 
-sdo:GroceryStore
+schema:GroceryStore
     rdfs:label "Grocery Store" ;
     rdfs:comment "A grocery store." ;
 .
 
-sdo:GroupBoardingPolicy
+schema:GroupBoardingPolicy
     rdfs:label "Group  Boarding Policy" ;
     rdfs:comment "The airline boards by groups based on check-in time, priority, etc." ;
 .
 
-sdo:Guide
+schema:Guide
     rdfs:label "Guide" ;
     rdfs:comment "[[Guide]] is a page or article that recommend specific products or services, or aspects of a thing for a user to consider. A [[Guide]] may represent a Buying Guide and detail aspects of products or services for a user to consider. A [[Guide]] may represent a Product Guide and recommend specific products or services. A [[Guide]] may represent a Ranked List and recommend specific products or services with ranking." ;
 .
 
-sdo:Gynecologic
+schema:Gynecologic
     rdfs:label "Gynecologic" ;
     rdfs:comment "A specific branch of medical science that pertains to the health care of women, particularly in the diagnosis and treatment of disorders affecting the female reproductive system." ;
 .
 
-sdo:HVACBusiness
+schema:HVACBusiness
     rdfs:label "HVACBusiness" ;
     rdfs:comment "A business that provide Heating, Ventilation and Air Conditioning services." ;
 .
 
-sdo:Hackathon
+schema:Hackathon
     rdfs:label "Hackathon" ;
     rdfs:comment "A [hackathon](https://en.wikipedia.org/wiki/Hackathon) event." ;
 .
 
-sdo:HairSalon
+schema:HairSalon
     rdfs:label "Hair Salon" ;
     rdfs:comment "A hair salon." ;
 .
 
-sdo:HalalDiet
+schema:HalalDiet
     rdfs:label "Halal Diet" ;
     rdfs:comment "A diet conforming to Islamic dietary practices." ;
 .
 
-sdo:Hardcover
+schema:Hardcover
     rdfs:label "Hardcover" ;
     rdfs:comment "Book format: Hardcover." ;
 .
 
-sdo:HardwareStore
+schema:HardwareStore
     rdfs:label "Hardware Store" ;
     rdfs:comment "A hardware store." ;
 .
 
-sdo:Head
+schema:Head
     rdfs:label "Head" ;
     rdfs:comment "Head assessment with clinical examination." ;
 .
 
-sdo:HealthAndBeautyBusiness
+schema:HealthAndBeautyBusiness
     rdfs:label "Health And Beauty Business" ;
     rdfs:comment "Health and beauty." ;
 .
 
-sdo:HealthAspectEnumeration
+schema:HealthAspectEnumeration
     rdfs:label "Health  Aspect Enumeration" ;
     rdfs:comment "HealthAspectEnumeration enumerates several aspects of health content online, each of which might be described using [[hasHealthAspect]] and [[HealthTopicContent]]." ;
 .
 
-sdo:HealthCare
+schema:HealthCare
     rdfs:label "Health Care" ;
     rdfs:comment "HealthCare: this is a benefit for health care." ;
 .
 
-sdo:HealthClub
+schema:HealthClub
     rdfs:label "Health Club" ;
     rdfs:comment "A health club." ;
 .
 
-sdo:HealthInsurancePlan
+schema:HealthInsurancePlan
     rdfs:label "Health  Insurance Plan" ;
     rdfs:comment "A US-style health insurance plan, including PPOs, EPOs, and HMOs. " ;
 .
 
-sdo:HealthPlanCostSharingSpecification
+schema:HealthPlanCostSharingSpecification
     rdfs:label "Health PlanCost Sharing Specification" ;
     rdfs:comment "A description of costs to the patient under a given network or formulary." ;
 .
 
-sdo:HealthPlanFormulary
+schema:HealthPlanFormulary
     rdfs:label "Health  Plan Formulary" ;
     rdfs:comment "For a given health insurance plan, the specification for costs and coverage of prescription drugs. " ;
 .
 
-sdo:HealthPlanNetwork
+schema:HealthPlanNetwork
     rdfs:label "Health  Plan Network" ;
     rdfs:comment "A US-style health insurance plan network. " ;
 .
 
-sdo:HealthTopicContent
+schema:HealthTopicContent
     rdfs:label "Health  Topic Content" ;
     rdfs:comment """[[HealthTopicContent]] is [[WebContent]] that is about some aspect of a health topic, e.g. a condition, its symptoms or treatments. Such content may be comprised of several parts or sections and use different types of media. Multiple instances of [[WebContent]] (and hence [[HealthTopicContent]]) can be related using [[hasPart]] / [[isPartOf]] where there is some kind of content hierarchy, and their content described with [[about]] and [[mentions]] e.g. building upon the existing [[MedicalCondition]] vocabulary.
   """ ;
 .
 
-sdo:HearingImpairedSupported
+schema:HearingImpairedSupported
     rdfs:label "Hearing  Impaired Supported" ;
     rdfs:comment "Uses devices to support users with hearing impairments." ;
 .
 
-sdo:Hematologic
+schema:Hematologic
     rdfs:label "Hematologic" ;
     rdfs:comment "A specific branch of medical science that pertains to diagnosis and treatment of disorders of blood and blood producing organs." ;
 .
 
-sdo:HighSchool
+schema:HighSchool
     rdfs:label "High School" ;
     rdfs:comment "A high school." ;
 .
 
-sdo:HinduDiet
+schema:HinduDiet
     rdfs:label "Hindu Diet" ;
     rdfs:comment "A diet conforming to Hindu dietary practices, in particular, beef-free." ;
 .
 
-sdo:HinduTemple
+schema:HinduTemple
     rdfs:label "Hindu Temple" ;
     rdfs:comment "A Hindu temple." ;
 .
 
-sdo:HobbyShop
+schema:HobbyShop
     rdfs:label "Hobby Shop" ;
     rdfs:comment "A store that sells materials useful or necessary for various hobbies." ;
 .
 
-sdo:HomeAndConstructionBusiness
+schema:HomeAndConstructionBusiness
     rdfs:label "Home And Construction Business" ;
     rdfs:comment "A construction business.\\n\\nA HomeAndConstructionBusiness is a [[LocalBusiness]] that provides services around homes and buildings.\\n\\nAs a [[LocalBusiness]] it can be described as a [[provider]] of one or more [[Service]]\\(s)." ;
 .
 
-sdo:HomeGoodsStore
+schema:HomeGoodsStore
     rdfs:label "Home  Goods Store" ;
     rdfs:comment "A home goods store." ;
 .
 
-sdo:Homeopathic
+schema:Homeopathic
     rdfs:label "Homeopathic" ;
     rdfs:comment "A system of medicine based on the principle that a disease can be cured by a substance that produces similar symptoms in healthy people." ;
 .
 
-sdo:Hospital
+schema:Hospital
     rdfs:label "Hospital" ;
     rdfs:comment "A hospital." ;
 .
 
-sdo:Hostel
+schema:Hostel
     rdfs:label "Hostel" ;
     rdfs:comment """A hostel - cheap accommodation, often in shared dormitories.
 <br /><br />
@@ -5226,7 +5226,7 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 """ ;
 .
 
-sdo:Hotel
+schema:Hotel
     rdfs:label "Hotel" ;
     rdfs:comment """A hotel is an establishment that provides lodging paid on a short-term basis (Source: Wikipedia, the free encyclopedia, see http://en.wikipedia.org/wiki/Hotel).
 <br /><br />
@@ -5234,7 +5234,7 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 """ ;
 .
 
-sdo:HotelRoom
+schema:HotelRoom
     rdfs:label "Hotel Room" ;
     rdfs:comment """A hotel room is a single room in a hotel.
 <br /><br />
@@ -5242,317 +5242,317 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 """ ;
 .
 
-sdo:House
+schema:House
     rdfs:label "House" ;
     rdfs:comment "A house is a building or structure that has the ability to be occupied for habitation by humans or other creatures (Source: Wikipedia, the free encyclopedia, see <a href=\"http://en.wikipedia.org/wiki/House\">http://en.wikipedia.org/wiki/House</a>)." ;
 .
 
-sdo:HousePainter
+schema:HousePainter
     rdfs:label "House Painter" ;
     rdfs:comment "A house painting service." ;
 .
 
-sdo:HowItWorksHealthAspect
+schema:HowItWorksHealthAspect
     rdfs:label "How ItWorks Health Aspect" ;
     rdfs:comment "Content that discusses and explains how a particular health-related topic works, e.g. in terms of mechanisms and underlying science." ;
 .
 
-sdo:HowOrWhereHealthAspect
+schema:HowOrWhereHealthAspect
     rdfs:label "How OrWhere Health Aspect" ;
     rdfs:comment "Information about how or where to find a topic. Also may contain location data that can be used for where to look for help if the topic is observed." ;
 .
 
-sdo:HowTo
+schema:HowTo
     rdfs:label "How To" ;
     rdfs:comment "Instructions that explain how to achieve a result by performing a sequence of steps." ;
 .
 
-sdo:HowToDirection
+schema:HowToDirection
     rdfs:label "How  To Direction" ;
     rdfs:comment "A direction indicating a single action to do in the instructions for how to achieve a result." ;
 .
 
-sdo:HowToItem
+schema:HowToItem
     rdfs:label "How  To Item" ;
     rdfs:comment "An item used as either a tool or supply when performing the instructions for how to to achieve a result." ;
 .
 
-sdo:HowToSection
+schema:HowToSection
     rdfs:label "How  To Section" ;
     rdfs:comment "A sub-grouping of steps in the instructions for how to achieve a result (e.g. steps for making a pie crust within a pie recipe)." ;
 .
 
-sdo:HowToStep
+schema:HowToStep
     rdfs:label "How  To Step" ;
     rdfs:comment "A step in the instructions for how to achieve a result. It is an ordered list with HowToDirection and/or HowToTip items." ;
 .
 
-sdo:HowToSupply
+schema:HowToSupply
     rdfs:label "How  To Supply" ;
     rdfs:comment "A supply consumed when performing the instructions for how to achieve a result." ;
 .
 
-sdo:HowToTip
+schema:HowToTip
     rdfs:label "How  To Tip" ;
     rdfs:comment "An explanation in the instructions for how to achieve a result. It provides supplementary information about a technique, supply, author's preference, etc. It can explain what could be done, or what should not be done, but doesn't specify what should be done (see HowToDirection)." ;
 .
 
-sdo:HowToTool
+schema:HowToTool
     rdfs:label "How  To Tool" ;
     rdfs:comment "A tool used (but not consumed) when performing instructions for how to achieve a result." ;
 .
 
-sdo:HyperToc
+schema:HyperToc
     rdfs:label "Hyper Toc" ;
     rdfs:comment "A HyperToc represents a hypertext table of contents for complex media objects, such as [[VideoObject]], [[AudioObject]]. Items in the table of contents are indicated using the [[tocEntry]] property, and typed [[HyperTocEntry]]. For cases where the same larger work is split into multiple files, [[associatedMedia]] can be used on individual [[HyperTocEntry]] items." ;
 .
 
-sdo:HyperTocEntry
+schema:HyperTocEntry
     rdfs:label "Hyper  Toc Entry" ;
     rdfs:comment "A HyperToEntry is an item within a [[HyperToc]], which represents a hypertext table of contents for complex media objects, such as [[VideoObject]], [[AudioObject]]. The media object itself is indicated using [[associatedMedia]]. Each section of interest within that content can be described with a [[HyperTocEntry]], with associated [[startOffset]] and [[endOffset]]. When several entries are all from the same file, [[associatedMedia]] is used on the overarching [[HyperTocEntry]]; if the content has been split into multiple files, they can be referenced using [[associatedMedia]] on each [[HyperTocEntry]]." ;
 .
 
-sdo:IceCreamShop
+schema:IceCreamShop
     rdfs:label "Ice  Cream Shop" ;
     rdfs:comment "An ice cream shop." ;
 .
 
-sdo:IgnoreAction
+schema:IgnoreAction
     rdfs:label "Ignore Action" ;
     rdfs:comment "The act of intentionally disregarding the object. An agent ignores an object." ;
 .
 
-sdo:ImageGallery
+schema:ImageGallery
     rdfs:label "Image Gallery" ;
     rdfs:comment "Web page type: Image gallery page." ;
 .
 
-sdo:ImageObject
+schema:ImageObject
     rdfs:label "Image Object" ;
     rdfs:comment "An image file." ;
 .
 
-sdo:ImageObjectSnapshot
+schema:ImageObjectSnapshot
     rdfs:label "Image  Object Snapshot" ;
     rdfs:comment "A specific and exact (byte-for-byte) version of an [[ImageObject]]. Two byte-for-byte identical files, for the purposes of this type, considered identical. If they have different embedded metadata (e.g. XMP, EXIF) the files will differ. Different external facts about the files, e.g. creator or dateCreated that aren't represented in their actual content, do not affect this notion of identity." ;
 .
 
-sdo:ImagingTest
+schema:ImagingTest
     rdfs:label "Imaging Test" ;
     rdfs:comment "Any medical imaging modality typically used for diagnostic purposes." ;
 .
 
-sdo:InForce
+schema:InForce
     rdfs:label "In Force" ;
     rdfs:comment "Indicates that a legislation is in force." ;
 .
 
-sdo:InStock
+schema:InStock
     rdfs:label "In Stock" ;
     rdfs:comment "Indicates that the item is in stock." ;
 .
 
-sdo:InStoreOnly
+schema:InStoreOnly
     rdfs:label "In  Store Only" ;
     rdfs:comment "Indicates that the item is available only at physical locations." ;
 .
 
-sdo:IndividualProduct
+schema:IndividualProduct
     rdfs:label "Individual Product" ;
     rdfs:comment "A single, identifiable product instance (e.g. a laptop with a particular serial number)." ;
 .
 
-sdo:Infectious
+schema:Infectious
     rdfs:label "Infectious" ;
     rdfs:comment "Something in medical science that pertains to infectious diseases i.e caused by bacterial, viral, fungal or parasitic infections." ;
 .
 
-sdo:InfectiousAgentClass
+schema:InfectiousAgentClass
     rdfs:label "Infectious  Agent Class" ;
     rdfs:comment "Classes of agents or pathogens that transmit infectious diseases. Enumerated type." ;
 .
 
-sdo:InfectiousDisease
+schema:InfectiousDisease
     rdfs:label "Infectious Disease" ;
     rdfs:comment "An infectious disease is a clinically evident human disease resulting from the presence of pathogenic microbial agents, like pathogenic viruses, pathogenic bacteria, fungi, protozoa, multicellular parasites, and prions. To be considered an infectious disease, such pathogens are known to be able to cause this disease." ;
 .
 
-sdo:InformAction
+schema:InformAction
     rdfs:label "Inform Action" ;
     rdfs:comment "The act of notifying someone of information pertinent to them, with no expectation of a response." ;
 .
 
-sdo:IngredientsHealthAspect
+schema:IngredientsHealthAspect
     rdfs:label "Ingredients  Health Aspect" ;
     rdfs:comment "Content discussing ingredients-related aspects of a health topic." ;
 .
 
-sdo:InsertAction
+schema:InsertAction
     rdfs:label "Insert Action" ;
     rdfs:comment "The act of adding at a specific location in an ordered collection." ;
 .
 
-sdo:InstallAction
+schema:InstallAction
     rdfs:label "Install Action" ;
     rdfs:comment "The act of installing an application." ;
 .
 
-sdo:Installment
+schema:Installment
     rdfs:label "Installment" ;
     rdfs:comment "Represents the installment pricing component of the total price for an offered product." ;
 .
 
-sdo:InsuranceAgency
+schema:InsuranceAgency
     rdfs:label "Insurance Agency" ;
     rdfs:comment "An Insurance agency." ;
 .
 
-sdo:Intangible
+schema:Intangible
     rdfs:label "Intangible" ;
     rdfs:comment "A utility class that serves as the umbrella for a number of 'intangible' things such as quantities, structured values, etc." ;
 .
 
-sdo:Integer
+schema:Integer
     rdfs:label "Integer" ;
     rdfs:comment "Data type: Integer." ;
 .
 
-sdo:InteractAction
+schema:InteractAction
     rdfs:label "Interact Action" ;
     rdfs:comment "The act of interacting with another person or organization." ;
 .
 
-sdo:InteractionCounter
+schema:InteractionCounter
     rdfs:label "Interaction Counter" ;
     rdfs:comment "A summary of how users have interacted with this CreativeWork. In most cases, authors will use a subtype to specify the specific type of interaction." ;
 .
 
-sdo:InternationalTrial
+schema:InternationalTrial
     rdfs:label "International Trial" ;
     rdfs:comment "An international trial." ;
 .
 
-sdo:InternetCafe
+schema:InternetCafe
     rdfs:label "Internet Cafe" ;
     rdfs:comment "An internet cafe." ;
 .
 
-sdo:InvestmentFund
+schema:InvestmentFund
     rdfs:label "Investment Fund" ;
     rdfs:comment "A company or fund that gathers capital from a number of investors to create a pool of money that is then re-invested into stocks, bonds and other assets." ;
 .
 
-sdo:InvestmentOrDeposit
+schema:InvestmentOrDeposit
     rdfs:label "Investment  Or Deposit" ;
     rdfs:comment "A type of financial product that typically requires the client to transfer funds to a financial service in return for potential beneficial financial return." ;
 .
 
-sdo:InviteAction
+schema:InviteAction
     rdfs:label "Invite Action" ;
     rdfs:comment "The act of asking someone to attend an event. Reciprocal of RsvpAction." ;
 .
 
-sdo:Invoice
+schema:Invoice
     rdfs:label "Invoice" ;
     rdfs:comment "A statement of the money due for goods or services; a bill." ;
 .
 
-sdo:InvoicePrice
+schema:InvoicePrice
     rdfs:label "Invoice Price" ;
     rdfs:comment "Represents the invoice price of an offered product." ;
 .
 
-sdo:ItemAvailability
+schema:ItemAvailability
     rdfs:label "Item Availability" ;
     rdfs:comment "A list of possible product availability options." ;
 .
 
-sdo:ItemList
+schema:ItemList
     rdfs:label "Item List" ;
     rdfs:comment "A list of items of any sort—for example, Top 10 Movies About Weathermen, or Top 100 Party Songs. Not to be confused with HTML lists, which are often used only for formatting." ;
 .
 
-sdo:ItemListOrderAscending
+schema:ItemListOrderAscending
     rdfs:label "Item List Order Ascending" ;
     rdfs:comment "An ItemList ordered with lower values listed first." ;
 .
 
-sdo:ItemListOrderDescending
+schema:ItemListOrderDescending
     rdfs:label "Item List Order Descending" ;
     rdfs:comment "An ItemList ordered with higher values listed first." ;
 .
 
-sdo:ItemListOrderType
+schema:ItemListOrderType
     rdfs:label "Item List Order Type" ;
     rdfs:comment "Enumerated for values for itemListOrder for indicating how an ordered ItemList is organized." ;
 .
 
-sdo:ItemListUnordered
+schema:ItemListUnordered
     rdfs:label "Item  List Unordered" ;
     rdfs:comment "An ItemList ordered with no explicit order." ;
 .
 
-sdo:ItemPage
+schema:ItemPage
     rdfs:label "Item Page" ;
     rdfs:comment "A page devoted to a single item, such as a particular product or hotel." ;
 .
 
-sdo:JewelryStore
+schema:JewelryStore
     rdfs:label "Jewelry Store" ;
     rdfs:comment "A jewelry store." ;
 .
 
-sdo:JobPosting
+schema:JobPosting
     rdfs:label "Job Posting" ;
     rdfs:comment "A listing that describes a job opening in a certain organization." ;
 .
 
-sdo:JoinAction
+schema:JoinAction
     rdfs:label "Join Action" ;
     rdfs:comment "An agent joins an event/group with participants/friends at a location.\\n\\nRelated actions:\\n\\n* [[RegisterAction]]: Unlike RegisterAction, JoinAction refers to joining a group/team of people.\\n* [[SubscribeAction]]: Unlike SubscribeAction, JoinAction does not imply that you'll be receiving updates.\\n* [[FollowAction]]: Unlike FollowAction, JoinAction does not imply that you'll be polling for updates." ;
 .
 
-sdo:Joint
+schema:Joint
     rdfs:label "Joint" ;
     rdfs:comment "The anatomical location at which two or more bones make contact." ;
 .
 
-sdo:KosherDiet
+schema:KosherDiet
     rdfs:label "Kosher Diet" ;
     rdfs:comment "A diet conforming to Jewish dietary practices." ;
 .
 
-sdo:LaboratoryScience
+schema:LaboratoryScience
     rdfs:label "Laboratory Science" ;
     rdfs:comment "A medical science pertaining to chemical, hematological, immunologic, microscopic, or bacteriological diagnostic analyses or research." ;
 .
 
-sdo:LakeBodyOfWater
+schema:LakeBodyOfWater
     rdfs:label "Lake Body Of Water" ;
     rdfs:comment "A lake (for example, Lake Pontrachain)." ;
 .
 
-sdo:Landform
+schema:Landform
     rdfs:label "Landform" ;
     rdfs:comment "A landform or physical feature.  Landform elements include mountains, plains, lakes, rivers, seascape and oceanic waterbody interface features such as bays, peninsulas, seas and so forth, including sub-aqueous terrain features such as submersed mountain ranges, volcanoes, and the great ocean basins." ;
 .
 
-sdo:LandmarksOrHistoricalBuildings
+schema:LandmarksOrHistoricalBuildings
     rdfs:label "Landmarks Or Historical Buildings" ;
     rdfs:comment "An historical landmark or building." ;
 .
 
-sdo:Language
+schema:Language
     rdfs:label "Language" ;
     rdfs:comment "Natural languages such as Spanish, Tamil, Hindi, English, etc. Formal language code tags expressed in [BCP 47](https://en.wikipedia.org/wiki/IETF_language_tag) can be used via the [[alternateName]] property. The Language type previously also covered programming languages such as Scheme and Lisp, which are now best represented using [[ComputerLanguage]]." ;
 .
 
-sdo:LaserDiscFormat
+schema:LaserDiscFormat
     rdfs:label "Laser  Disc Format" ;
     rdfs:comment "LaserDiscFormat." ;
 .
 
-sdo:LearningResource
+schema:LearningResource
     rdfs:label "Learning Resource" ;
     rdfs:comment """The LearningResource type can be used to indicate [[CreativeWork]]s (whether physical or digital) that have a particular and explicit orientation towards learning, education, skill acquisition, and other educational purposes.
 
@@ -5561,287 +5561,287 @@ sdo:LearningResource
 [[EducationEvent]] serves a similar purpose for event-like things (e.g. a [[Trip]]). A [[LearningResource]] may be created as a result of an [[EducationEvent]], for example by recording one.""" ;
 .
 
-sdo:LeaveAction
+schema:LeaveAction
     rdfs:label "Leave Action" ;
     rdfs:comment "An agent leaves an event / group with participants/friends at a location.\\n\\nRelated actions:\\n\\n* [[JoinAction]]: The antonym of LeaveAction.\\n* [[UnRegisterAction]]: Unlike UnRegisterAction, LeaveAction implies leaving a group/team of people rather than a service." ;
 .
 
-sdo:LeftHandDriving
+schema:LeftHandDriving
     rdfs:label "Left  Hand Driving" ;
     rdfs:comment "The steering position is on the left side of the vehicle (viewed from the main direction of driving)." ;
 .
 
-sdo:LegalForceStatus
+schema:LegalForceStatus
     rdfs:label "Legal  Force Status" ;
     rdfs:comment "A list of possible statuses for the legal force of a legislation." ;
 .
 
-sdo:LegalService
+schema:LegalService
     rdfs:label "Legal Service" ;
     rdfs:comment "A LegalService is a business that provides legally-oriented services, advice and representation, e.g. law firms.\\n\\nAs a [[LocalBusiness]] it can be described as a [[provider]] of one or more [[Service]]\\(s)." ;
 .
 
-sdo:LegalValueLevel
+schema:LegalValueLevel
     rdfs:label "Legal  Value Level" ;
     rdfs:comment "A list of possible levels for the legal validity of a legislation." ;
 .
 
-sdo:Legislation
+schema:Legislation
     rdfs:label "Legislation" ;
     rdfs:comment "A legal document such as an act, decree, bill, etc. (enforceable or not) or a component of a legal act (like an article)." ;
 .
 
-sdo:LegislationObject
+schema:LegislationObject
     rdfs:label "Legislation Object" ;
     rdfs:comment "A specific object or file containing a Legislation. Note that the same Legislation can be published in multiple files. For example, a digitally signed PDF, a plain PDF and an HTML version." ;
 .
 
-sdo:LegislativeBuilding
+schema:LegislativeBuilding
     rdfs:label "Legislative Building" ;
     rdfs:comment "A legislative building—for example, the state capitol." ;
 .
 
-sdo:LeisureTimeActivity
+schema:LeisureTimeActivity
     rdfs:label "Leisure  Time Activity" ;
     rdfs:comment "Any physical activity engaged in for recreational purposes. Examples may include ballroom dancing, roller skating, canoeing, fishing, etc." ;
 .
 
-sdo:LendAction
+schema:LendAction
     rdfs:label "Lend Action" ;
     rdfs:comment "The act of providing an object under an agreement that it will be returned at a later date. Reciprocal of BorrowAction.\\n\\nRelated actions:\\n\\n* [[BorrowAction]]: Reciprocal of LendAction." ;
 .
 
-sdo:Library
+schema:Library
     rdfs:label "Library" ;
     rdfs:comment "A library." ;
 .
 
-sdo:LibrarySystem
+schema:LibrarySystem
     rdfs:label "Library System" ;
     rdfs:comment "A [[LibrarySystem]] is a collaborative system amongst several libraries." ;
 .
 
-sdo:LifestyleModification
+schema:LifestyleModification
     rdfs:label "Lifestyle Modification" ;
     rdfs:comment "A process of care involving exercise, changes to diet, fitness routines, and other lifestyle changes aimed at improving a health condition." ;
 .
 
-sdo:Ligament
+schema:Ligament
     rdfs:label "Ligament" ;
     rdfs:comment "A short band of tough, flexible, fibrous connective tissue that functions to connect multiple bones, cartilages, and structurally support joints." ;
 .
 
-sdo:LikeAction
+schema:LikeAction
     rdfs:label "Like Action" ;
     rdfs:comment "The act of expressing a positive sentiment about the object. An agent likes an object (a proposition, topic or theme) with participants." ;
 .
 
-sdo:LimitedAvailability
+schema:LimitedAvailability
     rdfs:label "Limited Availability" ;
     rdfs:comment "Indicates that the item has limited availability." ;
 .
 
-sdo:LimitedByGuaranteeCharity
+schema:LimitedByGuaranteeCharity
     rdfs:label "Limited By Guarantee Charity" ;
     rdfs:comment "LimitedByGuaranteeCharity: Non-profit type referring to a charitable company that is limited by guarantee (UK)." ;
 .
 
-sdo:LinkRole
+schema:LinkRole
     rdfs:label "Link Role" ;
     rdfs:comment "A Role that represents a Web link e.g. as expressed via the 'url' property. Its linkRelationship property can indicate URL-based and plain textual link types e.g. those in IANA link registry or others such as 'amphtml'. This structure provides a placeholder where details from HTML's link element can be represented outside of HTML, e.g. in JSON-LD feeds." ;
 .
 
-sdo:LiquorStore
+schema:LiquorStore
     rdfs:label "Liquor Store" ;
     rdfs:comment "A shop that sells alcoholic drinks such as wine, beer, whisky and other spirits." ;
 .
 
-sdo:ListItem
+schema:ListItem
     rdfs:label "List Item" ;
     rdfs:comment "An list item, e.g. a step in a checklist or how-to description." ;
 .
 
-sdo:ListPrice
+schema:ListPrice
     rdfs:label "List Price" ;
     rdfs:comment "Represents the list price (the price a product is actually advertised for) of an offered product." ;
 .
 
-sdo:ListenAction
+schema:ListenAction
     rdfs:label "Listen Action" ;
     rdfs:comment "The act of consuming audio content." ;
 .
 
-sdo:LiteraryEvent
+schema:LiteraryEvent
     rdfs:label "Literary Event" ;
     rdfs:comment "Event type: Literary event." ;
 .
 
-sdo:LiveAlbum
+schema:LiveAlbum
     rdfs:label "Live Album" ;
     rdfs:comment "LiveAlbum." ;
 .
 
-sdo:LiveBlogPosting
+schema:LiveBlogPosting
     rdfs:label "Live  Blog Posting" ;
     rdfs:comment "A [[LiveBlogPosting]] is a [[BlogPosting]] intended to provide a rolling textual coverage of an ongoing event through continuous updates." ;
 .
 
-sdo:LivingWithHealthAspect
+schema:LivingWithHealthAspect
     rdfs:label "Living With Health Aspect" ;
     rdfs:comment "Information about coping or life related to the topic." ;
 .
 
-sdo:LoanOrCredit
+schema:LoanOrCredit
     rdfs:label "Loan  Or Credit" ;
     rdfs:comment "A financial product for the loaning of an amount of money, or line of credit, under agreed terms and charges." ;
 .
 
-sdo:LocalBusiness
+schema:LocalBusiness
     rdfs:label "Local Business" ;
     rdfs:comment "A particular physical business or branch of an organization. Examples of LocalBusiness include a restaurant, a particular branch of a restaurant chain, a branch of a bank, a medical practice, a club, a bowling alley, etc." ;
 .
 
-sdo:LocationFeatureSpecification
+schema:LocationFeatureSpecification
     rdfs:label "Location  Feature Specification" ;
     rdfs:comment "Specifies a location feature by providing a structured value representing a feature of an accommodation as a property-value pair of varying degrees of formality." ;
 .
 
-sdo:LockerDelivery
+schema:LockerDelivery
     rdfs:label "Locker Delivery" ;
     rdfs:comment "A DeliveryMethod in which an item is made available via locker." ;
 .
 
-sdo:Locksmith
+schema:Locksmith
     rdfs:label "Locksmith" ;
     rdfs:comment "A locksmith." ;
 .
 
-sdo:LodgingBusiness
+schema:LodgingBusiness
     rdfs:label "Lodging Business" ;
     rdfs:comment "A lodging business, such as a motel, hotel, or inn." ;
 .
 
-sdo:LodgingReservation
+schema:LodgingReservation
     rdfs:label "Lodging Reservation" ;
     rdfs:comment "A reservation for lodging at a hotel, motel, inn, etc.\\n\\nNote: This type is for information about actual reservations, e.g. in confirmation emails or HTML pages with individual confirmations of reservations." ;
 .
 
-sdo:Longitudinal
+schema:Longitudinal
     rdfs:label "Longitudinal" ;
     rdfs:comment "Unlike cross-sectional studies, longitudinal studies track the same people, and therefore the differences observed in those people are less likely to be the result of cultural differences across generations. Longitudinal studies are also used in medicine to uncover predictors of certain diseases." ;
 .
 
-sdo:LoseAction
+schema:LoseAction
     rdfs:label "Lose Action" ;
     rdfs:comment "The act of being defeated in a competitive activity." ;
 .
 
-sdo:LowCalorieDiet
+schema:LowCalorieDiet
     rdfs:label "Low  Calorie Diet" ;
     rdfs:comment "A diet focused on reduced calorie intake." ;
 .
 
-sdo:LowFatDiet
+schema:LowFatDiet
     rdfs:label "Low  Fat Diet" ;
     rdfs:comment "A diet focused on reduced fat and cholesterol intake." ;
 .
 
-sdo:LowLactoseDiet
+schema:LowLactoseDiet
     rdfs:label "Low  Lactose Diet" ;
     rdfs:comment "A diet appropriate for people with lactose intolerance." ;
 .
 
-sdo:LowSaltDiet
+schema:LowSaltDiet
     rdfs:label "Low  Salt Diet" ;
     rdfs:comment "A diet focused on reduced sodium intake." ;
 .
 
-sdo:Lung
+schema:Lung
     rdfs:label "Lung" ;
     rdfs:comment "Lung and respiratory system clinical examination." ;
 .
 
-sdo:LymphaticVessel
+schema:LymphaticVessel
     rdfs:label "Lymphatic Vessel" ;
     rdfs:comment "A type of blood vessel that specifically carries lymph fluid unidirectionally toward the heart." ;
 .
 
-sdo:MRI
+schema:MRI
     rdfs:label "MRI" ;
     rdfs:comment "Magnetic resonance imaging." ;
 .
 
-sdo:MSRP
+schema:MSRP
     rdfs:label "MSRP" ;
     rdfs:comment "Represents the manufacturer suggested retail price (\"MSRP\") of an offered product." ;
 .
 
-sdo:Male
+schema:Male
     rdfs:label "Male" ;
     rdfs:comment "The male gender." ;
 .
 
-sdo:Manuscript
+schema:Manuscript
     rdfs:label "Manuscript" ;
     rdfs:comment "A book, document, or piece of music written by hand rather than typed or printed." ;
 .
 
-sdo:Map
+schema:Map
     rdfs:label "Map" ;
     rdfs:comment "A map." ;
 .
 
-sdo:MapCategoryType
+schema:MapCategoryType
     rdfs:label "Map  Category Type" ;
     rdfs:comment "An enumeration of several kinds of Map." ;
 .
 
-sdo:MarryAction
+schema:MarryAction
     rdfs:label "Marry Action" ;
     rdfs:comment "The act of marrying a person." ;
 .
 
-sdo:Mass
+schema:Mass
     rdfs:label "Mass" ;
     rdfs:comment "Properties that take Mass as values are of the form '<Number> <Mass unit of measure>'. E.g., '7 kg'." ;
 .
 
-sdo:MathSolver
+schema:MathSolver
     rdfs:label "Math Solver" ;
     rdfs:comment "A math solver which is capable of solving a subset of mathematical problems." ;
 .
 
-sdo:MaximumDoseSchedule
+schema:MaximumDoseSchedule
     rdfs:label "Maximum  Dose Schedule" ;
     rdfs:comment "The maximum dosing schedule considered safe for a drug or supplement as recommended by an authority or by the drug/supplement's manufacturer. Capture the recommending authority in the recognizingAuthority property of MedicalEntity." ;
 .
 
-sdo:MayTreatHealthAspect
+schema:MayTreatHealthAspect
     rdfs:label "May Treat Health Aspect" ;
     rdfs:comment "Related topics may be treated by a Topic." ;
 .
 
-sdo:MeasurementTypeEnumeration
+schema:MeasurementTypeEnumeration
     rdfs:label "Measurement  Type Enumeration" ;
     rdfs:comment "Enumeration of common measurement types (or dimensions), for example \"chest\" for a person, \"inseam\" for pants, \"gauge\" for screws, or \"wheel\" for bicycles." ;
 .
 
-sdo:MediaGallery
+schema:MediaGallery
     rdfs:label "Media Gallery" ;
     rdfs:comment "Web page type: Media gallery page. A mixed-media page that can contains media such as images, videos, and other multimedia." ;
 .
 
-sdo:MediaManipulationRatingEnumeration
+schema:MediaManipulationRatingEnumeration
     rdfs:label "Media Manipulation Rating Enumeration" ;
     rdfs:comment " Codes for use with the [[mediaAuthenticityCategory]] property, indicating the authenticity of a media object (in the context of how it was published or shared). In general these codes are not mutually exclusive, although some combinations (such as 'original' versus 'transformed', 'edited' and 'staged') would be contradictory if applied in the same [[MediaReview]]. Note that the application of these codes is with regard to a piece of media shared or published in a particular context." ;
 .
 
-sdo:MediaObject
+schema:MediaObject
     rdfs:label "Media Object" ;
     rdfs:comment "A media object, such as an image, video, or audio object embedded in a web page or a downloadable dataset i.e. DataDownload. Note that a creative work may have many media objects associated with it on the same web page. For example, a page about a single song (MusicRecording) may have a music video (VideoObject), and a high and low bandwidth audio stream (2 AudioObject's)." ;
 .
 
-sdo:MediaReview
+schema:MediaReview
     rdfs:label "Media Review" ;
     rdfs:comment """A [[MediaReview]] is a more specialized form of Review dedicated to the evaluation of media content online, typically in the context of fact-checking and misinformation.
     For more general reviews of media in the broader sense, use [[UserReview]], [[CriticReview]] or other [[Review]] types. This definition is
@@ -5849,237 +5849,237 @@ sdo:MediaReview
     to combat misinformation, the specific structures for representing media objects, their versions and publication context, is still evolving. Similarly, best practices for the relationship between [[MediaReview]] and [[ClaimReview]] markup has not yet been finalized.""" ;
 .
 
-sdo:MediaReviewItem
+schema:MediaReviewItem
     rdfs:label "Media  Review Item" ;
     rdfs:comment "Represents an item or group of closely related items treated as a unit for the sake of evaluation in a [[MediaReview]]. Authorship etc. apply to the items rather than to the curation/grouping or reviewing party." ;
 .
 
-sdo:MediaSubscription
+schema:MediaSubscription
     rdfs:label "Media Subscription" ;
     rdfs:comment "A subscription which allows a user to access media including audio, video, books, etc." ;
 .
 
-sdo:MedicalAudience
+schema:MedicalAudience
     rdfs:label "Medical Audience" ;
     rdfs:comment "Target audiences for medical web pages." ;
 .
 
-sdo:MedicalAudienceType
+schema:MedicalAudienceType
     rdfs:label "Medical  Audience Type" ;
     rdfs:comment "Target audiences types for medical web pages. Enumerated type." ;
 .
 
-sdo:MedicalBusiness
+schema:MedicalBusiness
     rdfs:label "Medical Business" ;
     rdfs:comment "A particular physical or virtual business of an organization for medical purposes. Examples of MedicalBusiness include differents business run by health professionals." ;
 .
 
-sdo:MedicalCause
+schema:MedicalCause
     rdfs:label "Medical Cause" ;
     rdfs:comment "The causative agent(s) that are responsible for the pathophysiologic process that eventually results in a medical condition, symptom or sign. In this schema, unless otherwise specified this is meant to be the proximate cause of the medical condition, symptom or sign. The proximate cause is defined as the causative agent that most directly results in the medical condition, symptom or sign. For example, the HIV virus could be considered a cause of AIDS. Or in a diagnostic context, if a patient fell and sustained a hip fracture and two days later sustained a pulmonary embolism which eventuated in a cardiac arrest, the cause of the cardiac arrest (the proximate cause) would be the pulmonary embolism and not the fall. Medical causes can include cardiovascular, chemical, dermatologic, endocrine, environmental, gastroenterologic, genetic, hematologic, gynecologic, iatrogenic, infectious, musculoskeletal, neurologic, nutritional, obstetric, oncologic, otolaryngologic, pharmacologic, psychiatric, pulmonary, renal, rheumatologic, toxic, traumatic, or urologic causes; medical conditions can be causes as well." ;
 .
 
-sdo:MedicalClinic
+schema:MedicalClinic
     rdfs:label "Medical Clinic" ;
     rdfs:comment "A facility, often associated with a hospital or medical school, that is devoted to the specific diagnosis and/or healthcare. Previously limited to outpatients but with evolution it may be open to inpatients as well." ;
 .
 
-sdo:MedicalCode
+schema:MedicalCode
     rdfs:label "Medical Code" ;
     rdfs:comment "A code for a medical entity." ;
 .
 
-sdo:MedicalCondition
+schema:MedicalCondition
     rdfs:label "Medical Condition" ;
     rdfs:comment "Any condition of the human body that affects the normal functioning of a person, whether physically or mentally. Includes diseases, injuries, disabilities, disorders, syndromes, etc." ;
 .
 
-sdo:MedicalConditionStage
+schema:MedicalConditionStage
     rdfs:label "Medical  Condition Stage" ;
     rdfs:comment "A stage of a medical condition, such as 'Stage IIIa'." ;
 .
 
-sdo:MedicalContraindication
+schema:MedicalContraindication
     rdfs:label "Medical Contraindication" ;
     rdfs:comment "A condition or factor that serves as a reason to withhold a certain medical therapy. Contraindications can be absolute (there are no reasonable circumstances for undertaking a course of action) or relative (the patient is at higher risk of complications, but that these risks may be outweighed by other considerations or mitigated by other measures)." ;
 .
 
-sdo:MedicalDevice
+schema:MedicalDevice
     rdfs:label "Medical Device" ;
     rdfs:comment "Any object used in a medical capacity, such as to diagnose or treat a patient." ;
 .
 
-sdo:MedicalDevicePurpose
+schema:MedicalDevicePurpose
     rdfs:label "Medical  Device Purpose" ;
     rdfs:comment "Categories of medical devices, organized by the purpose or intended use of the device." ;
 .
 
-sdo:MedicalEntity
+schema:MedicalEntity
     rdfs:label "Medical Entity" ;
     rdfs:comment "The most generic type of entity related to health and the practice of medicine." ;
 .
 
-sdo:MedicalEnumeration
+schema:MedicalEnumeration
     rdfs:label "Medical Enumeration" ;
     rdfs:comment "Enumerations related to health and the practice of medicine: A concept that is used to attribute a quality to another concept, as a qualifier, a collection of items or a listing of all of the elements of a set in medicine practice." ;
 .
 
-sdo:MedicalEvidenceLevel
+schema:MedicalEvidenceLevel
     rdfs:label "Medical  Evidence Level" ;
     rdfs:comment "Level of evidence for a medical guideline. Enumerated type." ;
 .
 
-sdo:MedicalGuideline
+schema:MedicalGuideline
     rdfs:label "Medical Guideline" ;
     rdfs:comment "Any recommendation made by a standard society (e.g. ACC/AHA) or consensus statement that denotes how to diagnose and treat a particular condition. Note: this type should be used to tag the actual guideline recommendation; if the guideline recommendation occurs in a larger scholarly article, use MedicalScholarlyArticle to tag the overall article, not this type. Note also: the organization making the recommendation should be captured in the recognizingAuthority base property of MedicalEntity." ;
 .
 
-sdo:MedicalGuidelineContraindication
+schema:MedicalGuidelineContraindication
     rdfs:label "Medical  Guideline Contraindication" ;
     rdfs:comment "A guideline contraindication that designates a process as harmful and where quality of the data supporting the contraindication is sound." ;
 .
 
-sdo:MedicalGuidelineRecommendation
+schema:MedicalGuidelineRecommendation
     rdfs:label "Medical  Guideline Recommendation" ;
     rdfs:comment "A guideline recommendation that is regarded as efficacious and where quality of the data supporting the recommendation is sound." ;
 .
 
-sdo:MedicalImagingTechnique
+schema:MedicalImagingTechnique
     rdfs:label "Medical  Imaging Technique" ;
     rdfs:comment "Any medical imaging modality typically used for diagnostic purposes. Enumerated type." ;
 .
 
-sdo:MedicalIndication
+schema:MedicalIndication
     rdfs:label "Medical Indication" ;
     rdfs:comment "A condition or factor that indicates use of a medical therapy, including signs, symptoms, risk factors, anatomical states, etc." ;
 .
 
-sdo:MedicalIntangible
+schema:MedicalIntangible
     rdfs:label "Medical Intangible" ;
     rdfs:comment "A utility class that serves as the umbrella for a number of 'intangible' things in the medical space." ;
 .
 
-sdo:MedicalObservationalStudy
+schema:MedicalObservationalStudy
     rdfs:label "Medical  Observational Study" ;
     rdfs:comment "An observational study is a type of medical study that attempts to infer the possible effect of a treatment through observation of a cohort of subjects over a period of time. In an observational study, the assignment of subjects into treatment groups versus control groups is outside the control of the investigator. This is in contrast with controlled studies, such as the randomized controlled trials represented by MedicalTrial, where each subject is randomly assigned to a treatment group or a control group before the start of the treatment." ;
 .
 
-sdo:MedicalObservationalStudyDesign
+schema:MedicalObservationalStudyDesign
     rdfs:label "Medical Observational Study Design" ;
     rdfs:comment "Design models for observational medical studies. Enumerated type." ;
 .
 
-sdo:MedicalOrganization
+schema:MedicalOrganization
     rdfs:label "Medical Organization" ;
     rdfs:comment "A medical organization (physical or not), such as hospital, institution or clinic." ;
 .
 
-sdo:MedicalProcedure
+schema:MedicalProcedure
     rdfs:label "Medical Procedure" ;
     rdfs:comment "A process of care used in either a diagnostic, therapeutic, preventive or palliative capacity that relies on invasive (surgical), non-invasive, or other techniques." ;
 .
 
-sdo:MedicalProcedureType
+schema:MedicalProcedureType
     rdfs:label "Medical  Procedure Type" ;
     rdfs:comment "An enumeration that describes different types of medical procedures." ;
 .
 
-sdo:MedicalResearcher
+schema:MedicalResearcher
     rdfs:label "Medical Researcher" ;
     rdfs:comment "Medical researchers." ;
 .
 
-sdo:MedicalRiskCalculator
+schema:MedicalRiskCalculator
     rdfs:label "Medical  Risk Calculator" ;
     rdfs:comment "A complex mathematical calculation requiring an online calculator, used to assess prognosis. Note: use the url property of Thing to record any URLs for online calculators." ;
 .
 
-sdo:MedicalRiskEstimator
+schema:MedicalRiskEstimator
     rdfs:label "Medical  Risk Estimator" ;
     rdfs:comment "Any rule set or interactive tool for estimating the risk of developing a complication or condition." ;
 .
 
-sdo:MedicalRiskFactor
+schema:MedicalRiskFactor
     rdfs:label "Medical  Risk Factor" ;
     rdfs:comment "A risk factor is anything that increases a person's likelihood of developing or contracting a disease, medical condition, or complication." ;
 .
 
-sdo:MedicalRiskScore
+schema:MedicalRiskScore
     rdfs:label "Medical  Risk Score" ;
     rdfs:comment "A simple system that adds up the number of risk factors to yield a score that is associated with prognosis, e.g. CHAD score, TIMI risk score." ;
 .
 
-sdo:MedicalScholarlyArticle
+schema:MedicalScholarlyArticle
     rdfs:label "Medical  Scholarly Article" ;
     rdfs:comment "A scholarly article in the medical domain." ;
 .
 
-sdo:MedicalSign
+schema:MedicalSign
     rdfs:label "Medical Sign" ;
     rdfs:comment "Any physical manifestation of a person's medical condition discoverable by objective diagnostic tests or physical examination." ;
 .
 
-sdo:MedicalSignOrSymptom
+schema:MedicalSignOrSymptom
     rdfs:label "Medical Sign Or Symptom" ;
     rdfs:comment "Any feature associated or not with a medical condition. In medicine a symptom is generally subjective while a sign is objective." ;
 .
 
-sdo:MedicalSpecialty
+schema:MedicalSpecialty
     rdfs:label "Medical Specialty" ;
     rdfs:comment "Any specific branch of medical science or practice. Medical specialities include clinical specialties that pertain to particular organ systems and their respective disease states, as well as allied health specialties. Enumerated type." ;
 .
 
-sdo:MedicalStudy
+schema:MedicalStudy
     rdfs:label "Medical Study" ;
     rdfs:comment "A medical study is an umbrella type covering all kinds of research studies relating to human medicine or health, including observational studies and interventional trials and registries, randomized, controlled or not. When the specific type of study is known, use one of the extensions of this type, such as MedicalTrial or MedicalObservationalStudy. Also, note that this type should be used to mark up data that describes the study itself; to tag an article that publishes the results of a study, use MedicalScholarlyArticle. Note: use the code property of MedicalEntity to store study IDs, e.g. clinicaltrials.gov ID." ;
 .
 
-sdo:MedicalStudyStatus
+schema:MedicalStudyStatus
     rdfs:label "Medical  Study Status" ;
     rdfs:comment "The status of a medical study. Enumerated type." ;
 .
 
-sdo:MedicalSymptom
+schema:MedicalSymptom
     rdfs:label "Medical Symptom" ;
     rdfs:comment "Any complaint sensed and expressed by the patient (therefore defined as subjective)  like stomachache, lower-back pain, or fatigue." ;
 .
 
-sdo:MedicalTest
+schema:MedicalTest
     rdfs:label "Medical Test" ;
     rdfs:comment "Any medical test, typically performed for diagnostic purposes." ;
 .
 
-sdo:MedicalTestPanel
+schema:MedicalTestPanel
     rdfs:label "Medical  Test Panel" ;
     rdfs:comment "Any collection of tests commonly ordered together." ;
 .
 
-sdo:MedicalTherapy
+schema:MedicalTherapy
     rdfs:label "Medical Therapy" ;
     rdfs:comment "Any medical intervention designed to prevent, treat, and cure human diseases and medical conditions, including both curative and palliative therapies. Medical therapies are typically processes of care relying upon pharmacotherapy, behavioral therapy, supportive therapy (with fluid or nutrition for example), or detoxification (e.g. hemodialysis) aimed at improving or preventing a health condition." ;
 .
 
-sdo:MedicalTrial
+schema:MedicalTrial
     rdfs:label "Medical Trial" ;
     rdfs:comment "A medical trial is a type of medical study that uses scientific process used to compare the safety and efficacy of medical therapies or medical procedures. In general, medical trials are controlled and subjects are allocated at random to the different treatment and/or control groups." ;
 .
 
-sdo:MedicalTrialDesign
+schema:MedicalTrialDesign
     rdfs:label "Medical  Trial Design" ;
     rdfs:comment "Design models for medical trials. Enumerated type." ;
 .
 
-sdo:MedicalWebPage
+schema:MedicalWebPage
     rdfs:label "Medical  Web Page" ;
     rdfs:comment "A web page that provides medical information." ;
 .
 
-sdo:MedicineSystem
+schema:MedicineSystem
     rdfs:label "Medicine System" ;
     rdfs:comment "Systems of medical practice." ;
 .
 
-sdo:MeetingRoom
+schema:MeetingRoom
     rdfs:label "Meeting Room" ;
     rdfs:comment """A meeting room, conference room, or conference hall is a room provided for singular events such as business conferences and meetings (Source: Wikipedia, the free encyclopedia, see <a href="http://en.wikipedia.org/wiki/Conference_hall">http://en.wikipedia.org/wiki/Conference_hall</a>).
 <br /><br />
@@ -6087,147 +6087,147 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 """ ;
 .
 
-sdo:MensClothingStore
+schema:MensClothingStore
     rdfs:label "Mens  Clothing Store" ;
     rdfs:comment "A men's clothing store." ;
 .
 
-sdo:Menu
+schema:Menu
     rdfs:label "Menu" ;
     rdfs:comment "A structured representation of food or drink items available from a FoodEstablishment." ;
 .
 
-sdo:MenuItem
+schema:MenuItem
     rdfs:label "Menu Item" ;
     rdfs:comment "A food or drink item listed in a menu or menu section." ;
 .
 
-sdo:MenuSection
+schema:MenuSection
     rdfs:label "Menu Section" ;
     rdfs:comment "A sub-grouping of food or drink items in a menu. E.g. courses (such as 'Dinner', 'Breakfast', etc.), specific type of dishes (such as 'Meat', 'Vegan', 'Drinks', etc.), or some other classification made by the menu provider." ;
 .
 
-sdo:MerchantReturnEnumeration
+schema:MerchantReturnEnumeration
     rdfs:label "Merchant  Return Enumeration" ;
     rdfs:comment "Enumerates several kinds of product return policies." ;
 .
 
-sdo:MerchantReturnFiniteReturnWindow
+schema:MerchantReturnFiniteReturnWindow
     rdfs:label "Merchant ReturnFinite Return Window" ;
     rdfs:comment "Specifies that there is a finite window for product returns." ;
 .
 
-sdo:MerchantReturnNotPermitted
+schema:MerchantReturnNotPermitted
     rdfs:label "Merchant Return Not Permitted" ;
     rdfs:comment "Specifies that product returns are not permitted." ;
 .
 
-sdo:MerchantReturnPolicy
+schema:MerchantReturnPolicy
     rdfs:label "Merchant  Return Policy" ;
     rdfs:comment "A MerchantReturnPolicy provides information about product return policies associated with an [[Organization]], [[Product]], or [[Offer]]." ;
 .
 
-sdo:MerchantReturnPolicySeasonalOverride
+schema:MerchantReturnPolicySeasonalOverride
     rdfs:label "Merchant ReturnPolicy Seasonal Override" ;
     rdfs:comment "A seasonal override of a return policy, for example used for holidays." ;
 .
 
-sdo:MerchantReturnUnlimitedWindow
+schema:MerchantReturnUnlimitedWindow
     rdfs:label "Merchant Return Unlimited Window" ;
     rdfs:comment "Specifies that there is an unlimited window for product returns." ;
 .
 
-sdo:MerchantReturnUnspecified
+schema:MerchantReturnUnspecified
     rdfs:label "Merchant  Return Unspecified" ;
     rdfs:comment "Specifies that a product return policy is not provided." ;
 .
 
-sdo:Message
+schema:Message
     rdfs:label "Message" ;
     rdfs:comment "A single message from a sender to one or more organizations or people." ;
 .
 
-sdo:MiddleSchool
+schema:MiddleSchool
     rdfs:label "Middle School" ;
     rdfs:comment "A middle school (typically for children aged around 11-14, although this varies somewhat)." ;
 .
 
-sdo:Midwifery
+schema:Midwifery
     rdfs:label "Midwifery" ;
     rdfs:comment "A nurse-like health profession that deals with pregnancy, childbirth, and the postpartum period (including care of the newborn), besides sexual and reproductive health of women throughout their lives." ;
 .
 
-sdo:MinimumAdvertisedPrice
+schema:MinimumAdvertisedPrice
     rdfs:label "Minimum  Advertised Price" ;
     rdfs:comment "Represents the minimum advertised price (\"MAP\") (as dictated by the manufacturer) of an offered product." ;
 .
 
-sdo:MisconceptionsHealthAspect
+schema:MisconceptionsHealthAspect
     rdfs:label "Misconceptions  Health Aspect" ;
     rdfs:comment "Content about common misconceptions and myths that are related to a topic." ;
 .
 
-sdo:MixedEventAttendanceMode
+schema:MixedEventAttendanceMode
     rdfs:label "Mixed Event Attendance Mode" ;
     rdfs:comment "MixedEventAttendanceMode - an event that is conducted as a combination of both offline and online modes." ;
 .
 
-sdo:MixtapeAlbum
+schema:MixtapeAlbum
     rdfs:label "Mixtape Album" ;
     rdfs:comment "MixtapeAlbum." ;
 .
 
-sdo:MobileApplication
+schema:MobileApplication
     rdfs:label "Mobile Application" ;
     rdfs:comment "A software application designed specifically to work well on a mobile device such as a telephone." ;
 .
 
-sdo:MobilePhoneStore
+schema:MobilePhoneStore
     rdfs:label "Mobile  Phone Store" ;
     rdfs:comment "A store that sells mobile phones and related accessories." ;
 .
 
-sdo:MolecularEntity
+schema:MolecularEntity
     rdfs:label "Molecular Entity" ;
     rdfs:comment "Any constitutionally or isotopically distinct atom, molecule, ion, ion pair, radical, radical ion, complex, conformer etc., identifiable as a separately distinguishable entity." ;
 .
 
-sdo:Monday
+schema:Monday
     rdfs:label "Monday" ;
     rdfs:comment "The day of the week between Sunday and Tuesday." ;
 .
 
-sdo:MonetaryAmount
+schema:MonetaryAmount
     rdfs:label "Monetary Amount" ;
     rdfs:comment "A monetary value or range. This type can be used to describe an amount of money such as $50 USD, or a range as in describing a bank account being suitable for a balance between £1,000 and £1,000,000 GBP, or the value of a salary, etc. It is recommended to use [[PriceSpecification]] Types to describe the price of an Offer, Invoice, etc." ;
 .
 
-sdo:MonetaryAmountDistribution
+schema:MonetaryAmountDistribution
     rdfs:label "Monetary  Amount Distribution" ;
     rdfs:comment "A statistical distribution of monetary amounts." ;
 .
 
-sdo:MonetaryGrant
+schema:MonetaryGrant
     rdfs:label "Monetary Grant" ;
     rdfs:comment "A monetary grant." ;
 .
 
-sdo:MoneyTransfer
+schema:MoneyTransfer
     rdfs:label "Money Transfer" ;
     rdfs:comment "The act of transferring money from one place to another place. This may occur electronically or physically." ;
 .
 
-sdo:MortgageLoan
+schema:MortgageLoan
     rdfs:label "Mortgage Loan" ;
     rdfs:comment "A loan in which property or real estate is used as collateral. (A loan securitized against some real estate)." ;
 .
 
-sdo:Mosque
+schema:Mosque
     rdfs:label "Mosque" ;
     rdfs:comment "A mosque." ;
 .
 
-sdo:Motel
+schema:Motel
     rdfs:label "Motel" ;
     rdfs:comment """A motel.
 <br /><br />
@@ -6235,207 +6235,207 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 """ ;
 .
 
-sdo:Motorcycle
+schema:Motorcycle
     rdfs:label "Motorcycle" ;
     rdfs:comment "A motorcycle or motorbike is a single-track, two-wheeled motor vehicle." ;
 .
 
-sdo:MotorcycleDealer
+schema:MotorcycleDealer
     rdfs:label "Motorcycle Dealer" ;
     rdfs:comment "A motorcycle dealer." ;
 .
 
-sdo:MotorcycleRepair
+schema:MotorcycleRepair
     rdfs:label "Motorcycle Repair" ;
     rdfs:comment "A motorcycle repair shop." ;
 .
 
-sdo:MotorizedBicycle
+schema:MotorizedBicycle
     rdfs:label "Motorized Bicycle" ;
     rdfs:comment "A motorized bicycle is a bicycle with an attached motor used to power the vehicle, or to assist with pedaling." ;
 .
 
-sdo:Mountain
+schema:Mountain
     rdfs:label "Mountain" ;
     rdfs:comment "A mountain, like Mount Whitney or Mount Everest." ;
 .
 
-sdo:MoveAction
+schema:MoveAction
     rdfs:label "Move Action" ;
     rdfs:comment "The act of an agent relocating to a place.\\n\\nRelated actions:\\n\\n* [[TransferAction]]: Unlike TransferAction, the subject of the move is a living Person or Organization rather than an inanimate object." ;
 .
 
-sdo:Movie
+schema:Movie
     rdfs:label "Movie" ;
     rdfs:comment "A movie." ;
 .
 
-sdo:MovieClip
+schema:MovieClip
     rdfs:label "Movie Clip" ;
     rdfs:comment "A short segment/part of a movie." ;
 .
 
-sdo:MovieRentalStore
+schema:MovieRentalStore
     rdfs:label "Movie  Rental Store" ;
     rdfs:comment "A movie rental store." ;
 .
 
-sdo:MovieSeries
+schema:MovieSeries
     rdfs:label "Movie Series" ;
     rdfs:comment "A series of movies. Included movies can be indicated with the hasPart property." ;
 .
 
-sdo:MovieTheater
+schema:MovieTheater
     rdfs:label "Movie Theater" ;
     rdfs:comment "A movie theater." ;
 .
 
-sdo:MovingCompany
+schema:MovingCompany
     rdfs:label "Moving Company" ;
     rdfs:comment "A moving company." ;
 .
 
-sdo:MultiCenterTrial
+schema:MultiCenterTrial
     rdfs:label "Multi  Center Trial" ;
     rdfs:comment "A trial that takes place at multiple centers." ;
 .
 
-sdo:MultiPlayer
+schema:MultiPlayer
     rdfs:label "Multi Player" ;
     rdfs:comment "Play mode: MultiPlayer. Requiring or allowing multiple human players to play simultaneously." ;
 .
 
-sdo:MulticellularParasite
+schema:MulticellularParasite
     rdfs:label "Multicellular Parasite" ;
     rdfs:comment "Multicellular parasite that causes an infection." ;
 .
 
-sdo:Muscle
+schema:Muscle
     rdfs:label "Muscle" ;
     rdfs:comment "A muscle is an anatomical structure consisting of a contractile form of tissue that animals use to effect movement." ;
 .
 
-sdo:Musculoskeletal
+schema:Musculoskeletal
     rdfs:label "Musculoskeletal" ;
     rdfs:comment "A specific branch of medical science that pertains to diagnosis and treatment of disorders of muscles, ligaments and skeletal system." ;
 .
 
-sdo:MusculoskeletalExam
+schema:MusculoskeletalExam
     rdfs:label "Musculoskeletal Exam" ;
     rdfs:comment "Musculoskeletal system clinical examination." ;
 .
 
-sdo:Museum
+schema:Museum
     rdfs:label "Museum" ;
     rdfs:comment "A museum." ;
 .
 
-sdo:MusicAlbum
+schema:MusicAlbum
     rdfs:label "Music Album" ;
     rdfs:comment "A collection of music tracks." ;
 .
 
-sdo:MusicAlbumProductionType
+schema:MusicAlbumProductionType
     rdfs:label "Music Album Production Type" ;
     rdfs:comment "Classification of the album by it's type of content: soundtrack, live album, studio album, etc." ;
 .
 
-sdo:MusicAlbumReleaseType
+schema:MusicAlbumReleaseType
     rdfs:label "Music Album Release Type" ;
     rdfs:comment "The kind of release which this album is: single, EP or album." ;
 .
 
-sdo:MusicComposition
+schema:MusicComposition
     rdfs:label "Music Composition" ;
     rdfs:comment "A musical composition." ;
 .
 
-sdo:MusicEvent
+schema:MusicEvent
     rdfs:label "Music Event" ;
     rdfs:comment "Event type: Music event." ;
 .
 
-sdo:MusicGroup
+schema:MusicGroup
     rdfs:label "Music Group" ;
     rdfs:comment "A musical group, such as a band, an orchestra, or a choir. Can also be a solo musician." ;
 .
 
-sdo:MusicPlaylist
+schema:MusicPlaylist
     rdfs:label "Music Playlist" ;
     rdfs:comment "A collection of music tracks in playlist form." ;
 .
 
-sdo:MusicRecording
+schema:MusicRecording
     rdfs:label "Music Recording" ;
     rdfs:comment "A music recording (track), usually a single song." ;
 .
 
-sdo:MusicRelease
+schema:MusicRelease
     rdfs:label "Music Release" ;
     rdfs:comment "A MusicRelease is a specific release of a music album." ;
 .
 
-sdo:MusicReleaseFormatType
+schema:MusicReleaseFormatType
     rdfs:label "Music Release Format Type" ;
     rdfs:comment "Format of this release (the type of recording media used, ie. compact disc, digital media, LP, etc.)." ;
 .
 
-sdo:MusicStore
+schema:MusicStore
     rdfs:label "Music Store" ;
     rdfs:comment "A music store." ;
 .
 
-sdo:MusicVenue
+schema:MusicVenue
     rdfs:label "Music Venue" ;
     rdfs:comment "A music venue." ;
 .
 
-sdo:MusicVideoObject
+schema:MusicVideoObject
     rdfs:label "Music  Video Object" ;
     rdfs:comment "A music video file." ;
 .
 
-sdo:NGO
+schema:NGO
     rdfs:label "NGO" ;
     rdfs:comment "Organization: Non-governmental Organization." ;
 .
 
-sdo:NLNonprofitType
+schema:NLNonprofitType
     rdfs:label "NL Nonprofit Type" ;
     rdfs:comment "NLNonprofitType: Non-profit organization type originating from the Netherlands." ;
 .
 
-sdo:NailSalon
+schema:NailSalon
     rdfs:label "Nail Salon" ;
     rdfs:comment "A nail salon." ;
 .
 
-sdo:Neck
+schema:Neck
     rdfs:label "Neck" ;
     rdfs:comment "Neck assessment with clinical examination." ;
 .
 
-sdo:Nerve
+schema:Nerve
     rdfs:label "Nerve" ;
     rdfs:comment "A common pathway for the electrochemical nerve impulses that are transmitted along each of the axons." ;
 .
 
-sdo:Neuro
+schema:Neuro
     rdfs:label "Neuro" ;
     rdfs:comment "Neurological system clinical examination." ;
 .
 
-sdo:Neurologic
+schema:Neurologic
     rdfs:label "Neurologic" ;
     rdfs:comment "A specific branch of medical science that studies the nerves and nervous system and its respective disease states." ;
 .
 
-sdo:NewCondition
+schema:NewCondition
     rdfs:label "New Condition" ;
     rdfs:comment "Indicates that the item is new." ;
 .
 
-sdo:NewsArticle
+schema:NewsArticle
     rdfs:label "News Article" ;
     rdfs:comment """A NewsArticle is an article whose content reports news, or provides background context and supporting materials for understanding the news.
 
@@ -6443,319 +6443,319 @@ A more detailed overview of [schema.org News markup](/docs/news.html) is also av
 """ ;
 .
 
-sdo:NewsMediaOrganization
+schema:NewsMediaOrganization
     rdfs:label "News  Media Organization" ;
     rdfs:comment "A News/Media organization such as a newspaper or TV station." ;
 .
 
-sdo:Newspaper
+schema:Newspaper
     rdfs:label "Newspaper" ;
     rdfs:comment "A publication containing information about varied topics that are pertinent to general information, a geographic area, or a specific subject matter (i.e. business, culture, education). Often published daily." ;
 .
 
-sdo:NightClub
+schema:NightClub
     rdfs:label "Night Club" ;
     rdfs:comment "A nightclub or discotheque." ;
 .
 
-sdo:NoninvasiveProcedure
+schema:NoninvasiveProcedure
     rdfs:label "Noninvasive Procedure" ;
     rdfs:comment "A type of medical procedure that involves noninvasive techniques." ;
 .
 
-sdo:Nonprofit501a
+schema:Nonprofit501a
     rdfs:label "Nonprofit501a" ;
     rdfs:comment "Nonprofit501a: Non-profit type referring to Farmers’ Cooperative Associations." ;
 .
 
-sdo:Nonprofit501c1
+schema:Nonprofit501c1
     rdfs:label "Nonprofit501c1" ;
     rdfs:comment "Nonprofit501c1: Non-profit type referring to Corporations Organized Under Act of Congress, including Federal Credit Unions and National Farm Loan Associations." ;
 .
 
-sdo:Nonprofit501c10
+schema:Nonprofit501c10
     rdfs:label "Nonprofit501c10" ;
     rdfs:comment "Nonprofit501c10: Non-profit type referring to Domestic Fraternal Societies and Associations." ;
 .
 
-sdo:Nonprofit501c11
+schema:Nonprofit501c11
     rdfs:label "Nonprofit501c11" ;
     rdfs:comment "Nonprofit501c11: Non-profit type referring to Teachers' Retirement Fund Associations." ;
 .
 
-sdo:Nonprofit501c12
+schema:Nonprofit501c12
     rdfs:label "Nonprofit501c12" ;
     rdfs:comment "Nonprofit501c12: Non-profit type referring to Benevolent Life Insurance Associations, Mutual Ditch or Irrigation Companies, Mutual or Cooperative Telephone Companies." ;
 .
 
-sdo:Nonprofit501c13
+schema:Nonprofit501c13
     rdfs:label "Nonprofit501c13" ;
     rdfs:comment "Nonprofit501c13: Non-profit type referring to Cemetery Companies." ;
 .
 
-sdo:Nonprofit501c14
+schema:Nonprofit501c14
     rdfs:label "Nonprofit501c14" ;
     rdfs:comment "Nonprofit501c14: Non-profit type referring to State-Chartered Credit Unions, Mutual Reserve Funds." ;
 .
 
-sdo:Nonprofit501c15
+schema:Nonprofit501c15
     rdfs:label "Nonprofit501c15" ;
     rdfs:comment "Nonprofit501c15: Non-profit type referring to Mutual Insurance Companies or Associations." ;
 .
 
-sdo:Nonprofit501c16
+schema:Nonprofit501c16
     rdfs:label "Nonprofit501c16" ;
     rdfs:comment "Nonprofit501c16: Non-profit type referring to Cooperative Organizations to Finance Crop Operations." ;
 .
 
-sdo:Nonprofit501c17
+schema:Nonprofit501c17
     rdfs:label "Nonprofit501c17" ;
     rdfs:comment "Nonprofit501c17: Non-profit type referring to Supplemental Unemployment Benefit Trusts." ;
 .
 
-sdo:Nonprofit501c18
+schema:Nonprofit501c18
     rdfs:label "Nonprofit501c18" ;
     rdfs:comment "Nonprofit501c18: Non-profit type referring to Employee Funded Pension Trust (created before 25 June 1959)." ;
 .
 
-sdo:Nonprofit501c19
+schema:Nonprofit501c19
     rdfs:label "Nonprofit501c19" ;
     rdfs:comment "Nonprofit501c19: Non-profit type referring to Post or Organization of Past or Present Members of the Armed Forces." ;
 .
 
-sdo:Nonprofit501c2
+schema:Nonprofit501c2
     rdfs:label "Nonprofit501c2" ;
     rdfs:comment "Nonprofit501c2: Non-profit type referring to Title-holding Corporations for Exempt Organizations." ;
 .
 
-sdo:Nonprofit501c20
+schema:Nonprofit501c20
     rdfs:label "Nonprofit501c20" ;
     rdfs:comment "Nonprofit501c20: Non-profit type referring to Group Legal Services Plan Organizations." ;
 .
 
-sdo:Nonprofit501c21
+schema:Nonprofit501c21
     rdfs:label "Nonprofit501c21" ;
     rdfs:comment "Nonprofit501c21: Non-profit type referring to Black Lung Benefit Trusts." ;
 .
 
-sdo:Nonprofit501c22
+schema:Nonprofit501c22
     rdfs:label "Nonprofit501c22" ;
     rdfs:comment "Nonprofit501c22: Non-profit type referring to Withdrawal Liability Payment Funds." ;
 .
 
-sdo:Nonprofit501c23
+schema:Nonprofit501c23
     rdfs:label "Nonprofit501c23" ;
     rdfs:comment "Nonprofit501c23: Non-profit type referring to Veterans Organizations." ;
 .
 
-sdo:Nonprofit501c24
+schema:Nonprofit501c24
     rdfs:label "Nonprofit501c24" ;
     rdfs:comment "Nonprofit501c24: Non-profit type referring to Section 4049 ERISA Trusts." ;
 .
 
-sdo:Nonprofit501c25
+schema:Nonprofit501c25
     rdfs:label "Nonprofit501c25" ;
     rdfs:comment "Nonprofit501c25: Non-profit type referring to Real Property Title-Holding Corporations or Trusts with Multiple Parents." ;
 .
 
-sdo:Nonprofit501c26
+schema:Nonprofit501c26
     rdfs:label "Nonprofit501c26" ;
     rdfs:comment "Nonprofit501c26: Non-profit type referring to State-Sponsored Organizations Providing Health Coverage for High-Risk Individuals." ;
 .
 
-sdo:Nonprofit501c27
+schema:Nonprofit501c27
     rdfs:label "Nonprofit501c27" ;
     rdfs:comment "Nonprofit501c27: Non-profit type referring to State-Sponsored Workers' Compensation Reinsurance Organizations." ;
 .
 
-sdo:Nonprofit501c28
+schema:Nonprofit501c28
     rdfs:label "Nonprofit501c28" ;
     rdfs:comment "Nonprofit501c28: Non-profit type referring to National Railroad Retirement Investment Trusts." ;
 .
 
-sdo:Nonprofit501c3
+schema:Nonprofit501c3
     rdfs:label "Nonprofit501c3" ;
     rdfs:comment "Nonprofit501c3: Non-profit type referring to Religious, Educational, Charitable, Scientific, Literary, Testing for Public Safety, to Foster National or International Amateur Sports Competition, or Prevention of Cruelty to Children or Animals Organizations." ;
 .
 
-sdo:Nonprofit501c4
+schema:Nonprofit501c4
     rdfs:label "Nonprofit501c4" ;
     rdfs:comment "Nonprofit501c4: Non-profit type referring to Civic Leagues, Social Welfare Organizations, and Local Associations of Employees." ;
 .
 
-sdo:Nonprofit501c5
+schema:Nonprofit501c5
     rdfs:label "Nonprofit501c5" ;
     rdfs:comment "Nonprofit501c5: Non-profit type referring to Labor, Agricultural and Horticultural Organizations." ;
 .
 
-sdo:Nonprofit501c6
+schema:Nonprofit501c6
     rdfs:label "Nonprofit501c6" ;
     rdfs:comment "Nonprofit501c6: Non-profit type referring to Business Leagues, Chambers of Commerce, Real Estate Boards." ;
 .
 
-sdo:Nonprofit501c7
+schema:Nonprofit501c7
     rdfs:label "Nonprofit501c7" ;
     rdfs:comment "Nonprofit501c7: Non-profit type referring to Social and Recreational Clubs." ;
 .
 
-sdo:Nonprofit501c8
+schema:Nonprofit501c8
     rdfs:label "Nonprofit501c8" ;
     rdfs:comment "Nonprofit501c8: Non-profit type referring to Fraternal Beneficiary Societies and Associations." ;
 .
 
-sdo:Nonprofit501c9
+schema:Nonprofit501c9
     rdfs:label "Nonprofit501c9" ;
     rdfs:comment "Nonprofit501c9: Non-profit type referring to Voluntary Employee Beneficiary Associations." ;
 .
 
-sdo:Nonprofit501d
+schema:Nonprofit501d
     rdfs:label "Nonprofit501d" ;
     rdfs:comment "Nonprofit501d: Non-profit type referring to Religious and Apostolic Associations." ;
 .
 
-sdo:Nonprofit501e
+schema:Nonprofit501e
     rdfs:label "Nonprofit501e" ;
     rdfs:comment "Nonprofit501e: Non-profit type referring to Cooperative Hospital Service Organizations." ;
 .
 
-sdo:Nonprofit501f
+schema:Nonprofit501f
     rdfs:label "Nonprofit501f" ;
     rdfs:comment "Nonprofit501f: Non-profit type referring to Cooperative Service Organizations." ;
 .
 
-sdo:Nonprofit501k
+schema:Nonprofit501k
     rdfs:label "Nonprofit501k" ;
     rdfs:comment "Nonprofit501k: Non-profit type referring to Child Care Organizations." ;
 .
 
-sdo:Nonprofit501n
+schema:Nonprofit501n
     rdfs:label "Nonprofit501n" ;
     rdfs:comment "Nonprofit501n: Non-profit type referring to Charitable Risk Pools." ;
 .
 
-sdo:Nonprofit501q
+schema:Nonprofit501q
     rdfs:label "Nonprofit501q" ;
     rdfs:comment "Nonprofit501q: Non-profit type referring to Credit Counseling Organizations." ;
 .
 
-sdo:Nonprofit527
+schema:Nonprofit527
     rdfs:label "Nonprofit527" ;
     rdfs:comment "Nonprofit527: Non-profit type referring to Political organizations." ;
 .
 
-sdo:NonprofitANBI
+schema:NonprofitANBI
     rdfs:label "NonprofitANBI" ;
     rdfs:comment "NonprofitANBI: Non-profit type referring to a Public Benefit Organization (NL)." ;
 .
 
-sdo:NonprofitSBBI
+schema:NonprofitSBBI
     rdfs:label "NonprofitSBBI" ;
     rdfs:comment "NonprofitSBBI: Non-profit type referring to a Social Interest Promoting Institution (NL)." ;
 .
 
-sdo:NonprofitType
+schema:NonprofitType
     rdfs:label "Nonprofit Type" ;
     rdfs:comment "NonprofitType enumerates several kinds of official non-profit types of which a non-profit organization can be." ;
 .
 
-sdo:Nose
+schema:Nose
     rdfs:label "Nose" ;
     rdfs:comment "Nose function assessment with clinical examination." ;
 .
 
-sdo:NotInForce
+schema:NotInForce
     rdfs:label "Not  In Force" ;
     rdfs:comment "Indicates that a legislation is currently not in force." ;
 .
 
-sdo:NotYetRecruiting
+schema:NotYetRecruiting
     rdfs:label "Not  Yet Recruiting" ;
     rdfs:comment "Not yet recruiting." ;
 .
 
-sdo:Notary
+schema:Notary
     rdfs:label "Notary" ;
     rdfs:comment "A notary." ;
 .
 
-sdo:NoteDigitalDocument
+schema:NoteDigitalDocument
     rdfs:label "Note  Digital Document" ;
     rdfs:comment "A file containing a note, primarily for the author." ;
 .
 
-sdo:Number
+schema:Number
     rdfs:label "Number" ;
     rdfs:comment "Data type: Number.\\n\\nUsage guidelines:\\n\\n* Use values from 0123456789 (Unicode 'DIGIT ZERO' (U+0030) to 'DIGIT NINE' (U+0039)) rather than superficially similiar Unicode symbols.\\n* Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a decimal point. Avoid using these symbols as a readability separator." ;
 .
 
-sdo:Nursing
+schema:Nursing
     rdfs:label "Nursing" ;
     rdfs:comment "A health profession of a person formally educated and trained in the care of the sick or infirm person." ;
 .
 
-sdo:NutritionInformation
+schema:NutritionInformation
     rdfs:label "Nutrition Information" ;
     rdfs:comment "Nutritional information about the recipe." ;
 .
 
-sdo:OTC
+schema:OTC
     rdfs:label "OTC" ;
     rdfs:comment "The character of a medical substance, typically a medicine, of being available over the counter or not." ;
 .
 
-sdo:Observation
+schema:Observation
     rdfs:label "Observation" ;
     rdfs:comment """Instances of the class [[Observation]] are used to specify observations about an entity (which may or may not be an instance of a [[StatisticalPopulation]]), at a particular time. The principal properties of an [[Observation]] are [[observedNode]], [[measuredProperty]], [[measuredValue]] (or [[median]], etc.) and [[observationDate]] ([[measuredProperty]] properties can, but need not always, be W3C RDF Data Cube "measure properties", as in the [lifeExpectancy example](https://www.w3.org/TR/vocab-data-cube/#dsd-example)).
 See also [[StatisticalPopulation]], and the [data and datasets](/docs/data-and-datasets.html) overview for more details.
   """ ;
 .
 
-sdo:Observational
+schema:Observational
     rdfs:label "Observational" ;
     rdfs:comment "An observational study design." ;
 .
 
-sdo:Obstetric
+schema:Obstetric
     rdfs:label "Obstetric" ;
     rdfs:comment "A specific branch of medical science that specializes in the care of women during the prenatal and postnatal care and with the delivery of the child." ;
 .
 
-sdo:Occupation
+schema:Occupation
     rdfs:label "Occupation" ;
     rdfs:comment "A profession, may involve prolonged training and/or a formal qualification." ;
 .
 
-sdo:OccupationalActivity
+schema:OccupationalActivity
     rdfs:label "Occupational Activity" ;
     rdfs:comment "Any physical activity engaged in for job-related purposes. Examples may include waiting tables, maid service, carrying a mailbag, picking fruits or vegetables, construction work, etc." ;
 .
 
-sdo:OccupationalExperienceRequirements
+schema:OccupationalExperienceRequirements
     rdfs:label "Occupational  Experience Requirements" ;
     rdfs:comment "Indicates employment-related experience requirements, e.g. [[monthsOfExperience]]." ;
 .
 
-sdo:OccupationalTherapy
+schema:OccupationalTherapy
     rdfs:label "Occupational Therapy" ;
     rdfs:comment "A treatment of people with physical, emotional, or social problems, using purposeful activity to help them overcome or learn to deal with their problems." ;
 .
 
-sdo:OceanBodyOfWater
+schema:OceanBodyOfWater
     rdfs:label "Ocean Body Of Water" ;
     rdfs:comment "An ocean (for example, the Pacific)." ;
 .
 
-sdo:Offer
+schema:Offer
     rdfs:label "Offer" ;
     rdfs:comment "An offer to transfer some rights to an item or to provide a service — for example, an offer to sell tickets to an event, to rent the DVD of a movie, to stream a TV show over the internet, to repair a motorcycle, or to loan a book.\\n\\nNote: As the [[businessFunction]] property, which identifies the form of offer (e.g. sell, lease, repair, dispose), defaults to http://purl.org/goodrelations/v1#Sell; an Offer without a defined businessFunction value can be assumed to be an offer to sell.\\n\\nFor [GTIN](http://www.gs1.org/barcodes/technical/idkeys/gtin)-related fields, see [Check Digit calculator](http://www.gs1.org/barcodes/support/check_digit_calculator) and [validation guide](http://www.gs1us.org/resources/standards/gtin-validation-guide) from [GS1](http://www.gs1.org/)." ;
 .
 
-sdo:OfferCatalog
+schema:OfferCatalog
     rdfs:label "Offer Catalog" ;
     rdfs:comment "An OfferCatalog is an ItemList that contains related Offers and/or further OfferCatalogs that are offeredBy the same provider." ;
 .
 
-sdo:OfferForLease
+schema:OfferForLease
     rdfs:label "Offer  For Lease" ;
     rdfs:comment """An [[OfferForLease]] in Schema.org represents an [[Offer]] to lease out something, i.e. an [[Offer]] whose
   [[businessFunction]] is [lease out](http://purl.org/goodrelations/v1#LeaseOut.). See [Good Relations](https://en.wikipedia.org/wiki/GoodRelations) for
@@ -6763,7 +6763,7 @@ sdo:OfferForLease
   """ ;
 .
 
-sdo:OfferForPurchase
+schema:OfferForPurchase
     rdfs:label "Offer  For Purchase" ;
     rdfs:comment """An [[OfferForPurchase]] in Schema.org represents an [[Offer]] to sell something, i.e. an [[Offer]] whose
   [[businessFunction]] is [sell](http://purl.org/goodrelations/v1#Sell.). See [Good Relations](https://en.wikipedia.org/wiki/GoodRelations) for
@@ -6771,12 +6771,12 @@ sdo:OfferForPurchase
   """ ;
 .
 
-sdo:OfferItemCondition
+schema:OfferItemCondition
     rdfs:label "Offer  Item Condition" ;
     rdfs:comment "A list of possible conditions for the item." ;
 .
 
-sdo:OfferShippingDetails
+schema:OfferShippingDetails
     rdfs:label "Offer  Shipping Details" ;
     rdfs:comment """OfferShippingDetails represents information about shipping destinations.
 
@@ -6792,174 +6792,174 @@ e.g. Cheaper and slower: $5 in 5-7days
 or Fast and expensive: $15 in 1-2 days.""" ;
 .
 
-sdo:OfficeEquipmentStore
+schema:OfficeEquipmentStore
     rdfs:label "Office  Equipment Store" ;
     rdfs:comment "An office equipment store." ;
 .
 
-sdo:OfficialLegalValue
+schema:OfficialLegalValue
     rdfs:label "Official  Legal Value" ;
     rdfs:comment "All the documents published by an official publisher should have at least the legal value level \"OfficialLegalValue\". This indicates that the document was published by an organisation with the public task of making it available (e.g. a consolidated version of a EU directive published by the EU Office of Publications)." ;
 .
 
-sdo:OfflineEventAttendanceMode
+schema:OfflineEventAttendanceMode
     rdfs:label "Offline Event Attendance Mode" ;
     rdfs:comment "OfflineEventAttendanceMode - an event that is primarily conducted offline. " ;
 .
 
-sdo:OfflinePermanently
+schema:OfflinePermanently
     rdfs:label "Offline Permanently" ;
     rdfs:comment "Game server status: OfflinePermanently. Server is offline and not available." ;
 .
 
-sdo:OfflineTemporarily
+schema:OfflineTemporarily
     rdfs:label "Offline Temporarily" ;
     rdfs:comment "Game server status: OfflineTemporarily. Server is offline now but it can be online soon." ;
 .
 
-sdo:OnDemandEvent
+schema:OnDemandEvent
     rdfs:label "On  Demand Event" ;
     rdfs:comment "A publication event e.g. catch-up TV or radio podcast, during which a program is available on-demand." ;
 .
 
-sdo:OnSitePickup
+schema:OnSitePickup
     rdfs:label "On  Site Pickup" ;
     rdfs:comment "A DeliveryMethod in which an item is collected on site, e.g. in a store or at a box office." ;
 .
 
-sdo:Oncologic
+schema:Oncologic
     rdfs:label "Oncologic" ;
     rdfs:comment "A specific branch of medical science that deals with benign and malignant tumors, including the study of their development, diagnosis, treatment and prevention." ;
 .
 
-sdo:OneTimePayments
+schema:OneTimePayments
     rdfs:label "One  Time Payments" ;
     rdfs:comment "OneTimePayments: this is a benefit for one-time payments for individuals." ;
 .
 
-sdo:Online
+schema:Online
     rdfs:label "Online" ;
     rdfs:comment "Game server status: Online. Server is available." ;
 .
 
-sdo:OnlineEventAttendanceMode
+schema:OnlineEventAttendanceMode
     rdfs:label "Online Event Attendance Mode" ;
     rdfs:comment "OnlineEventAttendanceMode - an event that is primarily conducted online. " ;
 .
 
-sdo:OnlineFull
+schema:OnlineFull
     rdfs:label "Online Full" ;
     rdfs:comment "Game server status: OnlineFull. Server is online but unavailable. The maximum number of players has reached." ;
 .
 
-sdo:OnlineOnly
+schema:OnlineOnly
     rdfs:label "Online Only" ;
     rdfs:comment "Indicates that the item is available only online." ;
 .
 
-sdo:OpenTrial
+schema:OpenTrial
     rdfs:label "Open Trial" ;
     rdfs:comment "A trial design in which the researcher knows the full details of the treatment, and so does the patient." ;
 .
 
-sdo:OpeningHoursSpecification
+schema:OpeningHoursSpecification
     rdfs:label "Opening  Hours Specification" ;
     rdfs:comment """A structured value providing information about the opening hours of a place or a certain service inside a place.\\n\\n
 The place is __open__ if the [[opens]] property is specified, and __closed__ otherwise.\\n\\nIf the value for the [[closes]] property is less than the value for the [[opens]] property then the hour range is assumed to span over the next day.
       """ ;
 .
 
-sdo:OpinionNewsArticle
+schema:OpinionNewsArticle
     rdfs:label "Opinion  News Article" ;
     rdfs:comment "An [[OpinionNewsArticle]] is a [[NewsArticle]] that primarily expresses opinions rather than journalistic reporting of news and events. For example, a [[NewsArticle]] consisting of a column or [[Blog]]/[[BlogPosting]] entry in the Opinions section of a news publication. " ;
 .
 
-sdo:Optician
+schema:Optician
     rdfs:label "Optician" ;
     rdfs:comment "A store that sells reading glasses and similar devices for improving vision." ;
 .
 
-sdo:Optometric
+schema:Optometric
     rdfs:label "Optometric" ;
     rdfs:comment "The science or practice of testing visual acuity and prescribing corrective lenses." ;
 .
 
-sdo:Order
+schema:Order
     rdfs:label "Order" ;
     rdfs:comment "An order is a confirmation of a transaction (a receipt), which can contain multiple line items, each represented by an Offer that has been accepted by the customer." ;
 .
 
-sdo:OrderAction
+schema:OrderAction
     rdfs:label "Order Action" ;
     rdfs:comment "An agent orders an object/product/service to be delivered/sent." ;
 .
 
-sdo:OrderCancelled
+schema:OrderCancelled
     rdfs:label "Order Cancelled" ;
     rdfs:comment "OrderStatus representing cancellation of an order." ;
 .
 
-sdo:OrderDelivered
+schema:OrderDelivered
     rdfs:label "Order Delivered" ;
     rdfs:comment "OrderStatus representing successful delivery of an order." ;
 .
 
-sdo:OrderInTransit
+schema:OrderInTransit
     rdfs:label "Order  In Transit" ;
     rdfs:comment "OrderStatus representing that an order is in transit." ;
 .
 
-sdo:OrderItem
+schema:OrderItem
     rdfs:label "Order Item" ;
     rdfs:comment "An order item is a line of an order. It includes the quantity and shipping details of a bought offer." ;
 .
 
-sdo:OrderPaymentDue
+schema:OrderPaymentDue
     rdfs:label "Order  Payment Due" ;
     rdfs:comment "OrderStatus representing that payment is due on an order." ;
 .
 
-sdo:OrderPickupAvailable
+schema:OrderPickupAvailable
     rdfs:label "Order  Pickup Available" ;
     rdfs:comment "OrderStatus representing availability of an order for pickup." ;
 .
 
-sdo:OrderProblem
+schema:OrderProblem
     rdfs:label "Order Problem" ;
     rdfs:comment "OrderStatus representing that there is a problem with the order." ;
 .
 
-sdo:OrderProcessing
+schema:OrderProcessing
     rdfs:label "Order Processing" ;
     rdfs:comment "OrderStatus representing that an order is being processed." ;
 .
 
-sdo:OrderReturned
+schema:OrderReturned
     rdfs:label "Order Returned" ;
     rdfs:comment "OrderStatus representing that an order has been returned." ;
 .
 
-sdo:OrderStatus
+schema:OrderStatus
     rdfs:label "Order Status" ;
     rdfs:comment "Enumerated status values for Order." ;
 .
 
-sdo:Organization
+schema:Organization
     rdfs:label "Organization" ;
     rdfs:comment "An organization such as a school, NGO, corporation, club, etc." ;
 .
 
-sdo:OrganizationRole
+schema:OrganizationRole
     rdfs:label "Organization Role" ;
     rdfs:comment "A subclass of Role used to describe roles within organizations." ;
 .
 
-sdo:OrganizeAction
+schema:OrganizeAction
     rdfs:label "Organize Action" ;
     rdfs:comment "The act of manipulating/administering/supervising/controlling one or more objects." ;
 .
 
-sdo:OriginalMediaContent
+schema:OriginalMediaContent
     rdfs:label "Original  Media Content" ;
     rdfs:comment """Content coded 'as original media content' in a [[MediaReview]], considered in the context of how it was published or shared.
 
@@ -6973,853 +6973,853 @@ For an [[AudioObject]] to be 'original': No evidence the audio has been misleadi
 """ ;
 .
 
-sdo:OriginalShippingFees
+schema:OriginalShippingFees
     rdfs:label "Original  Shipping Fees" ;
     rdfs:comment "Specifies that the customer must pay the original shipping costs when returning a product." ;
 .
 
-sdo:Osteopathic
+schema:Osteopathic
     rdfs:label "Osteopathic" ;
     rdfs:comment "A system of medicine focused on promoting the body's innate ability to heal itself." ;
 .
 
-sdo:Otolaryngologic
+schema:Otolaryngologic
     rdfs:label "Otolaryngologic" ;
     rdfs:comment "A specific branch of medical science that is concerned with the ear, nose and throat and their respective disease states." ;
 .
 
-sdo:OutOfStock
+schema:OutOfStock
     rdfs:label "Out  Of Stock" ;
     rdfs:comment "Indicates that the item is out of stock." ;
 .
 
-sdo:OutletStore
+schema:OutletStore
     rdfs:label "Outlet Store" ;
     rdfs:comment "An outlet store." ;
 .
 
-sdo:OverviewHealthAspect
+schema:OverviewHealthAspect
     rdfs:label "Overview  Health Aspect" ;
     rdfs:comment "Overview of the content. Contains a summarized view of the topic with the most relevant information for an introduction." ;
 .
 
-sdo:OwnershipInfo
+schema:OwnershipInfo
     rdfs:label "Ownership Info" ;
     rdfs:comment "A structured value providing information about when a certain organization or person owned a certain product." ;
 .
 
-sdo:PET
+schema:PET
     rdfs:label "PET" ;
     rdfs:comment "Positron emission tomography imaging." ;
 .
 
-sdo:PaidLeave
+schema:PaidLeave
     rdfs:label "Paid Leave" ;
     rdfs:comment "PaidLeave: this is a benefit for paid leave." ;
 .
 
-sdo:PaintAction
+schema:PaintAction
     rdfs:label "Paint Action" ;
     rdfs:comment "The act of producing a painting, typically with paint and canvas as instruments." ;
 .
 
-sdo:Painting
+schema:Painting
     rdfs:label "Painting" ;
     rdfs:comment "A painting." ;
 .
 
-sdo:PalliativeProcedure
+schema:PalliativeProcedure
     rdfs:label "Palliative Procedure" ;
     rdfs:comment "A medical procedure intended primarily for palliative purposes, aimed at relieving the symptoms of an underlying health condition." ;
 .
 
-sdo:Paperback
+schema:Paperback
     rdfs:label "Paperback" ;
     rdfs:comment "Book format: Paperback." ;
 .
 
-sdo:ParcelDelivery
+schema:ParcelDelivery
     rdfs:label "Parcel Delivery" ;
     rdfs:comment "The delivery of a parcel either via the postal service or a commercial service." ;
 .
 
-sdo:ParcelService
+schema:ParcelService
     rdfs:label "Parcel Service" ;
     rdfs:comment """A private parcel service as the delivery mode available for a certain offer.\\n\\nCommonly used values:\\n\\n* http://purl.org/goodrelations/v1#DHL\\n* http://purl.org/goodrelations/v1#FederalExpress\\n* http://purl.org/goodrelations/v1#UPS
       """ ;
 .
 
-sdo:ParentAudience
+schema:ParentAudience
     rdfs:label "Parent Audience" ;
     rdfs:comment "A set of characteristics describing parents, who can be interested in viewing some content." ;
 .
 
-sdo:ParentalSupport
+schema:ParentalSupport
     rdfs:label "Parental Support" ;
     rdfs:comment "ParentalSupport: this is a benefit for parental support." ;
 .
 
-sdo:Park
+schema:Park
     rdfs:label "Park" ;
     rdfs:comment "A park." ;
 .
 
-sdo:ParkingFacility
+schema:ParkingFacility
     rdfs:label "Parking Facility" ;
     rdfs:comment "A parking lot or other parking facility." ;
 .
 
-sdo:ParkingMap
+schema:ParkingMap
     rdfs:label "Parking Map" ;
     rdfs:comment "A parking map." ;
 .
 
-sdo:PartiallyInForce
+schema:PartiallyInForce
     rdfs:label "Partially  In Force" ;
     rdfs:comment "Indicates that parts of the legislation are in force, and parts are not." ;
 .
 
-sdo:Pathology
+schema:Pathology
     rdfs:label "Pathology" ;
     rdfs:comment "A specific branch of medical science that is concerned with the study of the cause, origin and nature of a disease state, including its consequences as a result of manifestation of the disease. In clinical care, the term is used to designate a branch of medicine using laboratory tests to diagnose and determine the prognostic significance of illness." ;
 .
 
-sdo:PathologyTest
+schema:PathologyTest
     rdfs:label "Pathology Test" ;
     rdfs:comment "A medical test performed by a laboratory that typically involves examination of a tissue sample by a pathologist." ;
 .
 
-sdo:Patient
+schema:Patient
     rdfs:label "Patient" ;
     rdfs:comment "A patient is any person recipient of health care services." ;
 .
 
-sdo:PatientExperienceHealthAspect
+schema:PatientExperienceHealthAspect
     rdfs:label "Patient Experience Health Aspect" ;
     rdfs:comment "Content about the real life experience of patients or people that have lived a similar experience about the topic. May be forums, topics, Q-and-A and related material." ;
 .
 
-sdo:PawnShop
+schema:PawnShop
     rdfs:label "Pawn Shop" ;
     rdfs:comment "A shop that will buy, or lend money against the security of, personal possessions." ;
 .
 
-sdo:PayAction
+schema:PayAction
     rdfs:label "Pay Action" ;
     rdfs:comment "An agent pays a price to a participant." ;
 .
 
-sdo:PaymentAutomaticallyApplied
+schema:PaymentAutomaticallyApplied
     rdfs:label "Payment  Automatically Applied" ;
     rdfs:comment "An automatic payment system is in place and will be used." ;
 .
 
-sdo:PaymentCard
+schema:PaymentCard
     rdfs:label "Payment Card" ;
     rdfs:comment "A payment method using a credit, debit, store or other card to associate the payment with an account." ;
 .
 
-sdo:PaymentChargeSpecification
+schema:PaymentChargeSpecification
     rdfs:label "Payment  Charge Specification" ;
     rdfs:comment "The costs of settling the payment using a particular payment method." ;
 .
 
-sdo:PaymentComplete
+schema:PaymentComplete
     rdfs:label "Payment Complete" ;
     rdfs:comment "The payment has been received and processed." ;
 .
 
-sdo:PaymentDeclined
+schema:PaymentDeclined
     rdfs:label "Payment Declined" ;
     rdfs:comment "The payee received the payment, but it was declined for some reason." ;
 .
 
-sdo:PaymentDue
+schema:PaymentDue
     rdfs:label "Payment Due" ;
     rdfs:comment "The payment is due, but still within an acceptable time to be received." ;
 .
 
-sdo:PaymentMethod
+schema:PaymentMethod
     rdfs:label "Payment Method" ;
     rdfs:comment """A payment method is a standardized procedure for transferring the monetary amount for a purchase. Payment methods are characterized by the legal and technical structures used, and by the organization or group carrying out the transaction.\\n\\nCommonly used values:\\n\\n* http://purl.org/goodrelations/v1#ByBankTransferInAdvance\\n* http://purl.org/goodrelations/v1#ByInvoice\\n* http://purl.org/goodrelations/v1#Cash\\n* http://purl.org/goodrelations/v1#CheckInAdvance\\n* http://purl.org/goodrelations/v1#COD\\n* http://purl.org/goodrelations/v1#DirectDebit\\n* http://purl.org/goodrelations/v1#GoogleCheckout\\n* http://purl.org/goodrelations/v1#PayPal\\n* http://purl.org/goodrelations/v1#PaySwarm
         """ ;
 .
 
-sdo:PaymentPastDue
+schema:PaymentPastDue
     rdfs:label "Payment  Past Due" ;
     rdfs:comment "The payment is due and considered late." ;
 .
 
-sdo:PaymentService
+schema:PaymentService
     rdfs:label "Payment Service" ;
     rdfs:comment "A Service to transfer funds from a person or organization to a beneficiary person or organization." ;
 .
 
-sdo:PaymentStatusType
+schema:PaymentStatusType
     rdfs:label "Payment  Status Type" ;
     rdfs:comment "A specific payment status. For example, PaymentDue, PaymentComplete, etc." ;
 .
 
-sdo:Pediatric
+schema:Pediatric
     rdfs:label "Pediatric" ;
     rdfs:comment "A specific branch of medical science that specializes in the care of infants, children and adolescents." ;
 .
 
-sdo:PeopleAudience
+schema:PeopleAudience
     rdfs:label "People Audience" ;
     rdfs:comment "A set of characteristics belonging to people, e.g. who compose an item's target audience." ;
 .
 
-sdo:PercutaneousProcedure
+schema:PercutaneousProcedure
     rdfs:label "Percutaneous Procedure" ;
     rdfs:comment "A type of medical procedure that involves percutaneous techniques, where access to organs or tissue is achieved via needle-puncture of the skin. For example, catheter-based procedures like stent delivery." ;
 .
 
-sdo:PerformAction
+schema:PerformAction
     rdfs:label "Perform Action" ;
     rdfs:comment "The act of participating in performance arts." ;
 .
 
-sdo:PerformanceRole
+schema:PerformanceRole
     rdfs:label "Performance Role" ;
     rdfs:comment "A PerformanceRole is a Role that some entity places with regard to a theatrical performance, e.g. in a Movie, TVSeries etc." ;
 .
 
-sdo:PerformingArtsTheater
+schema:PerformingArtsTheater
     rdfs:label "Performing  Arts Theater" ;
     rdfs:comment "A theater or other performing art center." ;
 .
 
-sdo:PerformingGroup
+schema:PerformingGroup
     rdfs:label "Performing Group" ;
     rdfs:comment "A performance group, such as a band, an orchestra, or a circus." ;
 .
 
-sdo:Periodical
+schema:Periodical
     rdfs:label "Periodical" ;
     rdfs:comment "A publication in any medium issued in successive parts bearing numerical or chronological designations and intended, such as a magazine, scholarly journal, or newspaper to continue indefinitely.\\n\\nSee also [blog post](http://blog.schema.org/2014/09/schemaorg-support-for-bibliographic_2.html)." ;
 .
 
-sdo:Permit
+schema:Permit
     rdfs:label "Permit" ;
     rdfs:comment "A permit issued by an organization, e.g. a parking pass." ;
 .
 
-sdo:Person
+schema:Person
     rdfs:label "Person" ;
     rdfs:comment "A person (alive, dead, undead, or fictional)." ;
 .
 
-sdo:PetStore
+schema:PetStore
     rdfs:label "Pet Store" ;
     rdfs:comment "A pet store." ;
 .
 
-sdo:Pharmacy
+schema:Pharmacy
     rdfs:label "Pharmacy" ;
     rdfs:comment "A pharmacy or drugstore." ;
 .
 
-sdo:PharmacySpecialty
+schema:PharmacySpecialty
     rdfs:label "Pharmacy Specialty" ;
     rdfs:comment "The practice or art and science of preparing and dispensing drugs and medicines." ;
 .
 
-sdo:Photograph
+schema:Photograph
     rdfs:label "Photograph" ;
     rdfs:comment "A photograph." ;
 .
 
-sdo:PhotographAction
+schema:PhotographAction
     rdfs:label "Photograph Action" ;
     rdfs:comment "The act of capturing still images of objects using a camera." ;
 .
 
-sdo:PhysicalActivity
+schema:PhysicalActivity
     rdfs:label "Physical Activity" ;
     rdfs:comment "Any bodily activity that enhances or maintains physical fitness and overall health and wellness. Includes activity that is part of daily living and routine, structured exercise, and exercise prescribed as part of a medical treatment or recovery plan." ;
 .
 
-sdo:PhysicalActivityCategory
+schema:PhysicalActivityCategory
     rdfs:label "Physical  Activity Category" ;
     rdfs:comment "Categories of physical activity, organized by physiologic classification." ;
 .
 
-sdo:PhysicalExam
+schema:PhysicalExam
     rdfs:label "Physical Exam" ;
     rdfs:comment "A type of physical examination of a patient performed by a physician. " ;
 .
 
-sdo:PhysicalTherapy
+schema:PhysicalTherapy
     rdfs:label "Physical Therapy" ;
     rdfs:comment "A process of progressive physical care and rehabilitation aimed at improving a health condition." ;
 .
 
-sdo:Physician
+schema:Physician
     rdfs:label "Physician" ;
     rdfs:comment "A doctor's office." ;
 .
 
-sdo:Physiotherapy
+schema:Physiotherapy
     rdfs:label "Physiotherapy" ;
     rdfs:comment "The practice of treatment of disease, injury, or deformity by physical methods such as massage, heat treatment, and exercise rather than by drugs or surgery.." ;
 .
 
-sdo:Place
+schema:Place
     rdfs:label "Place" ;
     rdfs:comment "Entities that have a somewhat fixed, physical extension." ;
 .
 
-sdo:PlaceOfWorship
+schema:PlaceOfWorship
     rdfs:label "Place  Of Worship" ;
     rdfs:comment "Place of worship, such as a church, synagogue, or mosque." ;
 .
 
-sdo:PlaceboControlledTrial
+schema:PlaceboControlledTrial
     rdfs:label "Placebo  Controlled Trial" ;
     rdfs:comment "A placebo-controlled trial design." ;
 .
 
-sdo:PlanAction
+schema:PlanAction
     rdfs:label "Plan Action" ;
     rdfs:comment "The act of planning the execution of an event/task/action/reservation/plan to a future date." ;
 .
 
-sdo:PlasticSurgery
+schema:PlasticSurgery
     rdfs:label "Plastic Surgery" ;
     rdfs:comment "A specific branch of medical science that pertains to therapeutic or cosmetic repair or re-formation of missing, injured or malformed tissues or body parts by manual and instrumental means." ;
 .
 
-sdo:Play
+schema:Play
     rdfs:label "Play" ;
     rdfs:comment "A play is a form of literature, usually consisting of dialogue between characters, intended for theatrical performance rather than just reading. Note: A performance of a Play would be a [[TheaterEvent]] or [[BroadcastEvent]] - the *Play* being the [[workPerformed]]." ;
 .
 
-sdo:PlayAction
+schema:PlayAction
     rdfs:label "Play Action" ;
     rdfs:comment "The act of playing/exercising/training/performing for enjoyment, leisure, recreation, Competition or exercise.\\n\\nRelated actions:\\n\\n* [[ListenAction]]: Unlike ListenAction (which is under ConsumeAction), PlayAction refers to performing for an audience or at an event, rather than consuming music.\\n* [[WatchAction]]: Unlike WatchAction (which is under ConsumeAction), PlayAction refers to showing/displaying for an audience or at an event, rather than consuming visual content." ;
 .
 
-sdo:Playground
+schema:Playground
     rdfs:label "Playground" ;
     rdfs:comment "A playground." ;
 .
 
-sdo:Plumber
+schema:Plumber
     rdfs:label "Plumber" ;
     rdfs:comment "A plumbing service." ;
 .
 
-sdo:PodcastEpisode
+schema:PodcastEpisode
     rdfs:label "Podcast Episode" ;
     rdfs:comment "A single episode of a podcast series." ;
 .
 
-sdo:PodcastSeason
+schema:PodcastSeason
     rdfs:label "Podcast Season" ;
     rdfs:comment "A single season of a podcast. Many podcasts do not break down into separate seasons. In that case, PodcastSeries should be used." ;
 .
 
-sdo:PodcastSeries
+schema:PodcastSeries
     rdfs:label "Podcast Series" ;
     rdfs:comment "A podcast is an episodic series of digital audio or video files which a user can download and listen to." ;
 .
 
-sdo:Podiatric
+schema:Podiatric
     rdfs:label "Podiatric" ;
     rdfs:comment "Podiatry is the care of the human foot, especially the diagnosis and treatment of foot disorders." ;
 .
 
-sdo:PoliceStation
+schema:PoliceStation
     rdfs:label "Police Station" ;
     rdfs:comment "A police station." ;
 .
 
-sdo:Pond
+schema:Pond
     rdfs:label "Pond" ;
     rdfs:comment "A pond." ;
 .
 
-sdo:PostOffice
+schema:PostOffice
     rdfs:label "Post Office" ;
     rdfs:comment "A post office." ;
 .
 
-sdo:PostalAddress
+schema:PostalAddress
     rdfs:label "Postal Address" ;
     rdfs:comment "The mailing address." ;
 .
 
-sdo:PostalCodeRangeSpecification
+schema:PostalCodeRangeSpecification
     rdfs:label "Postal Code Range Specification" ;
     rdfs:comment "Indicates a range of postalcodes, usually defined as the set of valid codes between [[postalCodeBegin]] and [[postalCodeEnd]], inclusively." ;
 .
 
-sdo:Poster
+schema:Poster
     rdfs:label "Poster" ;
     rdfs:comment "A large, usually printed placard, bill, or announcement, often illustrated, that is posted to advertise or publicize something." ;
 .
 
-sdo:PotentialActionStatus
+schema:PotentialActionStatus
     rdfs:label "Potential  Action Status" ;
     rdfs:comment "A description of an action that is supported." ;
 .
 
-sdo:PreOrder
+schema:PreOrder
     rdfs:label "Pre Order" ;
     rdfs:comment "Indicates that the item is available for pre-order." ;
 .
 
-sdo:PreOrderAction
+schema:PreOrderAction
     rdfs:label "Pre  Order Action" ;
     rdfs:comment "An agent orders a (not yet released) object/product/service to be delivered/sent." ;
 .
 
-sdo:PreSale
+schema:PreSale
     rdfs:label "Pre Sale" ;
     rdfs:comment "Indicates that the item is available for ordering and delivery before general availability." ;
 .
 
-sdo:PregnancyHealthAspect
+schema:PregnancyHealthAspect
     rdfs:label "Pregnancy  Health Aspect" ;
     rdfs:comment "Content discussing pregnancy-related aspects of a health topic." ;
 .
 
-sdo:PrependAction
+schema:PrependAction
     rdfs:label "Prepend Action" ;
     rdfs:comment "The act of inserting at the beginning if an ordered collection." ;
 .
 
-sdo:Preschool
+schema:Preschool
     rdfs:label "Preschool" ;
     rdfs:comment "A preschool." ;
 .
 
-sdo:PrescriptionOnly
+schema:PrescriptionOnly
     rdfs:label "Prescription Only" ;
     rdfs:comment "Available by prescription only." ;
 .
 
-sdo:PresentationDigitalDocument
+schema:PresentationDigitalDocument
     rdfs:label "Presentation  Digital Document" ;
     rdfs:comment "A file containing slides or used for a presentation." ;
 .
 
-sdo:PreventionHealthAspect
+schema:PreventionHealthAspect
     rdfs:label "Prevention  Health Aspect" ;
     rdfs:comment "Information about actions or measures that can be taken to avoid getting the topic or reaching a critical situation related to the topic." ;
 .
 
-sdo:PreventionIndication
+schema:PreventionIndication
     rdfs:label "Prevention Indication" ;
     rdfs:comment "An indication for preventing an underlying condition, symptom, etc." ;
 .
 
-sdo:PriceComponentTypeEnumeration
+schema:PriceComponentTypeEnumeration
     rdfs:label "Price Component Type Enumeration" ;
     rdfs:comment "Enumerates different price components that together make up the total price for an offered product." ;
 .
 
-sdo:PriceSpecification
+schema:PriceSpecification
     rdfs:label "Price Specification" ;
     rdfs:comment "A structured value representing a price or price range. Typically, only the subclasses of this type are used for markup. It is recommended to use [[MonetaryAmount]] to describe independent amounts of money such as a salary, credit card limits, etc." ;
 .
 
-sdo:PriceTypeEnumeration
+schema:PriceTypeEnumeration
     rdfs:label "Price  Type Enumeration" ;
     rdfs:comment "Enumerates different price types, for example list price, invoice price, and sale price." ;
 .
 
-sdo:PrimaryCare
+schema:PrimaryCare
     rdfs:label "Primary Care" ;
     rdfs:comment "The medical care by a physician, or other health-care professional, who is the patient's first contact with the health-care system and who may recommend a specialist if necessary." ;
 .
 
-sdo:Prion
+schema:Prion
     rdfs:label "Prion" ;
     rdfs:comment "A prion is an infectious agent composed of protein in a misfolded form." ;
 .
 
-sdo:Product
+schema:Product
     rdfs:label "Product" ;
     rdfs:comment "Any offered product or service. For example: a pair of shoes; a concert ticket; the rental of a car; a haircut; or an episode of a TV show streamed online." ;
 .
 
-sdo:ProductCollection
+schema:ProductCollection
     rdfs:label "Product Collection" ;
     rdfs:comment "A set of products (either [[ProductGroup]]s or specific variants) that are listed together e.g. in an [[Offer]]." ;
 .
 
-sdo:ProductGroup
+schema:ProductGroup
     rdfs:label "Product Group" ;
     rdfs:comment """A ProductGroup represents a group of [[Product]]s that vary only in certain well-described ways, such as by [[size]], [[color]], [[material]] etc.
 
 While a ProductGroup itself is not directly offered for sale, the various varying products that it represents can be. The ProductGroup serves as a prototype or template, standing in for all of the products who have an [[isVariantOf]] relationship to it. As such, properties (including additional types) can be applied to the ProductGroup to represent characteristics shared by each of the (possibly very many) variants. Properties that reference a ProductGroup are not included in this mechanism; neither are the following specific properties [[variesBy]], [[hasVariant]], [[url]]. """ ;
 .
 
-sdo:ProductModel
+schema:ProductModel
     rdfs:label "Product Model" ;
     rdfs:comment "A datasheet or vendor specification of a product (in the sense of a prototypical description)." ;
 .
 
-sdo:ProfessionalService
+schema:ProfessionalService
     rdfs:label "Professional Service" ;
     rdfs:comment """Original definition: "provider of professional services."\\n\\nThe general [[ProfessionalService]] type for local businesses was deprecated due to confusion with [[Service]]. For reference, the types that it included were: [[Dentist]],
         [[AccountingService]], [[Attorney]], [[Notary]], as well as types for several kinds of [[HomeAndConstructionBusiness]]: [[Electrician]], [[GeneralContractor]],
         [[HousePainter]], [[Locksmith]], [[Plumber]], [[RoofingContractor]]. [[LegalService]] was introduced as a more inclusive supertype of [[Attorney]].""" ;
 .
 
-sdo:ProfilePage
+schema:ProfilePage
     rdfs:label "Profile Page" ;
     rdfs:comment "Web page type: Profile page." ;
 .
 
-sdo:PrognosisHealthAspect
+schema:PrognosisHealthAspect
     rdfs:label "Prognosis  Health Aspect" ;
     rdfs:comment "Typical progression and happenings of life course of the topic." ;
 .
 
-sdo:ProgramMembership
+schema:ProgramMembership
     rdfs:label "Program Membership" ;
     rdfs:comment "Used to describe membership in a loyalty programs (e.g. \"StarAliance\"), traveler clubs (e.g. \"AAA\"), purchase clubs (\"Safeway Club\"), etc." ;
 .
 
-sdo:Project
+schema:Project
     rdfs:label "Project" ;
     rdfs:comment """An enterprise (potentially individual but typically collaborative), planned to achieve a particular aim.
 Use properties from [[Organization]], [[subOrganization]]/[[parentOrganization]] to indicate project sub-structures.
    """ ;
 .
 
-sdo:PronounceableText
+schema:PronounceableText
     rdfs:label "Pronounceable Text" ;
     rdfs:comment "Data type: PronounceableText." ;
 .
 
-sdo:Property
+schema:Property
     rdfs:label "Property" ;
     rdfs:comment "A property, used to indicate attributes and relationships of some Thing; equivalent to rdf:Property." ;
 .
 
-sdo:PropertyValue
+schema:PropertyValue
     rdfs:label "Property Value" ;
     rdfs:comment """A property-value pair, e.g. representing a feature of a product or place. Use the 'name' property for the name of the property. If there is an additional human-readable version of the value, put that into the 'description' property.\\n\\n Always use specific schema.org properties when a) they exist and b) you can populate them. Using PropertyValue as a substitute will typically not trigger the same effect as using the original, specific property.
     """ ;
 .
 
-sdo:PropertyValueSpecification
+schema:PropertyValueSpecification
     rdfs:label "Property  Value Specification" ;
     rdfs:comment "A Property value specification." ;
 .
 
-sdo:Protein
+schema:Protein
     rdfs:label "Protein" ;
-    rdfs:comment "Protein is here used in its widest possible definition, as classes of amino acid based molecules. Amyloid-beta Protein in human (UniProt P05067), eukaryota (e.g. an OrthoDB group) or even a single molecule that one can point to are all of type sdo:Protein. A protein can thus be a subclass of another protein, e.g. sdo:Protein as a UniProt record can have multiple isoforms inside it which would also be sdo:Protein. They can be imagined, synthetic, hypothetical or naturally occurring." ;
+    rdfs:comment "Protein is here used in its widest possible definition, as classes of amino acid based molecules. Amyloid-beta Protein in human (UniProt P05067), eukaryota (e.g. an OrthoDB group) or even a single molecule that one can point to are all of type schema:Protein. A protein can thus be a subclass of another protein, e.g. schema:Protein as a UniProt record can have multiple isoforms inside it which would also be schema:Protein. They can be imagined, synthetic, hypothetical or naturally occurring." ;
 .
 
-sdo:Protozoa
+schema:Protozoa
     rdfs:label "Protozoa" ;
     rdfs:comment "Single-celled organism that causes an infection." ;
 .
 
-sdo:Psychiatric
+schema:Psychiatric
     rdfs:label "Psychiatric" ;
     rdfs:comment "A specific branch of medical science that is concerned with the study, treatment, and prevention of mental illness, using both medical and psychological therapies." ;
 .
 
-sdo:PsychologicalTreatment
+schema:PsychologicalTreatment
     rdfs:label "Psychological Treatment" ;
     rdfs:comment "A process of care relying upon counseling, dialogue and communication  aimed at improving a mental health condition without use of drugs." ;
 .
 
-sdo:PublicHealth
+schema:PublicHealth
     rdfs:label "Public Health" ;
     rdfs:comment "Branch of medicine that pertains to the health services to improve and protect community health, especially epidemiology, sanitation, immunization, and preventive medicine." ;
 .
 
-sdo:PublicHolidays
+schema:PublicHolidays
     rdfs:label "Public Holidays" ;
     rdfs:comment "This stands for any day that is a public holiday; it is a placeholder for all official public holidays in some particular location. While not technically a \"day of the week\", it can be used with [[OpeningHoursSpecification]]. In the context of an opening hours specification it can be used to indicate opening hours on public holidays, overriding general opening hours for the day of the week on which a public holiday occurs." ;
 .
 
-sdo:PublicSwimmingPool
+schema:PublicSwimmingPool
     rdfs:label "Public  Swimming Pool" ;
     rdfs:comment "A public swimming pool." ;
 .
 
-sdo:PublicToilet
+schema:PublicToilet
     rdfs:label "Public Toilet" ;
     rdfs:comment "A public toilet is a room or small building containing one or more toilets (and possibly also urinals) which is available for use by the general public, or by customers or employees of certain businesses." ;
 .
 
-sdo:PublicationEvent
+schema:PublicationEvent
     rdfs:label "Publication Event" ;
     rdfs:comment "A PublicationEvent corresponds indifferently to the event of publication for a CreativeWork of any type e.g. a broadcast event, an on-demand event, a book/journal publication via a variety of delivery media." ;
 .
 
-sdo:PublicationIssue
+schema:PublicationIssue
     rdfs:label "Publication Issue" ;
     rdfs:comment "A part of a successively published publication such as a periodical or publication volume, often numbered, usually containing a grouping of works such as articles.\\n\\nSee also [blog post](http://blog.schema.org/2014/09/schemaorg-support-for-bibliographic_2.html)." ;
 .
 
-sdo:PublicationVolume
+schema:PublicationVolume
     rdfs:label "Publication Volume" ;
     rdfs:comment "A part of a successively published publication such as a periodical or multi-volume work, often numbered. It may represent a time span, such as a year.\\n\\nSee also [blog post](http://blog.schema.org/2014/09/schemaorg-support-for-bibliographic_2.html)." ;
 .
 
-sdo:Pulmonary
+schema:Pulmonary
     rdfs:label "Pulmonary" ;
     rdfs:comment "A specific branch of medical science that pertains to the study of the respiratory system and its respective disease states." ;
 .
 
-sdo:QAPage
+schema:QAPage
     rdfs:label "QAPage" ;
     rdfs:comment "A QAPage is a WebPage focussed on a specific Question and its Answer(s), e.g. in a question answering site or documenting Frequently Asked Questions (FAQs)." ;
 .
 
-sdo:QualitativeValue
+schema:QualitativeValue
     rdfs:label "Qualitative Value" ;
     rdfs:comment "A predefined value for a product characteristic, e.g. the power cord plug type 'US' or the garment sizes 'S', 'M', 'L', and 'XL'." ;
 .
 
-sdo:QuantitativeValue
+schema:QuantitativeValue
     rdfs:label "Quantitative Value" ;
     rdfs:comment " A point value or interval for product characteristics and other purposes." ;
 .
 
-sdo:QuantitativeValueDistribution
+schema:QuantitativeValueDistribution
     rdfs:label "Quantitative  Value Distribution" ;
     rdfs:comment "A statistical distribution of values." ;
 .
 
-sdo:Quantity
+schema:Quantity
     rdfs:label "Quantity" ;
     rdfs:comment "Quantities such as distance, time, mass, weight, etc. Particular instances of say Mass are entities like '3 Kg' or '4 milligrams'." ;
 .
 
-sdo:Question
+schema:Question
     rdfs:label "Question" ;
     rdfs:comment "A specific question - e.g. from a user seeking answers online, or collected in a Frequently Asked Questions (FAQ) document." ;
 .
 
-sdo:Quiz
+schema:Quiz
     rdfs:label "Quiz" ;
     rdfs:comment "Quiz: A test of knowledge, skills and abilities." ;
 .
 
-sdo:Quotation
+schema:Quotation
     rdfs:label "Quotation" ;
     rdfs:comment "A quotation. Often but not necessarily from some written work, attributable to a real world author and - if associated with a fictional character - to any fictional Person. Use [[isBasedOn]] to link to source/origin. The [[recordedIn]] property can be used to reference a Quotation from an [[Event]]." ;
 .
 
-sdo:QuoteAction
+schema:QuoteAction
     rdfs:label "Quote Action" ;
     rdfs:comment "An agent quotes/estimates/appraises an object/product/service with a price at a location/store." ;
 .
 
-sdo:RVPark
+schema:RVPark
     rdfs:label "RVPark" ;
     rdfs:comment "A place offering space for \"Recreational Vehicles\", Caravans, mobile homes and the like." ;
 .
 
-sdo:RadiationTherapy
+schema:RadiationTherapy
     rdfs:label "Radiation Therapy" ;
     rdfs:comment "A process of care using radiation aimed at improving a health condition." ;
 .
 
-sdo:RadioBroadcastService
+schema:RadioBroadcastService
     rdfs:label "Radio  Broadcast Service" ;
     rdfs:comment "A delivery service through which radio content is provided via broadcast over the air or online." ;
 .
 
-sdo:RadioChannel
+schema:RadioChannel
     rdfs:label "Radio Channel" ;
     rdfs:comment "A unique instance of a radio BroadcastService on a CableOrSatelliteService lineup." ;
 .
 
-sdo:RadioClip
+schema:RadioClip
     rdfs:label "Radio Clip" ;
     rdfs:comment "A short radio program or a segment/part of a radio program." ;
 .
 
-sdo:RadioEpisode
+schema:RadioEpisode
     rdfs:label "Radio Episode" ;
     rdfs:comment "A radio episode which can be part of a series or season." ;
 .
 
-sdo:RadioSeason
+schema:RadioSeason
     rdfs:label "Radio Season" ;
     rdfs:comment "Season dedicated to radio broadcast and associated online delivery." ;
 .
 
-sdo:RadioSeries
+schema:RadioSeries
     rdfs:label "Radio Series" ;
     rdfs:comment "CreativeWorkSeries dedicated to radio broadcast and associated online delivery." ;
 .
 
-sdo:RadioStation
+schema:RadioStation
     rdfs:label "Radio Station" ;
     rdfs:comment "A radio station." ;
 .
 
-sdo:Radiography
+schema:Radiography
     rdfs:label "Radiography" ;
     rdfs:comment "Radiography is an imaging technique that uses electromagnetic radiation other than visible light, especially X-rays, to view the internal structure of a non-uniformly composed and opaque object such as the human body." ;
 .
 
-sdo:RandomizedTrial
+schema:RandomizedTrial
     rdfs:label "Randomized Trial" ;
     rdfs:comment "A randomized trial design." ;
 .
 
-sdo:Rating
+schema:Rating
     rdfs:label "Rating" ;
     rdfs:comment "A rating is an evaluation on a numeric scale, such as 1 to 5 stars." ;
 .
 
-sdo:ReactAction
+schema:ReactAction
     rdfs:label "React Action" ;
     rdfs:comment "The act of responding instinctively and emotionally to an object, expressing a sentiment." ;
 .
 
-sdo:ReadAction
+schema:ReadAction
     rdfs:label "Read Action" ;
     rdfs:comment "The act of consuming written content." ;
 .
 
-sdo:ReadPermission
+schema:ReadPermission
     rdfs:label "Read Permission" ;
     rdfs:comment "Permission to read or view the document." ;
 .
 
-sdo:RealEstateAgent
+schema:RealEstateAgent
     rdfs:label "Real  Estate Agent" ;
     rdfs:comment "A real-estate agent." ;
 .
 
-sdo:RealEstateListing
+schema:RealEstateListing
     rdfs:label "Real  Estate Listing" ;
     rdfs:comment """A [[RealEstateListing]] is a listing that describes one or more real-estate [[Offer]]s (whose [[businessFunction]] is typically to lease out, or to sell).
   The [[RealEstateListing]] type itself represents the overall listing, as manifested in some [[WebPage]].
   """ ;
 .
 
-sdo:RearWheelDriveConfiguration
+schema:RearWheelDriveConfiguration
     rdfs:label "Rear Wheel Drive Configuration" ;
     rdfs:comment "Real-wheel drive is a transmission layout where the engine drives the rear wheels." ;
 .
 
-sdo:ReceiveAction
+schema:ReceiveAction
     rdfs:label "Receive Action" ;
     rdfs:comment "The act of physically/electronically taking delivery of an object that has been transferred from an origin to a destination. Reciprocal of SendAction.\\n\\nRelated actions:\\n\\n* [[SendAction]]: The reciprocal of ReceiveAction.\\n* [[TakeAction]]: Unlike TakeAction, ReceiveAction does not imply that the ownership has been transfered (e.g. I can receive a package, but it does not mean the package is now mine)." ;
 .
 
-sdo:Recipe
+schema:Recipe
     rdfs:label "Recipe" ;
     rdfs:comment "A recipe. For dietary restrictions covered by the recipe, a few common restrictions are enumerated via [[suitableForDiet]]. The [[keywords]] property can also be used to add more detail." ;
 .
 
-sdo:Recommendation
+schema:Recommendation
     rdfs:label "Recommendation" ;
     rdfs:comment "[[Recommendation]] is a type of [[Review]] that suggests or proposes something as the best option or best course of action. Recommendations may be for products or services, or other concrete things, as in the case of a ranked list or product guide. A [[Guide]] may list multiple recommendations for different categories. For example, in a [[Guide]] about which TVs to buy, the author may have several [[Recommendation]]s." ;
 .
 
-sdo:RecommendedDoseSchedule
+schema:RecommendedDoseSchedule
     rdfs:label "Recommended  Dose Schedule" ;
     rdfs:comment "A recommended dosing schedule for a drug or supplement as prescribed or recommended by an authority or by the drug/supplement's manufacturer. Capture the recommending authority in the recognizingAuthority property of MedicalEntity." ;
 .
 
-sdo:Recruiting
+schema:Recruiting
     rdfs:label "Recruiting" ;
     rdfs:comment "Recruiting participants." ;
 .
 
-sdo:RecyclingCenter
+schema:RecyclingCenter
     rdfs:label "Recycling Center" ;
     rdfs:comment "A recycling center." ;
 .
 
-sdo:RefundTypeEnumeration
+schema:RefundTypeEnumeration
     rdfs:label "Refund  Type Enumeration" ;
     rdfs:comment "Enumerates several kinds of product return refund types." ;
 .
 
-sdo:RefurbishedCondition
+schema:RefurbishedCondition
     rdfs:label "Refurbished Condition" ;
     rdfs:comment "Indicates that the item is refurbished." ;
 .
 
-sdo:RegisterAction
+schema:RegisterAction
     rdfs:label "Register Action" ;
     rdfs:comment "The act of registering to be a user of a service, product or web page.\\n\\nRelated actions:\\n\\n* [[JoinAction]]: Unlike JoinAction, RegisterAction implies you are registering to be a user of a service, *not* a group/team of people.\\n* [FollowAction]]: Unlike FollowAction, RegisterAction doesn't imply that the agent is expecting to poll for updates from the object.\\n* [[SubscribeAction]]: Unlike SubscribeAction, RegisterAction doesn't imply that the agent is expecting updates from the object." ;
 .
 
-sdo:Registry
+schema:Registry
     rdfs:label "Registry" ;
     rdfs:comment "A registry-based study design." ;
 .
 
-sdo:ReimbursementCap
+schema:ReimbursementCap
     rdfs:label "Reimbursement Cap" ;
     rdfs:comment "The drug's cost represents the maximum reimbursement paid by an insurer for the drug." ;
 .
 
-sdo:RejectAction
+schema:RejectAction
     rdfs:label "Reject Action" ;
     rdfs:comment "The act of rejecting to/adopting an object.\\n\\nRelated actions:\\n\\n* [[AcceptAction]]: The antonym of RejectAction." ;
 .
 
-sdo:RelatedTopicsHealthAspect
+schema:RelatedTopicsHealthAspect
     rdfs:label "Related Topics Health Aspect" ;
     rdfs:comment "Other prominent or relevant topics tied to the main topic." ;
 .
 
-sdo:RemixAlbum
+schema:RemixAlbum
     rdfs:label "Remix Album" ;
     rdfs:comment "RemixAlbum." ;
 .
 
-sdo:Renal
+schema:Renal
     rdfs:label "Renal" ;
     rdfs:comment "A specific branch of medical science that pertains to the study of the kidneys and its respective disease states." ;
 .
 
-sdo:RentAction
+schema:RentAction
     rdfs:label "Rent Action" ;
     rdfs:comment "The act of giving money in return for temporary use, but not ownership, of an object such as a vehicle or property. For example, an agent rents a property from a landlord in exchange for a periodic payment." ;
 .
 
-sdo:RentalCarReservation
+schema:RentalCarReservation
     rdfs:label "Rental  Car Reservation" ;
     rdfs:comment "A reservation for a rental car.\\n\\nNote: This type is for information about actual reservations, e.g. in confirmation emails or HTML pages with individual confirmations of reservations." ;
 .
 
-sdo:RentalVehicleUsage
+schema:RentalVehicleUsage
     rdfs:label "Rental  Vehicle Usage" ;
     rdfs:comment "Indicates the usage of the vehicle as a rental car." ;
 .
 
-sdo:RepaymentSpecification
+schema:RepaymentSpecification
     rdfs:label "Repayment Specification" ;
     rdfs:comment "A structured value representing repayment." ;
 .
 
-sdo:ReplaceAction
+schema:ReplaceAction
     rdfs:label "Replace Action" ;
     rdfs:comment "The act of editing a recipient by replacing an old object with a new object." ;
 .
 
-sdo:ReplyAction
+schema:ReplyAction
     rdfs:label "Reply Action" ;
     rdfs:comment "The act of responding to a question/message asked/sent by the object. Related to [[AskAction]]\\n\\nRelated actions:\\n\\n* [[AskAction]]: Appears generally as an origin of a ReplyAction." ;
 .
 
-sdo:Report
+schema:Report
     rdfs:label "Report" ;
     rdfs:comment "A Report generated by governmental or non-governmental organization." ;
 .
 
-sdo:ReportageNewsArticle
+schema:ReportageNewsArticle
     rdfs:label "Reportage  News Article" ;
     rdfs:comment """The [[ReportageNewsArticle]] type is a subtype of [[NewsArticle]] representing
  news articles which are the result of journalistic news reporting conventions.
@@ -7832,77 +7832,77 @@ A [[ReportageNewsArticle]] which goes deeper into analysis can also be marked wi
 """ ;
 .
 
-sdo:ReportedDoseSchedule
+schema:ReportedDoseSchedule
     rdfs:label "Reported  Dose Schedule" ;
     rdfs:comment "A patient-reported or observed dosing schedule for a drug or supplement." ;
 .
 
-sdo:ResearchOrganization
+schema:ResearchOrganization
     rdfs:label "Research Organization" ;
     rdfs:comment "A Research Organization (e.g. scientific institute, research company)." ;
 .
 
-sdo:ResearchProject
+schema:ResearchProject
     rdfs:label "Research Project" ;
     rdfs:comment "A Research project." ;
 .
 
-sdo:Researcher
+schema:Researcher
     rdfs:label "Researcher" ;
     rdfs:comment "Researchers." ;
 .
 
-sdo:Reservation
+schema:Reservation
     rdfs:label "Reservation" ;
     rdfs:comment "Describes a reservation for travel, dining or an event. Some reservations require tickets. \\n\\nNote: This type is for information about actual reservations, e.g. in confirmation emails or HTML pages with individual confirmations of reservations. For offers of tickets, restaurant reservations, flights, or rental cars, use [[Offer]]." ;
 .
 
-sdo:ReservationCancelled
+schema:ReservationCancelled
     rdfs:label "Reservation Cancelled" ;
     rdfs:comment "The status for a previously confirmed reservation that is now cancelled." ;
 .
 
-sdo:ReservationConfirmed
+schema:ReservationConfirmed
     rdfs:label "Reservation Confirmed" ;
     rdfs:comment "The status of a confirmed reservation." ;
 .
 
-sdo:ReservationHold
+schema:ReservationHold
     rdfs:label "Reservation Hold" ;
     rdfs:comment "The status of a reservation on hold pending an update like credit card number or flight changes." ;
 .
 
-sdo:ReservationPackage
+schema:ReservationPackage
     rdfs:label "Reservation Package" ;
     rdfs:comment "A group of multiple reservations with common values for all sub-reservations." ;
 .
 
-sdo:ReservationPending
+schema:ReservationPending
     rdfs:label "Reservation Pending" ;
     rdfs:comment "The status of a reservation when a request has been sent, but not confirmed." ;
 .
 
-sdo:ReservationStatusType
+schema:ReservationStatusType
     rdfs:label "Reservation  Status Type" ;
     rdfs:comment "Enumerated status values for Reservation." ;
 .
 
-sdo:ReserveAction
+schema:ReserveAction
     rdfs:label "Reserve Action" ;
     rdfs:comment "Reserving a concrete object.\\n\\nRelated actions:\\n\\n* [[ScheduleAction]]: Unlike ScheduleAction, ReserveAction reserves concrete objects (e.g. a table, a hotel) towards a time slot / spatial allocation." ;
 .
 
-sdo:Reservoir
+schema:Reservoir
     rdfs:label "Reservoir" ;
     rdfs:comment "A reservoir of water, typically an artificially created lake, like the Lake Kariba reservoir." ;
 .
 
-sdo:Residence
+schema:Residence
     rdfs:label "Residence" ;
     rdfs:comment "The place where a person lives." ;
 .
 
-sdo:Resort
+schema:Resort
     rdfs:label "Resort" ;
     rdfs:comment """A resort is a place used for relaxation or recreation, attracting visitors for holidays or vacations. Resorts are places, towns or sometimes commercial establishment operated by a single company (Source: Wikipedia, the free encyclopedia, see <a href="http://en.wikipedia.org/wiki/Resort">http://en.wikipedia.org/wiki/Resort</a>).
 <br /><br />
@@ -7910,152 +7910,152 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
     """ ;
 .
 
-sdo:RespiratoryTherapy
+schema:RespiratoryTherapy
     rdfs:label "Respiratory Therapy" ;
     rdfs:comment "The therapy that is concerned with the maintenance or improvement of respiratory function (as in patients with pulmonary disease)." ;
 .
 
-sdo:Restaurant
+schema:Restaurant
     rdfs:label "Restaurant" ;
     rdfs:comment "A restaurant." ;
 .
 
-sdo:RestockingFees
+schema:RestockingFees
     rdfs:label "Restocking Fees" ;
     rdfs:comment "Specifies that the customer must pay a restocking fee when returning a product" ;
 .
 
-sdo:RestrictedDiet
+schema:RestrictedDiet
     rdfs:label "Restricted Diet" ;
     rdfs:comment "A diet restricted to certain foods or preparations for cultural, religious, health or lifestyle reasons. " ;
 .
 
-sdo:ResultsAvailable
+schema:ResultsAvailable
     rdfs:label "Results Available" ;
     rdfs:comment "Results are available." ;
 .
 
-sdo:ResultsNotAvailable
+schema:ResultsNotAvailable
     rdfs:label "Results  Not Available" ;
     rdfs:comment "Results are not available." ;
 .
 
-sdo:ResumeAction
+schema:ResumeAction
     rdfs:label "Resume Action" ;
     rdfs:comment "The act of resuming a device or application which was formerly paused (e.g. resume music playback or resume a timer)." ;
 .
 
-sdo:Retail
+schema:Retail
     rdfs:label "Retail" ;
     rdfs:comment "The drug's cost represents the retail cost of the drug." ;
 .
 
-sdo:ReturnAction
+schema:ReturnAction
     rdfs:label "Return Action" ;
     rdfs:comment "The act of returning to the origin that which was previously received (concrete objects) or taken (ownership)." ;
 .
 
-sdo:ReturnAtKiosk
+schema:ReturnAtKiosk
     rdfs:label "Return  At Kiosk" ;
     rdfs:comment "Specifies that product returns must be made at a kiosk." ;
 .
 
-sdo:ReturnByMail
+schema:ReturnByMail
     rdfs:label "Return  By Mail" ;
     rdfs:comment "Specifies that product returns must to be done by mail." ;
 .
 
-sdo:ReturnFeesCustomerResponsibility
+schema:ReturnFeesCustomerResponsibility
     rdfs:label "Return Fees Customer Responsibility" ;
     rdfs:comment "Specifies that product returns must be paid for, and are the responsibility of, the customer." ;
 .
 
-sdo:ReturnFeesEnumeration
+schema:ReturnFeesEnumeration
     rdfs:label "Return  Fees Enumeration" ;
     rdfs:comment "Enumerates several kinds of policies for product return fees." ;
 .
 
-sdo:ReturnInStore
+schema:ReturnInStore
     rdfs:label "Return  In Store" ;
     rdfs:comment "Specifies that product returns must be made in a store." ;
 .
 
-sdo:ReturnLabelCustomerResponsibility
+schema:ReturnLabelCustomerResponsibility
     rdfs:label "Return Label Customer Responsibility" ;
     rdfs:comment "Indicated that creating a return label is the responsibility of the customer." ;
 .
 
-sdo:ReturnLabelDownloadAndPrint
+schema:ReturnLabelDownloadAndPrint
     rdfs:label "Return LabelDownload And Print" ;
     rdfs:comment "Indicated that a return label must be downloaded and printed by the customer." ;
 .
 
-sdo:ReturnLabelInBox
+schema:ReturnLabelInBox
     rdfs:label "Return Label In Box" ;
     rdfs:comment "Specifies that a return label will be provided by the seller in the shipping box." ;
 .
 
-sdo:ReturnLabelSourceEnumeration
+schema:ReturnLabelSourceEnumeration
     rdfs:label "Return Label Source Enumeration" ;
     rdfs:comment "Enumerates several types of return labels for product returns." ;
 .
 
-sdo:ReturnMethodEnumeration
+schema:ReturnMethodEnumeration
     rdfs:label "Return  Method Enumeration" ;
     rdfs:comment "Enumerates several types of product return methods." ;
 .
 
-sdo:ReturnShippingFees
+schema:ReturnShippingFees
     rdfs:label "Return  Shipping Fees" ;
     rdfs:comment "Specifies that the customer must pay the return shipping costs when returning a product" ;
 .
 
-sdo:Review
+schema:Review
     rdfs:label "Review" ;
     rdfs:comment "A review of an item - for example, of a restaurant, movie, or store." ;
 .
 
-sdo:ReviewAction
+schema:ReviewAction
     rdfs:label "Review Action" ;
     rdfs:comment "The act of producing a balanced opinion about the object for an audience. An agent reviews an object with participants resulting in a review." ;
 .
 
-sdo:ReviewNewsArticle
+schema:ReviewNewsArticle
     rdfs:label "Review  News Article" ;
     rdfs:comment "A [[NewsArticle]] and [[CriticReview]] providing a professional critic's assessment of a service, product, performance, or artistic or literary work." ;
 .
 
-sdo:Rheumatologic
+schema:Rheumatologic
     rdfs:label "Rheumatologic" ;
     rdfs:comment "A specific branch of medical science that deals with the study and treatment of rheumatic, autoimmune or joint diseases." ;
 .
 
-sdo:RightHandDriving
+schema:RightHandDriving
     rdfs:label "Right  Hand Driving" ;
     rdfs:comment "The steering position is on the right side of the vehicle (viewed from the main direction of driving)." ;
 .
 
-sdo:RisksOrComplicationsHealthAspect
+schema:RisksOrComplicationsHealthAspect
     rdfs:label "Risks OrComplications Health Aspect" ;
     rdfs:comment "Information about the risk factors and possible complications that may follow a topic." ;
 .
 
-sdo:RiverBodyOfWater
+schema:RiverBodyOfWater
     rdfs:label "River Body Of Water" ;
     rdfs:comment "A river (for example, the broad majestic Shannon)." ;
 .
 
-sdo:Role
+schema:Role
     rdfs:label "Role" ;
     rdfs:comment "Represents additional information about a relationship or property. For example a Role can be used to say that a 'member' role linking some SportsTeam to a player occurred during a particular time period. Or that a Person's 'actor' role in a Movie was for some particular characterName. Such properties can be attached to a Role entity, which is then associated with the main entities using ordinary properties like 'member' or 'actor'.\\n\\nSee also [blog post](http://blog.schema.org/2014/06/introducing-role.html)." ;
 .
 
-sdo:RoofingContractor
+schema:RoofingContractor
     rdfs:label "Roofing Contractor" ;
     rdfs:comment "A roofing contractor." ;
 .
 
-sdo:Room
+schema:Room
     rdfs:label "Room" ;
     rdfs:comment """A room is a distinguishable space within a structure, usually separated from other spaces by interior walls. (Source: Wikipedia, the free encyclopedia, see <a href="http://en.wikipedia.org/wiki/Room">http://en.wikipedia.org/wiki/Room</a>).
 <br /><br />
@@ -8063,52 +8063,52 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 """ ;
 .
 
-sdo:RsvpAction
+schema:RsvpAction
     rdfs:label "Rsvp Action" ;
     rdfs:comment "The act of notifying an event organizer as to whether you expect to attend the event." ;
 .
 
-sdo:RsvpResponseMaybe
+schema:RsvpResponseMaybe
     rdfs:label "Rsvp  Response Maybe" ;
     rdfs:comment "The invitee may or may not attend." ;
 .
 
-sdo:RsvpResponseNo
+schema:RsvpResponseNo
     rdfs:label "Rsvp  Response No" ;
     rdfs:comment "The invitee will not attend." ;
 .
 
-sdo:RsvpResponseType
+schema:RsvpResponseType
     rdfs:label "Rsvp  Response Type" ;
     rdfs:comment "RsvpResponseType is an enumeration type whose instances represent responding to an RSVP request." ;
 .
 
-sdo:RsvpResponseYes
+schema:RsvpResponseYes
     rdfs:label "Rsvp  Response Yes" ;
     rdfs:comment "The invitee will attend." ;
 .
 
-sdo:SRP
+schema:SRP
     rdfs:label "SRP" ;
     rdfs:comment "Represents the suggested retail price (\"SRP\") of an offered product." ;
 .
 
-sdo:SafetyHealthAspect
+schema:SafetyHealthAspect
     rdfs:label "Safety  Health Aspect" ;
     rdfs:comment "Content about the safety-related aspects of a health topic." ;
 .
 
-sdo:SaleEvent
+schema:SaleEvent
     rdfs:label "Sale Event" ;
     rdfs:comment "Event type: Sales event." ;
 .
 
-sdo:SalePrice
+schema:SalePrice
     rdfs:label "Sale Price" ;
     rdfs:comment "Represents a sale price (usually active for a limited period) of an offered product." ;
 .
 
-sdo:SatireOrParodyContent
+schema:SatireOrParodyContent
     rdfs:label "Satire Or Parody Content" ;
     rdfs:comment """Content coded 'satire or parody content' in a [[MediaReview]], considered in the context of how it was published or shared.
 
@@ -8122,284 +8122,284 @@ For an [[AudioObject]] to be 'satire or parody content': Audio that was created 
 """ ;
 .
 
-sdo:SatiricalArticle
+schema:SatiricalArticle
     rdfs:label "Satirical Article" ;
     rdfs:comment "An [[Article]] whose content is primarily [[satirical]](https://en.wikipedia.org/wiki/Satire) in nature, i.e. unlikely to be literally true. A satirical article is sometimes but not necessarily also a [[NewsArticle]]. [[ScholarlyArticle]]s are also sometimes satirized." ;
 .
 
-sdo:Saturday
+schema:Saturday
     rdfs:label "Saturday" ;
     rdfs:comment "The day of the week between Friday and Sunday." ;
 .
 
-sdo:Schedule
+schema:Schedule
     rdfs:label "Schedule" ;
     rdfs:comment """A schedule defines a repeating time period used to describe a regularly occurring [[Event]]. At a minimum a schedule will specify [[repeatFrequency]] which describes the interval between occurences of the event. Additional information can be provided to specify the schedule more precisely.
       This includes identifying the day(s) of the week or month when the recurring event will take place, in addition to its start and end time. Schedules may also
       have start and end dates to indicate when they are active, e.g. to define a limited calendar of events.""" ;
 .
 
-sdo:ScheduleAction
+schema:ScheduleAction
     rdfs:label "Schedule Action" ;
     rdfs:comment "Scheduling future actions, events, or tasks.\\n\\nRelated actions:\\n\\n* [[ReserveAction]]: Unlike ReserveAction, ScheduleAction allocates future actions (e.g. an event, a task, etc) towards a time slot / spatial allocation." ;
 .
 
-sdo:ScholarlyArticle
+schema:ScholarlyArticle
     rdfs:label "Scholarly Article" ;
     rdfs:comment "A scholarly article." ;
 .
 
-sdo:School
+schema:School
     rdfs:label "School" ;
     rdfs:comment "A school." ;
 .
 
-sdo:SchoolDistrict
+schema:SchoolDistrict
     rdfs:label "School District" ;
     rdfs:comment "A School District is an administrative area for the administration of schools." ;
 .
 
-sdo:ScreeningEvent
+schema:ScreeningEvent
     rdfs:label "Screening Event" ;
     rdfs:comment "A screening of a movie or other video." ;
 .
 
-sdo:ScreeningHealthAspect
+schema:ScreeningHealthAspect
     rdfs:label "Screening  Health Aspect" ;
     rdfs:comment "Content about how to screen or further filter a topic." ;
 .
 
-sdo:Sculpture
+schema:Sculpture
     rdfs:label "Sculpture" ;
     rdfs:comment "A piece of sculpture." ;
 .
 
-sdo:SeaBodyOfWater
+schema:SeaBodyOfWater
     rdfs:label "Sea Body Of Water" ;
     rdfs:comment "A sea (for example, the Caspian sea)." ;
 .
 
-sdo:SearchAction
+schema:SearchAction
     rdfs:label "Search Action" ;
     rdfs:comment "The act of searching for an object.\\n\\nRelated actions:\\n\\n* [[FindAction]]: SearchAction generally leads to a FindAction, but not necessarily." ;
 .
 
-sdo:SearchResultsPage
+schema:SearchResultsPage
     rdfs:label "Search  Results Page" ;
     rdfs:comment "Web page type: Search results page." ;
 .
 
-sdo:Season
+schema:Season
     rdfs:label "Season" ;
     rdfs:comment "A media season e.g. tv, radio, video game etc." ;
 .
 
-sdo:Seat
+schema:Seat
     rdfs:label "Seat" ;
     rdfs:comment "Used to describe a seat, such as a reserved seat in an event reservation." ;
 .
 
-sdo:SeatingMap
+schema:SeatingMap
     rdfs:label "Seating Map" ;
     rdfs:comment "A seating map." ;
 .
 
-sdo:SeeDoctorHealthAspect
+schema:SeeDoctorHealthAspect
     rdfs:label "See Doctor Health Aspect" ;
     rdfs:comment "Information about questions that may be asked, when to see a professional, measures before seeing a doctor or content about the first consultation." ;
 .
 
-sdo:SeekToAction
+schema:SeekToAction
     rdfs:label "Seek  To Action" ;
     rdfs:comment "This is the [[Action]] of navigating to a specific [[startOffset]] timestamp within a [[VideoObject]], typically represented with a URL template structure." ;
 .
 
-sdo:SelfCareHealthAspect
+schema:SelfCareHealthAspect
     rdfs:label "Self Care Health Aspect" ;
     rdfs:comment "Self care actions or measures that can be taken to sooth, health or avoid a topic. This may be carried at home and can be carried/managed by the person itself." ;
 .
 
-sdo:SelfStorage
+schema:SelfStorage
     rdfs:label "Self Storage" ;
     rdfs:comment "A self-storage facility." ;
 .
 
-sdo:SellAction
+schema:SellAction
     rdfs:label "Sell Action" ;
     rdfs:comment "The act of taking money from a buyer in exchange for goods or services rendered. An agent sells an object, product, or service to a buyer for a price. Reciprocal of BuyAction." ;
 .
 
-sdo:SendAction
+schema:SendAction
     rdfs:label "Send Action" ;
     rdfs:comment "The act of physically/electronically dispatching an object for transfer from an origin to a destination.Related actions:\\n\\n* [[ReceiveAction]]: The reciprocal of SendAction.\\n* [[GiveAction]]: Unlike GiveAction, SendAction does not imply the transfer of ownership (e.g. I can send you my laptop, but I'm not necessarily giving it to you)." ;
 .
 
-sdo:Series
+schema:Series
     rdfs:label "Series" ;
     rdfs:comment "A Series in schema.org is a group of related items, typically but not necessarily of the same kind. See also [[CreativeWorkSeries]], [[EventSeries]]." ;
 .
 
-sdo:Service
+schema:Service
     rdfs:label "Service" ;
     rdfs:comment "A service provided by an organization, e.g. delivery service, print services, etc." ;
 .
 
-sdo:ServiceChannel
+schema:ServiceChannel
     rdfs:label "Service Channel" ;
     rdfs:comment "A means for accessing a service, e.g. a government office location, web site, or phone number." ;
 .
 
-sdo:ShareAction
+schema:ShareAction
     rdfs:label "Share Action" ;
     rdfs:comment "The act of distributing content to people for their amusement or edification." ;
 .
 
-sdo:SheetMusic
+schema:SheetMusic
     rdfs:label "Sheet Music" ;
     rdfs:comment "Printed music, as opposed to performed or recorded music." ;
 .
 
-sdo:ShippingDeliveryTime
+schema:ShippingDeliveryTime
     rdfs:label "Shipping  Delivery Time" ;
     rdfs:comment "ShippingDeliveryTime provides various pieces of information about delivery times for shipping." ;
 .
 
-sdo:ShippingRateSettings
+schema:ShippingRateSettings
     rdfs:label "Shipping  Rate Settings" ;
     rdfs:comment "A ShippingRateSettings represents re-usable pieces of shipping information. It is designed for publication on an URL that may be referenced via the [[shippingSettingsLink]] property of an [[OfferShippingDetails]]. Several occurrences can be published, distinguished and matched (i.e. identified/referenced) by their different values for [[shippingLabel]]." ;
 .
 
-sdo:ShoeStore
+schema:ShoeStore
     rdfs:label "Shoe Store" ;
     rdfs:comment "A shoe store." ;
 .
 
-sdo:ShoppingCenter
+schema:ShoppingCenter
     rdfs:label "Shopping Center" ;
     rdfs:comment "A shopping center or mall." ;
 .
 
-sdo:ShortStory
+schema:ShortStory
     rdfs:label "Short Story" ;
     rdfs:comment "Short story or tale. A brief work of literature, usually written in narrative prose." ;
 .
 
-sdo:SideEffectsHealthAspect
+schema:SideEffectsHealthAspect
     rdfs:label "Side Effects Health Aspect" ;
     rdfs:comment "Side effects that can be observed from the usage of the topic." ;
 .
 
-sdo:SingleBlindedTrial
+schema:SingleBlindedTrial
     rdfs:label "Single  Blinded Trial" ;
     rdfs:comment "A trial design in which the researcher knows which treatment the patient was randomly assigned to but the patient does not." ;
 .
 
-sdo:SingleCenterTrial
+schema:SingleCenterTrial
     rdfs:label "Single  Center Trial" ;
     rdfs:comment "A trial that takes place at a single center." ;
 .
 
-sdo:SingleFamilyResidence
+schema:SingleFamilyResidence
     rdfs:label "Single  Family Residence" ;
     rdfs:comment "Residence type: Single-family home." ;
 .
 
-sdo:SinglePlayer
+schema:SinglePlayer
     rdfs:label "Single Player" ;
     rdfs:comment "Play mode: SinglePlayer. Which is played by a lone player." ;
 .
 
-sdo:SingleRelease
+schema:SingleRelease
     rdfs:label "Single Release" ;
     rdfs:comment "SingleRelease." ;
 .
 
-sdo:SiteNavigationElement
+schema:SiteNavigationElement
     rdfs:label "Site  Navigation Element" ;
     rdfs:comment "A navigation element of the page." ;
 .
 
-sdo:SizeGroupEnumeration
+schema:SizeGroupEnumeration
     rdfs:label "Size  Group Enumeration" ;
     rdfs:comment "Enumerates common size groups for various product categories." ;
 .
 
-sdo:SizeSpecification
+schema:SizeSpecification
     rdfs:label "Size Specification" ;
     rdfs:comment "Size related properties of a product, typically a size code ([[name]]) and optionally a [[sizeSystem]], [[sizeGroup]], and product measurements ([[hasMeasurement]]). In addition, the intended audience can be defined through [[suggestedAge]], [[suggestedGender]], and suggested body measurements ([[suggestedMeasurement]])." ;
 .
 
-sdo:SizeSystemEnumeration
+schema:SizeSystemEnumeration
     rdfs:label "Size  System Enumeration" ;
     rdfs:comment "Enumerates common size systems for different categories of products, for example \"EN-13402\" or \"UK\" for wearables or \"Imperial\" for screws." ;
 .
 
-sdo:SizeSystemImperial
+schema:SizeSystemImperial
     rdfs:label "Size  System Imperial" ;
     rdfs:comment "Imperial size system." ;
 .
 
-sdo:SizeSystemMetric
+schema:SizeSystemMetric
     rdfs:label "Size  System Metric" ;
     rdfs:comment "Metric size system." ;
 .
 
-sdo:SkiResort
+schema:SkiResort
     rdfs:label "Ski Resort" ;
     rdfs:comment "A ski resort." ;
 .
 
-sdo:Skin
+schema:Skin
     rdfs:label "Skin" ;
     rdfs:comment "Skin assessment with clinical examination." ;
 .
 
-sdo:SocialEvent
+schema:SocialEvent
     rdfs:label "Social Event" ;
     rdfs:comment "Event type: Social event." ;
 .
 
-sdo:SocialMediaPosting
+schema:SocialMediaPosting
     rdfs:label "Social  Media Posting" ;
     rdfs:comment "A post to a social media platform, including blog posts, tweets, Facebook posts, etc." ;
 .
 
-sdo:SoftwareApplication
+schema:SoftwareApplication
     rdfs:label "Software Application" ;
     rdfs:comment "A software application." ;
 .
 
-sdo:SoftwareSourceCode
+schema:SoftwareSourceCode
     rdfs:label "Software  Source Code" ;
     rdfs:comment "Computer programming source code. Example: Full (compile ready) solutions, code snippet samples, scripts, templates." ;
 .
 
-sdo:SoldOut
+schema:SoldOut
     rdfs:label "Sold Out" ;
     rdfs:comment "Indicates that the item has sold out." ;
 .
 
-sdo:SolveMathAction
+schema:SolveMathAction
     rdfs:label "Solve  Math Action" ;
     rdfs:comment "The action that takes in a math expression and directs users to a page potentially capable of solving/simplifying that expression." ;
 .
 
-sdo:SomeProducts
+schema:SomeProducts
     rdfs:label "Some Products" ;
     rdfs:comment "A placeholder for multiple similar products of the same kind." ;
 .
 
-sdo:SoundtrackAlbum
+schema:SoundtrackAlbum
     rdfs:label "Soundtrack Album" ;
     rdfs:comment "SoundtrackAlbum." ;
 .
 
-sdo:SpeakableSpecification
+schema:SpeakableSpecification
     rdfs:label "Speakable Specification" ;
     rdfs:comment "A SpeakableSpecification indicates (typically via [[xpath]] or [[cssSelector]]) sections of a document that are highlighted as particularly [[speakable]]. Instances of this type are expected to be used primarily as values of the [[speakable]] property." ;
 .
 
-sdo:SpecialAnnouncement
+schema:SpecialAnnouncement
     rdfs:label "Special Announcement" ;
     rdfs:comment """A SpecialAnnouncement combines a simple date-stamped textual information update
       with contextualized Web links and other structured data.  It represents an information update made by a
@@ -8439,62 +8439,62 @@ media type information e.g. "application/rss+xml" or "application/atom+xml".
 """ ;
 .
 
-sdo:Specialty
+schema:Specialty
     rdfs:label "Specialty" ;
     rdfs:comment "Any branch of a field in which people typically develop specific expertise, usually after significant study, time, and effort." ;
 .
 
-sdo:SpeechPathology
+schema:SpeechPathology
     rdfs:label "Speech Pathology" ;
     rdfs:comment "The scientific study and treatment of defects, disorders, and malfunctions of speech and voice, as stuttering, lisping, or lalling, and of language disturbances, as aphasia or delayed language acquisition." ;
 .
 
-sdo:SpokenWordAlbum
+schema:SpokenWordAlbum
     rdfs:label "Spoken Word Album" ;
     rdfs:comment "Spoken Word Album." ;
 .
 
-sdo:SportingGoodsStore
+schema:SportingGoodsStore
     rdfs:label "Sporting Goods Store" ;
     rdfs:comment "A sporting goods store." ;
 .
 
-sdo:SportsActivityLocation
+schema:SportsActivityLocation
     rdfs:label "Sports Activity Location" ;
     rdfs:comment "A sports location, such as a playing field." ;
 .
 
-sdo:SportsClub
+schema:SportsClub
     rdfs:label "Sports Club" ;
     rdfs:comment "A sports club." ;
 .
 
-sdo:SportsEvent
+schema:SportsEvent
     rdfs:label "Sports Event" ;
     rdfs:comment "Event type: Sports event." ;
 .
 
-sdo:SportsOrganization
+schema:SportsOrganization
     rdfs:label "Sports Organization" ;
     rdfs:comment "Represents the collection of all sports organizations, including sports teams, governing bodies, and sports associations." ;
 .
 
-sdo:SportsTeam
+schema:SportsTeam
     rdfs:label "Sports Team" ;
     rdfs:comment "Organization: Sports team." ;
 .
 
-sdo:SpreadsheetDigitalDocument
+schema:SpreadsheetDigitalDocument
     rdfs:label "Spreadsheet Digital Document" ;
     rdfs:comment "A spreadsheet file." ;
 .
 
-sdo:StadiumOrArena
+schema:StadiumOrArena
     rdfs:label "Stadium Or Arena" ;
     rdfs:comment "A stadium." ;
 .
 
-sdo:StagedContent
+schema:StagedContent
     rdfs:label "Staged Content" ;
     rdfs:comment """Content coded 'staged content' in a [[MediaReview]], considered in the context of how it was published or shared.
 
@@ -8508,22 +8508,22 @@ For an [[AudioObject]] to be 'staged content': Audio that has been created using
 """ ;
 .
 
-sdo:StagesHealthAspect
+schema:StagesHealthAspect
     rdfs:label "Stages Health Aspect" ;
     rdfs:comment "Stages that can be observed from a topic." ;
 .
 
-sdo:State
+schema:State
     rdfs:label "State" ;
     rdfs:comment "A state or province of a country." ;
 .
 
-sdo:Statement
+schema:Statement
     rdfs:label "Statement" ;
     rdfs:comment "A statement about something, for example a fun or interesting fact. If known, the main entity this statement is about, can be indicated using mainEntity. For more formal claims (e.g. in Fact Checking), consider using [[Claim]] instead. Use the [[text]] property to capture the text of the statement." ;
 .
 
-sdo:StatisticalPopulation
+schema:StatisticalPopulation
     rdfs:label "Statistical Population" ;
     rdfs:comment """A StatisticalPopulation is a set of instances of a certain given type that satisfy some set of constraints. The property [[populationType]] is used to specify the type. Any property that can be used on instances of that type can appear on the statistical population. For example, a [[StatisticalPopulation]] representing all [[Person]]s with a [[homeLocation]] of East Podunk California, would be described by applying the appropriate [[homeLocation]] and [[populationType]] properties to a [[StatisticalPopulation]] item that stands for that set of people.
 The properties [[numConstraints]] and [[constrainingProperty]] are used to specify which of the populations properties are used to specify the population. Note that the sense of "population" used here is the general sense of a statistical
@@ -8531,62 +8531,62 @@ population, and does not imply that the population consists of people. For examp
   """ ;
 .
 
-sdo:StatusEnumeration
+schema:StatusEnumeration
     rdfs:label "Status Enumeration" ;
     rdfs:comment "Lists or enumerations dealing with status types." ;
 .
 
-sdo:SteeringPositionValue
+schema:SteeringPositionValue
     rdfs:label "Steering Position Value" ;
     rdfs:comment "A value indicating a steering position." ;
 .
 
-sdo:Store
+schema:Store
     rdfs:label "Store" ;
     rdfs:comment "A retail good store." ;
 .
 
-sdo:StoreCreditRefund
+schema:StoreCreditRefund
     rdfs:label "Store Credit Refund" ;
     rdfs:comment "Specifies that the customer receives a store credit as refund when returning a product" ;
 .
 
-sdo:StrengthTraining
+schema:StrengthTraining
     rdfs:label "Strength Training" ;
     rdfs:comment "Physical activity that is engaged in to improve muscle and bone strength. Also referred to as resistance training." ;
 .
 
-sdo:StructuredValue
+schema:StructuredValue
     rdfs:label "Structured Value" ;
     rdfs:comment "Structured values are used when the value of a property has a more complex structure than simply being a textual value or a reference to another thing." ;
 .
 
-sdo:StudioAlbum
+schema:StudioAlbum
     rdfs:label "Studio Album" ;
     rdfs:comment "StudioAlbum." ;
 .
 
-sdo:SubscribeAction
+schema:SubscribeAction
     rdfs:label "Subscribe Action" ;
     rdfs:comment "The act of forming a personal connection with someone/something (object) unidirectionally/asymmetrically to get updates pushed to.\\n\\nRelated actions:\\n\\n* [[FollowAction]]: Unlike FollowAction, SubscribeAction implies that the subscriber acts as a passive agent being constantly/actively pushed for updates.\\n* [[RegisterAction]]: Unlike RegisterAction, SubscribeAction implies that the agent is interested in continuing receiving updates from the object.\\n* [[JoinAction]]: Unlike JoinAction, SubscribeAction implies that the agent is interested in continuing receiving updates from the object." ;
 .
 
-sdo:Subscription
+schema:Subscription
     rdfs:label "Subscription" ;
     rdfs:comment "Represents the subscription pricing component of the total price for an offered product." ;
 .
 
-sdo:Substance
+schema:Substance
     rdfs:label "Substance" ;
     rdfs:comment "Any matter of defined composition that has discrete existence, whose origin may be biological, mineral or chemical." ;
 .
 
-sdo:SubwayStation
+schema:SubwayStation
     rdfs:label "Subway Station" ;
     rdfs:comment "A subway station." ;
 .
 
-sdo:Suite
+schema:Suite
     rdfs:label "Suite" ;
     rdfs:comment """A suite in a hotel or other public accommodation, denotes a class of luxury accommodations, the key feature of which is multiple rooms (Source: Wikipedia, the free encyclopedia, see <a href="http://en.wikipedia.org/wiki/Suite_(hotel)">http://en.wikipedia.org/wiki/Suite_(hotel)</a>).
 <br /><br />
@@ -8594,284 +8594,284 @@ See also the <a href="/docs/hotels.html">dedicated document on the use of schema
 """ ;
 .
 
-sdo:Sunday
+schema:Sunday
     rdfs:label "Sunday" ;
     rdfs:comment "The day of the week between Saturday and Monday." ;
 .
 
-sdo:SuperficialAnatomy
+schema:SuperficialAnatomy
     rdfs:label "Superficial Anatomy" ;
     rdfs:comment "Anatomical features that can be observed by sight (without dissection), including the form and proportions of the human body as well as surface landmarks that correspond to deeper subcutaneous structures. Superficial anatomy plays an important role in sports medicine, phlebotomy, and other medical specialties as underlying anatomical structures can be identified through surface palpation. For example, during back surgery, superficial anatomy can be used to palpate and count vertebrae to find the site of incision. Or in phlebotomy, superficial anatomy can be used to locate an underlying vein; for example, the median cubital vein can be located by palpating the borders of the cubital fossa (such as the epicondyles of the humerus) and then looking for the superficial signs of the vein, such as size, prominence, ability to refill after depression, and feel of surrounding tissue support. As another example, in a subluxation (dislocation) of the glenohumeral joint, the bony structure becomes pronounced with the deltoid muscle failing to cover the glenohumeral joint allowing the edges of the scapula to be superficially visible. Here, the superficial anatomy is the visible edges of the scapula, implying the underlying dislocation of the joint (the related anatomical structure)." ;
 .
 
-sdo:Surgical
+schema:Surgical
     rdfs:label "Surgical" ;
     rdfs:comment "A specific branch of medical science that pertains to treating diseases, injuries and deformities by manual and instrumental means." ;
 .
 
-sdo:SurgicalProcedure
+schema:SurgicalProcedure
     rdfs:label "Surgical Procedure" ;
     rdfs:comment "A medical procedure involving an incision with instruments; performed for diagnose, or therapeutic purposes." ;
 .
 
-sdo:SuspendAction
+schema:SuspendAction
     rdfs:label "Suspend Action" ;
     rdfs:comment "The act of momentarily pausing a device or application (e.g. pause music playback or pause a timer)." ;
 .
 
-sdo:Suspended
+schema:Suspended
     rdfs:label "Suspended" ;
     rdfs:comment "Suspended." ;
 .
 
-sdo:SymptomsHealthAspect
+schema:SymptomsHealthAspect
     rdfs:label "Symptoms Health Aspect" ;
     rdfs:comment "Symptoms or related symptoms of a Topic." ;
 .
 
-sdo:Synagogue
+schema:Synagogue
     rdfs:label "Synagogue" ;
     rdfs:comment "A synagogue." ;
 .
 
-sdo:TVClip
+schema:TVClip
     rdfs:label "TVClip" ;
     rdfs:comment "A short TV program or a segment/part of a TV program." ;
 .
 
-sdo:TVEpisode
+schema:TVEpisode
     rdfs:label "TVEpisode" ;
     rdfs:comment "A TV episode which can be part of a series or season." ;
 .
 
-sdo:TVSeason
+schema:TVSeason
     rdfs:label "TVSeason" ;
     rdfs:comment "Season dedicated to TV broadcast and associated online delivery." ;
 .
 
-sdo:TVSeries
+schema:TVSeries
     rdfs:label "TVSeries" ;
     rdfs:comment "CreativeWorkSeries dedicated to TV broadcast and associated online delivery." ;
 .
 
-sdo:Table
+schema:Table
     rdfs:label "Table" ;
     rdfs:comment "A table on a Web page." ;
 .
 
-sdo:TakeAction
+schema:TakeAction
     rdfs:label "Take Action" ;
     rdfs:comment "The act of gaining ownership of an object from an origin. Reciprocal of GiveAction.\\n\\nRelated actions:\\n\\n* [[GiveAction]]: The reciprocal of TakeAction.\\n* [[ReceiveAction]]: Unlike ReceiveAction, TakeAction implies that ownership has been transfered." ;
 .
 
-sdo:TattooParlor
+schema:TattooParlor
     rdfs:label "Tattoo Parlor" ;
     rdfs:comment "A tattoo parlor." ;
 .
 
-sdo:Taxi
+schema:Taxi
     rdfs:label "Taxi" ;
     rdfs:comment "A taxi." ;
 .
 
-sdo:TaxiReservation
+schema:TaxiReservation
     rdfs:label "Taxi Reservation" ;
     rdfs:comment "A reservation for a taxi.\\n\\nNote: This type is for information about actual reservations, e.g. in confirmation emails or HTML pages with individual confirmations of reservations. For offers of tickets, use [[Offer]]." ;
 .
 
-sdo:TaxiService
+schema:TaxiService
     rdfs:label "Taxi Service" ;
     rdfs:comment "A service for a vehicle for hire with a driver for local travel. Fares are usually calculated based on distance traveled." ;
 .
 
-sdo:TaxiStand
+schema:TaxiStand
     rdfs:label "Taxi Stand" ;
     rdfs:comment "A taxi stand." ;
 .
 
-sdo:TaxiVehicleUsage
+schema:TaxiVehicleUsage
     rdfs:label "Taxi Vehicle Usage" ;
     rdfs:comment "Indicates the usage of the car as a taxi." ;
 .
 
-sdo:Taxon
+schema:Taxon
     rdfs:label "Taxon" ;
     rdfs:comment "A set of organisms asserted to represent a natural cohesive biological unit." ;
 .
 
-sdo:TechArticle
+schema:TechArticle
     rdfs:label "Tech Article" ;
     rdfs:comment "A technical article - Example: How-to (task) topics, step-by-step, procedural troubleshooting, specifications, etc." ;
 .
 
-sdo:TelevisionChannel
+schema:TelevisionChannel
     rdfs:label "Television Channel" ;
     rdfs:comment "A unique instance of a television BroadcastService on a CableOrSatelliteService lineup." ;
 .
 
-sdo:TelevisionStation
+schema:TelevisionStation
     rdfs:label "Television Station" ;
     rdfs:comment "A television station." ;
 .
 
-sdo:TennisComplex
+schema:TennisComplex
     rdfs:label "Tennis Complex" ;
     rdfs:comment "A tennis complex." ;
 .
 
-sdo:Terminated
+schema:Terminated
     rdfs:label "Terminated" ;
     rdfs:comment "Terminated." ;
 .
 
-sdo:Text
+schema:Text
     rdfs:label "Text" ;
     rdfs:comment "Data type: Text." ;
 .
 
-sdo:TextDigitalDocument
+schema:TextDigitalDocument
     rdfs:label "Text Digital Document" ;
     rdfs:comment "A file composed primarily of text." ;
 .
 
-sdo:TheaterEvent
+schema:TheaterEvent
     rdfs:label "Theater Event" ;
     rdfs:comment "Event type: Theater performance." ;
 .
 
-sdo:TheaterGroup
+schema:TheaterGroup
     rdfs:label "Theater Group" ;
     rdfs:comment "A theater group or company, for example, the Royal Shakespeare Company or Druid Theatre." ;
 .
 
-sdo:Therapeutic
+schema:Therapeutic
     rdfs:label "Therapeutic" ;
     rdfs:comment "A medical device used for therapeutic purposes." ;
 .
 
-sdo:TherapeuticProcedure
+schema:TherapeuticProcedure
     rdfs:label "Therapeutic Procedure" ;
     rdfs:comment "A medical procedure intended primarily for therapeutic purposes, aimed at improving a health condition." ;
 .
 
-sdo:Thesis
+schema:Thesis
     rdfs:label "Thesis" ;
     rdfs:comment "A thesis or dissertation document submitted in support of candidature for an academic degree or professional qualification." ;
 .
 
-sdo:Thing
+schema:Thing
     rdfs:label "Thing" ;
     rdfs:comment "The most generic type of item." ;
 .
 
-sdo:Throat
+schema:Throat
     rdfs:label "Throat" ;
     rdfs:comment "Throat assessment with  clinical examination." ;
 .
 
-sdo:Thursday
+schema:Thursday
     rdfs:label "Thursday" ;
     rdfs:comment "The day of the week between Wednesday and Friday." ;
 .
 
-sdo:Ticket
+schema:Ticket
     rdfs:label "Ticket" ;
     rdfs:comment "Used to describe a ticket to an event, a flight, a bus ride, etc." ;
 .
 
-sdo:TieAction
+schema:TieAction
     rdfs:label "Tie Action" ;
     rdfs:comment "The act of reaching a draw in a competitive activity." ;
 .
 
-sdo:Time
+schema:Time
     rdfs:label "Time" ;
     rdfs:comment "A point in time recurring on multiple days in the form hh:mm:ss[Z|(+|-)hh:mm] (see [XML schema for details](http://www.w3.org/TR/xmlschema-2/#time))." ;
 .
 
-sdo:TipAction
+schema:TipAction
     rdfs:label "Tip Action" ;
     rdfs:comment "The act of giving money voluntarily to a beneficiary in recognition of services rendered." ;
 .
 
-sdo:TireShop
+schema:TireShop
     rdfs:label "Tire Shop" ;
     rdfs:comment "A tire shop." ;
 .
 
-sdo:TollFree
+schema:TollFree
     rdfs:label "Toll Free" ;
     rdfs:comment "The associated telephone number is toll free." ;
 .
 
-sdo:TouristAttraction
+schema:TouristAttraction
     rdfs:label "Tourist Attraction" ;
     rdfs:comment "A tourist attraction.  In principle any Thing can be a [[TouristAttraction]], from a [[Mountain]] and [[LandmarksOrHistoricalBuildings]] to a [[LocalBusiness]].  This Type can be used on its own to describe a general [[TouristAttraction]], or be used as an [[additionalType]] to add tourist attraction properties to any other type.  (See examples below)" ;
 .
 
-sdo:TouristDestination
+schema:TouristDestination
     rdfs:label "Tourist Destination" ;
     rdfs:comment """A tourist destination. In principle any [[Place]] can be a [[TouristDestination]] from a [[City]], Region or [[Country]] to an [[AmusementPark]] or [[Hotel]]. This Type can be used on its own to describe a general [[TouristDestination]], or be used as an [[additionalType]] to add tourist relevant properties to any other [[Place]].  A [[TouristDestination]] is defined as a [[Place]] that contains, or is colocated with, one or more [[TouristAttraction]]s, often linked by a similar theme or interest to a particular [[touristType]]. The [UNWTO](http://www2.unwto.org/) defines Destination (main destination of a tourism trip) as the place visited that is central to the decision to take the trip.
   (See examples below).""" ;
 .
 
-sdo:TouristInformationCenter
+schema:TouristInformationCenter
     rdfs:label "Tourist  Information Center" ;
     rdfs:comment "A tourist information center." ;
 .
 
-sdo:TouristTrip
+schema:TouristTrip
     rdfs:label "Tourist Trip" ;
     rdfs:comment """A tourist trip. A created itinerary of visits to one or more places of interest ([[TouristAttraction]]/[[TouristDestination]]) often linked by a similar theme, geographic area, or interest to a particular [[touristType]]. The [UNWTO](http://www2.unwto.org/) defines tourism trip as the Trip taken by visitors.
   (See examples below).""" ;
 .
 
-sdo:Toxicologic
+schema:Toxicologic
     rdfs:label "Toxicologic" ;
     rdfs:comment "A specific branch of medical science that is concerned with poisons, their nature, effects and detection and involved in the treatment of poisoning." ;
 .
 
-sdo:ToyStore
+schema:ToyStore
     rdfs:label "Toy Store" ;
     rdfs:comment "A toy store." ;
 .
 
-sdo:TrackAction
+schema:TrackAction
     rdfs:label "Track Action" ;
     rdfs:comment "An agent tracks an object for updates.\\n\\nRelated actions:\\n\\n* [[FollowAction]]: Unlike FollowAction, TrackAction refers to the interest on the location of innanimates objects.\\n* [[SubscribeAction]]: Unlike SubscribeAction, TrackAction refers to  the interest on the location of innanimate objects." ;
 .
 
-sdo:TradeAction
+schema:TradeAction
     rdfs:label "Trade Action" ;
     rdfs:comment "The act of participating in an exchange of goods and services for monetary compensation. An agent trades an object, product or service with a participant in exchange for a one time or periodic payment." ;
 .
 
-sdo:TraditionalChinese
+schema:TraditionalChinese
     rdfs:label "Traditional Chinese" ;
     rdfs:comment "A system of medicine based on common theoretical concepts that originated in China and evolved over thousands of years, that uses herbs, acupuncture, exercise, massage, dietary therapy, and other methods to treat a wide range of conditions." ;
 .
 
-sdo:TrainReservation
+schema:TrainReservation
     rdfs:label "Train Reservation" ;
     rdfs:comment "A reservation for train travel.\\n\\nNote: This type is for information about actual reservations, e.g. in confirmation emails or HTML pages with individual confirmations of reservations. For offers of tickets, use [[Offer]]." ;
 .
 
-sdo:TrainStation
+schema:TrainStation
     rdfs:label "Train Station" ;
     rdfs:comment "A train station." ;
 .
 
-sdo:TrainTrip
+schema:TrainTrip
     rdfs:label "Train Trip" ;
     rdfs:comment "A trip on a commercial train line." ;
 .
 
-sdo:TransferAction
+schema:TransferAction
     rdfs:label "Transfer Action" ;
     rdfs:comment "The act of transferring/moving (abstract or concrete) animate or inanimate objects from one place to another." ;
 .
 
-sdo:TransformedContent
+schema:TransformedContent
     rdfs:label "Transformed Content" ;
     rdfs:comment """Content coded 'transformed content' in a [[MediaReview]], considered in the context of how it was published or shared.
 
@@ -8885,2197 +8885,2197 @@ For an [[AudioObject]] to be 'transformed content': Part or all of the audio has
 """ ;
 .
 
-sdo:TransitMap
+schema:TransitMap
     rdfs:label "Transit Map" ;
     rdfs:comment "A transit map." ;
 .
 
-sdo:TravelAction
+schema:TravelAction
     rdfs:label "Travel Action" ;
     rdfs:comment "The act of traveling from an fromLocation to a destination by a specified mode of transport, optionally with participants." ;
 .
 
-sdo:TravelAgency
+schema:TravelAgency
     rdfs:label "Travel Agency" ;
     rdfs:comment "A travel agency." ;
 .
 
-sdo:TreatmentIndication
+schema:TreatmentIndication
     rdfs:label "Treatment Indication" ;
     rdfs:comment "An indication for treating an underlying condition, symptom, etc." ;
 .
 
-sdo:TreatmentsHealthAspect
+schema:TreatmentsHealthAspect
     rdfs:label "Treatments  Health Aspect" ;
     rdfs:comment "Treatments or related therapies for a Topic." ;
 .
 
-sdo:Trip
+schema:Trip
     rdfs:label "Trip" ;
     rdfs:comment "A trip or journey. An itinerary of visits to one or more places." ;
 .
 
-sdo:TripleBlindedTrial
+schema:TripleBlindedTrial
     rdfs:label "Triple  Blinded Trial" ;
     rdfs:comment "A trial design in which neither the researcher, the person administering the therapy nor the patient knows the details of the treatment the patient was randomly assigned to." ;
 .
 
-sdo:True
+schema:True
     rdfs:label "True" ;
     rdfs:comment "The boolean value true." ;
 .
 
-sdo:Tuesday
+schema:Tuesday
     rdfs:label "Tuesday" ;
     rdfs:comment "The day of the week between Monday and Wednesday." ;
 .
 
-sdo:TypeAndQuantityNode
+schema:TypeAndQuantityNode
     rdfs:label "Type And Quantity Node" ;
     rdfs:comment "A structured value indicating the quantity, unit of measurement, and business function of goods included in a bundle offer." ;
 .
 
-sdo:TypesHealthAspect
+schema:TypesHealthAspect
     rdfs:label "Types  Health Aspect" ;
     rdfs:comment "Categorization and other types related to a topic." ;
 .
 
-sdo:UKNonprofitType
+schema:UKNonprofitType
     rdfs:label "UK Nonprofit Type" ;
     rdfs:comment "UKNonprofitType: Non-profit organization type originating from the United Kingdom." ;
 .
 
-sdo:UKTrust
+schema:UKTrust
     rdfs:label "UKTrust" ;
     rdfs:comment "UKTrust: Non-profit type referring to a UK trust." ;
 .
 
-sdo:URL
+schema:URL
     rdfs:label "URL" ;
     rdfs:comment "Data type: URL." ;
 .
 
-sdo:USNonprofitType
+schema:USNonprofitType
     rdfs:label "US Nonprofit Type" ;
     rdfs:comment "USNonprofitType: Non-profit organization type originating from the United States." ;
 .
 
-sdo:Ultrasound
+schema:Ultrasound
     rdfs:label "Ultrasound" ;
     rdfs:comment "Ultrasound imaging." ;
 .
 
-sdo:UnRegisterAction
+schema:UnRegisterAction
     rdfs:label "Un  Register Action" ;
     rdfs:comment "The act of un-registering from a service.\\n\\nRelated actions:\\n\\n* [[RegisterAction]]: antonym of UnRegisterAction.\\n* [[LeaveAction]]: Unlike LeaveAction, UnRegisterAction implies that you are unregistering from a service you werer previously registered, rather than leaving a team/group of people." ;
 .
 
-sdo:UnemploymentSupport
+schema:UnemploymentSupport
     rdfs:label "Unemployment Support" ;
     rdfs:comment "UnemploymentSupport: this is a benefit for unemployment support." ;
 .
 
-sdo:UnincorporatedAssociationCharity
+schema:UnincorporatedAssociationCharity
     rdfs:label "Unincorporated  Association Charity" ;
     rdfs:comment "UnincorporatedAssociationCharity: Non-profit type referring to a charitable company that is not incorporated (UK)." ;
 .
 
-sdo:UnitPriceSpecification
+schema:UnitPriceSpecification
     rdfs:label "Unit  Price Specification" ;
     rdfs:comment "The price asked for a given offer by the respective organization or person." ;
 .
 
-sdo:UnofficialLegalValue
+schema:UnofficialLegalValue
     rdfs:label "Unofficial  Legal Value" ;
     rdfs:comment "Indicates that a document has no particular or special standing (e.g. a republication of a law by a private publisher)." ;
 .
 
-sdo:UpdateAction
+schema:UpdateAction
     rdfs:label "Update Action" ;
     rdfs:comment "The act of managing by changing/editing the state of the object." ;
 .
 
-sdo:Urologic
+schema:Urologic
     rdfs:label "Urologic" ;
     rdfs:comment "A specific branch of medical science that is concerned with the diagnosis and treatment of diseases pertaining to the urinary tract and the urogenital system." ;
 .
 
-sdo:UsageOrScheduleHealthAspect
+schema:UsageOrScheduleHealthAspect
     rdfs:label "Usage OrSchedule Health Aspect" ;
     rdfs:comment "Content about how, when, frequency and dosage of a topic." ;
 .
 
-sdo:UseAction
+schema:UseAction
     rdfs:label "Use Action" ;
     rdfs:comment "The act of applying an object to its intended purpose." ;
 .
 
-sdo:UsedCondition
+schema:UsedCondition
     rdfs:label "Used Condition" ;
     rdfs:comment "Indicates that the item is used." ;
 .
 
-sdo:UserBlocks
+schema:UserBlocks
     rdfs:label "User Blocks" ;
     rdfs:comment "UserInteraction and its subtypes is an old way of talking about users interacting with pages. It is generally better to use [[Action]]-based vocabulary, alongside types such as [[Comment]]." ;
 .
 
-sdo:UserCheckins
+schema:UserCheckins
     rdfs:label "User Checkins" ;
     rdfs:comment "UserInteraction and its subtypes is an old way of talking about users interacting with pages. It is generally better to use [[Action]]-based vocabulary, alongside types such as [[Comment]]." ;
 .
 
-sdo:UserComments
+schema:UserComments
     rdfs:label "User Comments" ;
     rdfs:comment "UserInteraction and its subtypes is an old way of talking about users interacting with pages. It is generally better to use [[Action]]-based vocabulary, alongside types such as [[Comment]]." ;
 .
 
-sdo:UserDownloads
+schema:UserDownloads
     rdfs:label "User Downloads" ;
     rdfs:comment "UserInteraction and its subtypes is an old way of talking about users interacting with pages. It is generally better to use [[Action]]-based vocabulary, alongside types such as [[Comment]]." ;
 .
 
-sdo:UserInteraction
+schema:UserInteraction
     rdfs:label "User Interaction" ;
     rdfs:comment "UserInteraction and its subtypes is an old way of talking about users interacting with pages. It is generally better to use [[Action]]-based vocabulary, alongside types such as [[Comment]]." ;
 .
 
-sdo:UserLikes
+schema:UserLikes
     rdfs:label "User Likes" ;
     rdfs:comment "UserInteraction and its subtypes is an old way of talking about users interacting with pages. It is generally better to use [[Action]]-based vocabulary, alongside types such as [[Comment]]." ;
 .
 
-sdo:UserPageVisits
+schema:UserPageVisits
     rdfs:label "User  Page Visits" ;
     rdfs:comment "UserInteraction and its subtypes is an old way of talking about users interacting with pages. It is generally better to use [[Action]]-based vocabulary, alongside types such as [[Comment]]." ;
 .
 
-sdo:UserPlays
+schema:UserPlays
     rdfs:label "User Plays" ;
     rdfs:comment "UserInteraction and its subtypes is an old way of talking about users interacting with pages. It is generally better to use [[Action]]-based vocabulary, alongside types such as [[Comment]]." ;
 .
 
-sdo:UserPlusOnes
+schema:UserPlusOnes
     rdfs:label "User  Plus Ones" ;
     rdfs:comment "UserInteraction and its subtypes is an old way of talking about users interacting with pages. It is generally better to use [[Action]]-based vocabulary, alongside types such as [[Comment]]." ;
 .
 
-sdo:UserReview
+schema:UserReview
     rdfs:label "User Review" ;
     rdfs:comment "A review created by an end-user (e.g. consumer, purchaser, attendee etc.), in contrast with [[CriticReview]]." ;
 .
 
-sdo:UserTweets
+schema:UserTweets
     rdfs:label "User Tweets" ;
     rdfs:comment "UserInteraction and its subtypes is an old way of talking about users interacting with pages. It is generally better to use [[Action]]-based vocabulary, alongside types such as [[Comment]]." ;
 .
 
-sdo:VeganDiet
+schema:VeganDiet
     rdfs:label "Vegan Diet" ;
     rdfs:comment "A diet exclusive of all animal products." ;
 .
 
-sdo:VegetarianDiet
+schema:VegetarianDiet
     rdfs:label "Vegetarian Diet" ;
     rdfs:comment "A diet exclusive of animal meat." ;
 .
 
-sdo:Vehicle
+schema:Vehicle
     rdfs:label "Vehicle" ;
     rdfs:comment "A vehicle is a device that is designed or used to transport people or cargo over land, water, air, or through space." ;
 .
 
-sdo:Vein
+schema:Vein
     rdfs:label "Vein" ;
     rdfs:comment "A type of blood vessel that specifically carries blood to the heart." ;
 .
 
-sdo:VenueMap
+schema:VenueMap
     rdfs:label "Venue Map" ;
     rdfs:comment "A venue map (e.g. for malls, auditoriums, museums, etc.)." ;
 .
 
-sdo:Vessel
+schema:Vessel
     rdfs:label "Vessel" ;
     rdfs:comment "A component of the human body circulatory system comprised of an intricate network of hollow tubes that transport blood throughout the entire body." ;
 .
 
-sdo:VeterinaryCare
+schema:VeterinaryCare
     rdfs:label "Veterinary Care" ;
     rdfs:comment "A vet's office." ;
 .
 
-sdo:VideoGallery
+schema:VideoGallery
     rdfs:label "Video Gallery" ;
     rdfs:comment "Web page type: Video gallery page." ;
 .
 
-sdo:VideoGame
+schema:VideoGame
     rdfs:label "Video Game" ;
     rdfs:comment "A video game is an electronic game that involves human interaction with a user interface to generate visual feedback on a video device." ;
 .
 
-sdo:VideoGameClip
+schema:VideoGameClip
     rdfs:label "Video  Game Clip" ;
     rdfs:comment "A short segment/part of a video game." ;
 .
 
-sdo:VideoGameSeries
+schema:VideoGameSeries
     rdfs:label "Video  Game Series" ;
     rdfs:comment "A video game series." ;
 .
 
-sdo:VideoObject
+schema:VideoObject
     rdfs:label "Video Object" ;
     rdfs:comment "A video file." ;
 .
 
-sdo:VideoObjectSnapshot
+schema:VideoObjectSnapshot
     rdfs:label "Video  Object Snapshot" ;
     rdfs:comment "A specific and exact (byte-for-byte) version of a [[VideoObject]]. Two byte-for-byte identical files, for the purposes of this type, considered identical. If they have different embedded metadata the files will differ. Different external facts about the files, e.g. creator or dateCreated that aren't represented in their actual content, do not affect this notion of identity." ;
 .
 
-sdo:ViewAction
+schema:ViewAction
     rdfs:label "View Action" ;
     rdfs:comment "The act of consuming static visual content." ;
 .
 
-sdo:VinylFormat
+schema:VinylFormat
     rdfs:label "Vinyl Format" ;
     rdfs:comment "VinylFormat." ;
 .
 
-sdo:VirtualLocation
+schema:VirtualLocation
     rdfs:label "Virtual Location" ;
     rdfs:comment "An online or virtual location for attending events. For example, one may attend an online seminar or educational event. While a virtual location may be used as the location of an event, virtual locations should not be confused with physical locations in the real world." ;
 .
 
-sdo:Virus
+schema:Virus
     rdfs:label "Virus" ;
     rdfs:comment "Pathogenic virus that causes viral infection." ;
 .
 
-sdo:VisualArtsEvent
+schema:VisualArtsEvent
     rdfs:label "Visual  Arts Event" ;
     rdfs:comment "Event type: Visual arts event." ;
 .
 
-sdo:VisualArtwork
+schema:VisualArtwork
     rdfs:label "Visual Artwork" ;
     rdfs:comment "A work of art that is primarily visual in character." ;
 .
 
-sdo:VitalSign
+schema:VitalSign
     rdfs:label "Vital Sign" ;
     rdfs:comment "Vital signs are measures of various physiological functions in order to assess the most basic body functions." ;
 .
 
-sdo:Volcano
+schema:Volcano
     rdfs:label "Volcano" ;
     rdfs:comment "A volcano, like Fuji san." ;
 .
 
-sdo:VoteAction
+schema:VoteAction
     rdfs:label "Vote Action" ;
     rdfs:comment "The act of expressing a preference from a fixed/finite/structured set of choices/options." ;
 .
 
-sdo:WPAdBlock
+schema:WPAdBlock
     rdfs:label "WP Ad Block" ;
     rdfs:comment "An advertising section of the page." ;
 .
 
-sdo:WPFooter
+schema:WPFooter
     rdfs:label "WPFooter" ;
     rdfs:comment "The footer section of the page." ;
 .
 
-sdo:WPHeader
+schema:WPHeader
     rdfs:label "WPHeader" ;
     rdfs:comment "The header section of the page." ;
 .
 
-sdo:WPSideBar
+schema:WPSideBar
     rdfs:label "WP Side Bar" ;
     rdfs:comment "A sidebar section of the page." ;
 .
 
-sdo:WantAction
+schema:WantAction
     rdfs:label "Want Action" ;
     rdfs:comment "The act of expressing a desire about the object. An agent wants an object." ;
 .
 
-sdo:WarrantyPromise
+schema:WarrantyPromise
     rdfs:label "Warranty Promise" ;
     rdfs:comment "A structured value representing the duration and scope of services that will be provided to a customer free of charge in case of a defect or malfunction of a product." ;
 .
 
-sdo:WarrantyScope
+schema:WarrantyScope
     rdfs:label "Warranty Scope" ;
     rdfs:comment """A range of of services that will be provided to a customer free of charge in case of a defect or malfunction of a product.\\n\\nCommonly used values:\\n\\n* http://purl.org/goodrelations/v1#Labor-BringIn\\n* http://purl.org/goodrelations/v1#PartsAndLabor-BringIn\\n* http://purl.org/goodrelations/v1#PartsAndLabor-PickUp
       """ ;
 .
 
-sdo:WatchAction
+schema:WatchAction
     rdfs:label "Watch Action" ;
     rdfs:comment "The act of consuming dynamic/moving visual content." ;
 .
 
-sdo:Waterfall
+schema:Waterfall
     rdfs:label "Waterfall" ;
     rdfs:comment "A waterfall, like Niagara." ;
 .
 
-sdo:WearAction
+schema:WearAction
     rdfs:label "Wear Action" ;
     rdfs:comment "The act of dressing oneself in clothing." ;
 .
 
-sdo:WearableMeasurementBack
+schema:WearableMeasurementBack
     rdfs:label "Wearable  Measurement Back" ;
     rdfs:comment "Measurement of the back section, for example of a jacket" ;
 .
 
-sdo:WearableMeasurementChestOrBust
+schema:WearableMeasurementChestOrBust
     rdfs:label "Wearable MeasurementChest Or Bust" ;
     rdfs:comment "Measurement of the chest/bust section, for example of a suit" ;
 .
 
-sdo:WearableMeasurementCollar
+schema:WearableMeasurementCollar
     rdfs:label "Wearable  Measurement Collar" ;
     rdfs:comment "Measurement of the collar, for example of a shirt" ;
 .
 
-sdo:WearableMeasurementCup
+schema:WearableMeasurementCup
     rdfs:label "Wearable  Measurement Cup" ;
     rdfs:comment "Measurement of the cup, for example of a bra" ;
 .
 
-sdo:WearableMeasurementHeight
+schema:WearableMeasurementHeight
     rdfs:label "Wearable  Measurement Height" ;
     rdfs:comment "Measurement of the height, for example the heel height of a shoe" ;
 .
 
-sdo:WearableMeasurementHips
+schema:WearableMeasurementHips
     rdfs:label "Wearable  Measurement Hips" ;
     rdfs:comment "Measurement of the hip section, for example of a skirt" ;
 .
 
-sdo:WearableMeasurementInseam
+schema:WearableMeasurementInseam
     rdfs:label "Wearable  Measurement Inseam" ;
     rdfs:comment "Measurement of the inseam, for example of pants" ;
 .
 
-sdo:WearableMeasurementLength
+schema:WearableMeasurementLength
     rdfs:label "Wearable  Measurement Length" ;
     rdfs:comment "Represents the length, for example of a dress" ;
 .
 
-sdo:WearableMeasurementOutsideLeg
+schema:WearableMeasurementOutsideLeg
     rdfs:label "Wearable Measurement Outside Leg" ;
     rdfs:comment "Measurement of the outside leg, for example of pants" ;
 .
 
-sdo:WearableMeasurementSleeve
+schema:WearableMeasurementSleeve
     rdfs:label "Wearable  Measurement Sleeve" ;
     rdfs:comment "Measurement of the sleeve length, for example of a shirt" ;
 .
 
-sdo:WearableMeasurementTypeEnumeration
+schema:WearableMeasurementTypeEnumeration
     rdfs:label "Wearable Measurement Type Enumeration" ;
     rdfs:comment "Enumerates common types of measurement for wearables products." ;
 .
 
-sdo:WearableMeasurementWaist
+schema:WearableMeasurementWaist
     rdfs:label "Wearable  Measurement Waist" ;
     rdfs:comment "Measurement of the waist section, for example of pants" ;
 .
 
-sdo:WearableMeasurementWidth
+schema:WearableMeasurementWidth
     rdfs:label "Wearable  Measurement Width" ;
     rdfs:comment "Measurement of the width, for example of shoes" ;
 .
 
-sdo:WearableSizeGroupBig
+schema:WearableSizeGroupBig
     rdfs:label "Wearable Size Group Big" ;
     rdfs:comment "Size group \"Big\" for wearables." ;
 .
 
-sdo:WearableSizeGroupBoys
+schema:WearableSizeGroupBoys
     rdfs:label "Wearable Size Group Boys" ;
     rdfs:comment "Size group \"Boys\" for wearables." ;
 .
 
-sdo:WearableSizeGroupEnumeration
+schema:WearableSizeGroupEnumeration
     rdfs:label "Wearable Size Group Enumeration" ;
     rdfs:comment "Enumerates common size groups (also known as \"size types\") for wearable products." ;
 .
 
-sdo:WearableSizeGroupExtraShort
+schema:WearableSizeGroupExtraShort
     rdfs:label "Wearable SizeGroup Extra Short" ;
     rdfs:comment "Size group \"Extra Short\" for wearables." ;
 .
 
-sdo:WearableSizeGroupExtraTall
+schema:WearableSizeGroupExtraTall
     rdfs:label "Wearable SizeGroup Extra Tall" ;
     rdfs:comment "Size group \"Extra Tall\" for wearables." ;
 .
 
-sdo:WearableSizeGroupGirls
+schema:WearableSizeGroupGirls
     rdfs:label "Wearable Size Group Girls" ;
     rdfs:comment "Size group \"Girls\" for wearables." ;
 .
 
-sdo:WearableSizeGroupHusky
+schema:WearableSizeGroupHusky
     rdfs:label "Wearable Size Group Husky" ;
     rdfs:comment "Size group \"Husky\" (or \"Stocky\") for wearables." ;
 .
 
-sdo:WearableSizeGroupInfants
+schema:WearableSizeGroupInfants
     rdfs:label "Wearable Size Group Infants" ;
     rdfs:comment "Size group \"Infants\" for wearables." ;
 .
 
-sdo:WearableSizeGroupJuniors
+schema:WearableSizeGroupJuniors
     rdfs:label "Wearable Size Group Juniors" ;
     rdfs:comment "Size group \"Juniors\" for wearables." ;
 .
 
-sdo:WearableSizeGroupMaternity
+schema:WearableSizeGroupMaternity
     rdfs:label "Wearable Size Group Maternity" ;
     rdfs:comment "Size group \"Maternity\" for wearables." ;
 .
 
-sdo:WearableSizeGroupMens
+schema:WearableSizeGroupMens
     rdfs:label "Wearable Size Group Mens" ;
     rdfs:comment "Size group \"Mens\" for wearables." ;
 .
 
-sdo:WearableSizeGroupMisses
+schema:WearableSizeGroupMisses
     rdfs:label "Wearable Size Group Misses" ;
     rdfs:comment "Size group \"Misses\" (also known as \"Missy\") for wearables." ;
 .
 
-sdo:WearableSizeGroupPetite
+schema:WearableSizeGroupPetite
     rdfs:label "Wearable Size Group Petite" ;
     rdfs:comment "Size group \"Petite\" for wearables." ;
 .
 
-sdo:WearableSizeGroupPlus
+schema:WearableSizeGroupPlus
     rdfs:label "Wearable Size Group Plus" ;
     rdfs:comment "Size group \"Plus\" for wearables." ;
 .
 
-sdo:WearableSizeGroupRegular
+schema:WearableSizeGroupRegular
     rdfs:label "Wearable Size Group Regular" ;
     rdfs:comment "Size group \"Regular\" for wearables." ;
 .
 
-sdo:WearableSizeGroupShort
+schema:WearableSizeGroupShort
     rdfs:label "Wearable Size Group Short" ;
     rdfs:comment "Size group \"Short\" for wearables." ;
 .
 
-sdo:WearableSizeGroupTall
+schema:WearableSizeGroupTall
     rdfs:label "Wearable Size Group Tall" ;
     rdfs:comment "Size group \"Tall\" for wearables." ;
 .
 
-sdo:WearableSizeGroupWomens
+schema:WearableSizeGroupWomens
     rdfs:label "Wearable Size Group Womens" ;
     rdfs:comment "Size group \"Womens\" for wearables." ;
 .
 
-sdo:WearableSizeSystemAU
+schema:WearableSizeSystemAU
     rdfs:label "Wearable  Size SystemAU" ;
     rdfs:comment "Australian size system for wearables." ;
 .
 
-sdo:WearableSizeSystemBR
+schema:WearableSizeSystemBR
     rdfs:label "Wearable  Size SystemBR" ;
     rdfs:comment "Brazilian size system for wearables." ;
 .
 
-sdo:WearableSizeSystemCN
+schema:WearableSizeSystemCN
     rdfs:label "Wearable  Size SystemCN" ;
     rdfs:comment "Chinese size system for wearables." ;
 .
 
-sdo:WearableSizeSystemContinental
+schema:WearableSizeSystemContinental
     rdfs:label "Wearable Size System Continental" ;
     rdfs:comment "Continental size system for wearables." ;
 .
 
-sdo:WearableSizeSystemDE
+schema:WearableSizeSystemDE
     rdfs:label "Wearable  Size SystemDE" ;
     rdfs:comment "German size system for wearables." ;
 .
 
-sdo:WearableSizeSystemEN13402
+schema:WearableSizeSystemEN13402
     rdfs:label "Wearable  Size SystemEN13402" ;
     rdfs:comment "EN 13402 (joint European standard for size labelling of clothes)." ;
 .
 
-sdo:WearableSizeSystemEnumeration
+schema:WearableSizeSystemEnumeration
     rdfs:label "Wearable Size System Enumeration" ;
     rdfs:comment "Enumerates common size systems specific for wearable products" ;
 .
 
-sdo:WearableSizeSystemEurope
+schema:WearableSizeSystemEurope
     rdfs:label "Wearable Size System Europe" ;
     rdfs:comment "European size system for wearables." ;
 .
 
-sdo:WearableSizeSystemFR
+schema:WearableSizeSystemFR
     rdfs:label "Wearable  Size SystemFR" ;
     rdfs:comment "French size system for wearables." ;
 .
 
-sdo:WearableSizeSystemGS1
+schema:WearableSizeSystemGS1
     rdfs:label "Wearable  Size SystemGS1" ;
     rdfs:comment "GS1 (formerly NRF) size system for wearables." ;
 .
 
-sdo:WearableSizeSystemIT
+schema:WearableSizeSystemIT
     rdfs:label "Wearable  Size SystemIT" ;
     rdfs:comment "Italian size system for wearables." ;
 .
 
-sdo:WearableSizeSystemJP
+schema:WearableSizeSystemJP
     rdfs:label "Wearable  Size SystemJP" ;
     rdfs:comment "Japanese size system for wearables." ;
 .
 
-sdo:WearableSizeSystemMX
+schema:WearableSizeSystemMX
     rdfs:label "Wearable  Size SystemMX" ;
     rdfs:comment "Mexican size system for wearables." ;
 .
 
-sdo:WearableSizeSystemUK
+schema:WearableSizeSystemUK
     rdfs:label "Wearable  Size SystemUK" ;
     rdfs:comment "United Kingdom size system for wearables." ;
 .
 
-sdo:WearableSizeSystemUS
+schema:WearableSizeSystemUS
     rdfs:label "Wearable  Size SystemUS" ;
     rdfs:comment "United States size system for wearables." ;
 .
 
-sdo:WebAPI
+schema:WebAPI
     rdfs:label "WebAPI" ;
     rdfs:comment "An application programming interface accessible over Web/Internet technologies." ;
 .
 
-sdo:WebApplication
+schema:WebApplication
     rdfs:label "Web Application" ;
     rdfs:comment "Web applications." ;
 .
 
-sdo:WebContent
+schema:WebContent
     rdfs:label "Web Content" ;
     rdfs:comment "WebContent is a type representing all [[WebPage]], [[WebSite]] and [[WebPageElement]] content. It is sometimes the case that detailed distinctions between Web pages, sites and their parts is not always important or obvious. The  [[WebContent]] type makes it easier to describe Web-addressable content without requiring such distinctions to always be stated. (The intent is that the existing types [[WebPage]], [[WebSite]] and [[WebPageElement]] will eventually be declared as subtypes of [[WebContent]])." ;
 .
 
-sdo:WebPage
+schema:WebPage
     rdfs:label "Web Page" ;
     rdfs:comment "A web page. Every web page is implicitly assumed to be declared to be of type WebPage, so the various properties about that webpage, such as <code>breadcrumb</code> may be used. We recommend explicit declaration if these properties are specified, but if they are found outside of an itemscope, they will be assumed to be about the page." ;
 .
 
-sdo:WebPageElement
+schema:WebPageElement
     rdfs:label "Web  Page Element" ;
     rdfs:comment "A web page element, like a table or an image." ;
 .
 
-sdo:WebSite
+schema:WebSite
     rdfs:label "Web Site" ;
     rdfs:comment "A WebSite is a set of related web pages and other items typically served from a single web domain and accessible via URLs." ;
 .
 
-sdo:Wednesday
+schema:Wednesday
     rdfs:label "Wednesday" ;
     rdfs:comment "The day of the week between Tuesday and Thursday." ;
 .
 
-sdo:WesternConventional
+schema:WesternConventional
     rdfs:label "Western Conventional" ;
     rdfs:comment "The conventional Western system of medicine, that aims to apply the best available evidence gained from the scientific method to clinical decision making. Also known as conventional or Western medicine." ;
 .
 
-sdo:Wholesale
+schema:Wholesale
     rdfs:label "Wholesale" ;
     rdfs:comment "The drug's cost represents the wholesale acquisition cost of the drug." ;
 .
 
-sdo:WholesaleStore
+schema:WholesaleStore
     rdfs:label "Wholesale Store" ;
     rdfs:comment "A wholesale store." ;
 .
 
-sdo:WinAction
+schema:WinAction
     rdfs:label "Win Action" ;
     rdfs:comment "The act of achieving victory in a competitive activity." ;
 .
 
-sdo:Winery
+schema:Winery
     rdfs:label "Winery" ;
     rdfs:comment "A winery." ;
 .
 
-sdo:Withdrawn
+schema:Withdrawn
     rdfs:label "Withdrawn" ;
     rdfs:comment "Withdrawn." ;
 .
 
-sdo:WorkBasedProgram
+schema:WorkBasedProgram
     rdfs:label "Work  Based Program" ;
     rdfs:comment "A program with both an educational and employment component. Typically based at a workplace and structured around work-based learning, with the aim of instilling competencies related to an occupation. WorkBasedProgram is used to distinguish programs such as apprenticeships from school, college or other classroom based educational programs." ;
 .
 
-sdo:WorkersUnion
+schema:WorkersUnion
     rdfs:label "Workers Union" ;
     rdfs:comment "A Workers Union (also known as a Labor Union, Labour Union, or Trade Union) is an organization that promotes the interests of its worker members by collectively bargaining with management, organizing, and political lobbying." ;
 .
 
-sdo:WriteAction
+schema:WriteAction
     rdfs:label "Write Action" ;
     rdfs:comment "The act of authoring written creative content." ;
 .
 
-sdo:WritePermission
+schema:WritePermission
     rdfs:label "Write Permission" ;
     rdfs:comment "Permission to write or edit the document." ;
 .
 
-sdo:XPathType
+schema:XPathType
     rdfs:label "XPath Type" ;
     rdfs:comment "Text representing an XPath (typically but not necessarily version 1.0)." ;
 .
 
-sdo:XRay
+schema:XRay
     rdfs:label "XRay" ;
     rdfs:comment "X-ray imaging." ;
 .
 
-sdo:ZoneBoardingPolicy
+schema:ZoneBoardingPolicy
     rdfs:label "Zone  Boarding Policy" ;
     rdfs:comment "The airline boards by zones of the plane." ;
 .
 
-sdo:Zoo
+schema:Zoo
     rdfs:label "Zoo" ;
     rdfs:comment "A zoo." ;
 .
 
-sdo:about
+schema:about
     rdfs:label "about" ;
     rdfs:comment "The subject matter of the content." ;
 .
 
-sdo:abridged
+schema:abridged
     rdfs:label "abridged" ;
     rdfs:comment "Indicates whether the book is an abridged edition." ;
 .
 
-sdo:abstract
+schema:abstract
     rdfs:label "abstract" ;
     rdfs:comment "An abstract is a short description that summarizes a [[CreativeWork]]." ;
 .
 
-sdo:accelerationTime
+schema:accelerationTime
     rdfs:label "acceleration time" ;
     rdfs:comment "The time needed to accelerate the vehicle from a given start velocity to a given target velocity.\\n\\nTypical unit code(s): SEC for seconds\\n\\n* Note: There are unfortunately no standard unit codes for seconds/0..100 km/h or seconds/0..60 mph. Simply use \"SEC\" for seconds and indicate the velocities in the [[name]] of the [[QuantitativeValue]], or use [[valueReference]] with a [[QuantitativeValue]] of 0..60 mph or 0..100 km/h to specify the reference speeds." ;
 .
 
-sdo:acceptedAnswer
+schema:acceptedAnswer
     rdfs:label "accepted answer" ;
     rdfs:comment "The answer(s) that has been accepted as best, typically on a Question/Answer site. Sites vary in their selection mechanisms, e.g. drawing on community opinion and/or the view of the Question author." ;
 .
 
-sdo:acceptedOffer
+schema:acceptedOffer
     rdfs:label "accepted offer" ;
     rdfs:comment "The offer(s) -- e.g., product, quantity and price combinations -- included in the order." ;
 .
 
-sdo:acceptedPaymentMethod
+schema:acceptedPaymentMethod
     rdfs:label "accepted paymentMethod" ;
     rdfs:comment "The payment method(s) accepted by seller for this offer." ;
 .
 
-sdo:acceptsReservations
+schema:acceptsReservations
     rdfs:label "accepts reservations" ;
     rdfs:comment "Indicates whether a FoodEstablishment accepts reservations. Values can be Boolean, an URL at which reservations can be made or (for backwards compatibility) the strings ```Yes``` or ```No```." ;
 .
 
-sdo:accessCode
+schema:accessCode
     rdfs:label "access code" ;
     rdfs:comment "Password, PIN, or access code needed for delivery (e.g. from a locker)." ;
 .
 
-sdo:accessMode
+schema:accessMode
     rdfs:label "access mode" ;
     rdfs:comment """The human sensory perceptual system or cognitive faculty through which a person may process or perceive information. Expected values include: auditory, tactile, textual, visual, colorDependent, chartOnVisual, chemOnVisual, diagramOnVisual, mathOnVisual, musicOnVisual, textOnVisual.
       """ ;
 .
 
-sdo:accessModeSufficient
+schema:accessModeSufficient
     rdfs:label "access modeSufficient" ;
     rdfs:comment """A list of single or combined accessModes that are sufficient to understand all the intellectual content of a resource. Expected values include:  auditory, tactile, textual, visual.
       """ ;
 .
 
-sdo:accessibilityAPI
+schema:accessibilityAPI
     rdfs:label "accessibility api" ;
     rdfs:comment "Indicates that the resource is compatible with the referenced accessibility API ([WebSchemas wiki lists possible values](http://www.w3.org/wiki/WebSchemas/Accessibility))." ;
 .
 
-sdo:accessibilityControl
+schema:accessibilityControl
     rdfs:label "accessibility control" ;
     rdfs:comment "Identifies input methods that are sufficient to fully control the described resource ([WebSchemas wiki lists possible values](http://www.w3.org/wiki/WebSchemas/Accessibility))." ;
 .
 
-sdo:accessibilityFeature
+schema:accessibilityFeature
     rdfs:label "accessibility feature" ;
     rdfs:comment "Content features of the resource, such as accessible media, alternatives and supported enhancements for accessibility ([WebSchemas wiki lists possible values](http://www.w3.org/wiki/WebSchemas/Accessibility))." ;
 .
 
-sdo:accessibilityHazard
+schema:accessibilityHazard
     rdfs:label "accessibility hazard" ;
     rdfs:comment "A characteristic of the described resource that is physiologically dangerous to some users. Related to WCAG 2.0 guideline 2.3 ([WebSchemas wiki lists possible values](http://www.w3.org/wiki/WebSchemas/Accessibility))." ;
 .
 
-sdo:accessibilitySummary
+schema:accessibilitySummary
     rdfs:label "accessibility summary" ;
     rdfs:comment "A human-readable summary of specific accessibility features or deficiencies, consistent with the other accessibility metadata but expressing subtleties such as \"short descriptions are present but long descriptions will be needed for non-visual users\" or \"short descriptions are present and no long descriptions are needed.\"" ;
 .
 
-sdo:accommodationCategory
+schema:accommodationCategory
     rdfs:label "accommodation category" ;
     rdfs:comment "Category of an [[Accommodation]], following real estate conventions e.g. RESO (see [PropertySubType](https://ddwiki.reso.org/display/DDW17/PropertySubType+Field), and [PropertyType](https://ddwiki.reso.org/display/DDW17/PropertyType+Field) fields  for suggested values)." ;
 .
 
-sdo:accommodationFloorPlan
+schema:accommodationFloorPlan
     rdfs:label "accommodation floorPlan" ;
     rdfs:comment "A floorplan of some [[Accommodation]]." ;
 .
 
-sdo:accountId
+schema:accountId
     rdfs:label "account id" ;
     rdfs:comment "The identifier for the account the payment will be applied to." ;
 .
 
-sdo:accountMinimumInflow
+schema:accountMinimumInflow
     rdfs:label "account minimumInflow" ;
     rdfs:comment "A minimum amount that has to be paid in every month." ;
 .
 
-sdo:accountOverdraftLimit
+schema:accountOverdraftLimit
     rdfs:label "account overdraftLimit" ;
     rdfs:comment "An overdraft is an extension of credit from a lending institution when an account reaches zero. An overdraft allows the individual to continue withdrawing money even if the account has no funds in it. Basically the bank allows people to borrow a set amount of money." ;
 .
 
-sdo:accountablePerson
+schema:accountablePerson
     rdfs:label "accountable person" ;
     rdfs:comment "Specifies the Person that is legally accountable for the CreativeWork." ;
 .
 
-sdo:acquireLicensePage
+schema:acquireLicensePage
     rdfs:label "acquire licensePage" ;
     rdfs:comment "Indicates a page documenting how licenses can be purchased or otherwise acquired, for the current item." ;
 .
 
-sdo:acquiredFrom
+schema:acquiredFrom
     rdfs:label "acquired from" ;
     rdfs:comment "The organization or person from which the product was acquired." ;
 .
 
-sdo:acrissCode
+schema:acrissCode
     rdfs:label "acriss code" ;
     rdfs:comment "The ACRISS Car Classification Code is a code used by many car rental companies, for classifying vehicles. ACRISS stands for Association of Car Rental Industry Systems and Standards." ;
 .
 
-sdo:actionAccessibilityRequirement
+schema:actionAccessibilityRequirement
     rdfs:label "action accessibilityRequirement" ;
     rdfs:comment "A set of requirements that a must be fulfilled in order to perform an Action. If more than one value is specied, fulfilling one set of requirements will allow the Action to be performed." ;
 .
 
-sdo:actionApplication
+schema:actionApplication
     rdfs:label "action application" ;
     rdfs:comment "An application that can complete the request." ;
 .
 
-sdo:actionOption
+schema:actionOption
     rdfs:label "action option" ;
     rdfs:comment "A sub property of object. The options subject to this action." ;
 .
 
-sdo:actionPlatform
+schema:actionPlatform
     rdfs:label "action platform" ;
     rdfs:comment "The high level platform(s) where the Action can be performed for the given URL. To specify a specific application or operating system instance, use actionApplication." ;
 .
 
-sdo:actionStatus
+schema:actionStatus
     rdfs:label "action status" ;
     rdfs:comment "Indicates the current disposition of the Action." ;
 .
 
-sdo:actionableFeedbackPolicy
+schema:actionableFeedbackPolicy
     rdfs:label "actionable feedbackPolicy" ;
     rdfs:comment "For a [[NewsMediaOrganization]] or other news-related [[Organization]], a statement about public engagement activities (for news media, the newsroom’s), including involving the public - digitally or otherwise -- in coverage decisions, reporting and activities after publication." ;
 .
 
-sdo:activeIngredient
+schema:activeIngredient
     rdfs:label "active ingredient" ;
     rdfs:comment "An active ingredient, typically chemical compounds and/or biologic substances." ;
 .
 
-sdo:activityDuration
+schema:activityDuration
     rdfs:label "activity duration" ;
     rdfs:comment "Length of time to engage in the activity." ;
 .
 
-sdo:activityFrequency
+schema:activityFrequency
     rdfs:label "activity frequency" ;
     rdfs:comment "How often one should engage in the activity." ;
 .
 
-sdo:actor
+schema:actor
     rdfs:label "actor" ;
     rdfs:comment "An actor, e.g. in tv, radio, movie, video games etc., or in an event. Actors can be associated with individual items or with a series, episode, clip." ;
 .
 
-sdo:actors
+schema:actors
     rdfs:label "actors" ;
     rdfs:comment "An actor, e.g. in tv, radio, movie, video games etc. Actors can be associated with individual items or with a series, episode, clip." ;
 .
 
-sdo:addOn
+schema:addOn
     rdfs:label "add on" ;
     rdfs:comment "An additional offer that can only be obtained in combination with the first base offer (e.g. supplements and extensions that are available for a surcharge)." ;
 .
 
-sdo:additionalName
+schema:additionalName
     rdfs:label "additional name" ;
     rdfs:comment "An additional name for a Person, can be used for a middle name." ;
 .
 
-sdo:additionalNumberOfGuests
+schema:additionalNumberOfGuests
     rdfs:label "additional number Of Guests" ;
     rdfs:comment "If responding yes, the number of guests who will attend in addition to the invitee." ;
 .
 
-sdo:additionalProperty
+schema:additionalProperty
     rdfs:label "additional property" ;
     rdfs:comment """A property-value pair representing an additional characteristics of the entitity, e.g. a product feature or another characteristic for which there is no matching property in schema.org.\\n\\nNote: Publishers should be aware that applications designed to use specific schema.org properties (e.g. https://schema.org/width, https://schema.org/color, https://schema.org/gtin13, ...) will typically expect such data to be provided using those properties, rather than using the generic property/value mechanism.
 """ ;
 .
 
-sdo:additionalType
+schema:additionalType
     rdfs:label "additional type" ;
     rdfs:comment "An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax. This is a relationship between something and a class that the thing is in. In RDFa syntax, it is better to use the native RDFa syntax - the 'typeof' attribute - for multiple types. Schema.org tools may have only weaker understanding of extra types, in particular those defined externally." ;
 .
 
-sdo:additionalVariable
+schema:additionalVariable
     rdfs:label "additional variable" ;
     rdfs:comment "Any additional component of the exercise prescription that may need to be articulated to the patient. This may include the order of exercises, the number of repetitions of movement, quantitative distance, progressions over time, etc." ;
 .
 
-sdo:address
+schema:address
     rdfs:label "address" ;
     rdfs:comment "Physical address of the item." ;
 .
 
-sdo:addressCountry
+schema:addressCountry
     rdfs:label "address country" ;
     rdfs:comment "The country. For example, USA. You can also provide the two-letter [ISO 3166-1 alpha-2 country code](http://en.wikipedia.org/wiki/ISO_3166-1)." ;
 .
 
-sdo:addressLocality
+schema:addressLocality
     rdfs:label "address locality" ;
     rdfs:comment "The locality in which the street address is, and which is in the region. For example, Mountain View." ;
 .
 
-sdo:addressRegion
+schema:addressRegion
     rdfs:label "address region" ;
     rdfs:comment "The region in which the locality is, and which is in the country. For example, California or another appropriate first-level [Administrative division](https://en.wikipedia.org/wiki/List_of_administrative_divisions_by_country) " ;
 .
 
-sdo:administrationRoute
+schema:administrationRoute
     rdfs:label "administration route" ;
     rdfs:comment "A route by which this drug may be administered, e.g. 'oral'." ;
 .
 
-sdo:advanceBookingRequirement
+schema:advanceBookingRequirement
     rdfs:label "advance bookingRequirement" ;
     rdfs:comment "The amount of time that is required between accepting the offer and the actual usage of the resource or service." ;
 .
 
-sdo:adverseOutcome
+schema:adverseOutcome
     rdfs:label "adverse outcome" ;
     rdfs:comment "A possible complication and/or side effect of this therapy. If it is known that an adverse outcome is serious (resulting in death, disability, or permanent damage; requiring hospitalization; or is otherwise life-threatening or requires immediate medical attention), tag it as a seriouseAdverseOutcome instead." ;
 .
 
-sdo:affectedBy
+schema:affectedBy
     rdfs:label "affected by" ;
     rdfs:comment "Drugs that affect the test's results." ;
 .
 
-sdo:affiliation
+schema:affiliation
     rdfs:label "affiliation" ;
     rdfs:comment "An organization that this person is affiliated with. For example, a school/university, a club, or a team." ;
 .
 
-sdo:afterMedia
+schema:afterMedia
     rdfs:label "after media" ;
     rdfs:comment "A media object representing the circumstances after performing this direction." ;
 .
 
-sdo:agent
+schema:agent
     rdfs:label "agent" ;
     rdfs:comment "The direct performer or driver of the action (animate or inanimate). e.g. *John* wrote a book." ;
 .
 
-sdo:aggregateRating
+schema:aggregateRating
     rdfs:label "aggregate rating" ;
     rdfs:comment "The overall rating, based on a collection of reviews or ratings, of the item." ;
 .
 
-sdo:aircraft
+schema:aircraft
     rdfs:label "aircraft" ;
     rdfs:comment "The kind of aircraft (e.g., \"Boeing 747\")." ;
 .
 
-sdo:album
+schema:album
     rdfs:label "album" ;
     rdfs:comment "A music album." ;
 .
 
-sdo:albumProductionType
+schema:albumProductionType
     rdfs:label "album productionType" ;
     rdfs:comment "Classification of the album by it's type of content: soundtrack, live album, studio album, etc." ;
 .
 
-sdo:albumRelease
+schema:albumRelease
     rdfs:label "album release" ;
     rdfs:comment "A release of this album." ;
 .
 
-sdo:albumReleaseType
+schema:albumReleaseType
     rdfs:label "album releaseType" ;
     rdfs:comment "The kind of release which this album is: single, EP or album." ;
 .
 
-sdo:albums
+schema:albums
     rdfs:label "albums" ;
     rdfs:comment "A collection of music albums." ;
 .
 
-sdo:alcoholWarning
+schema:alcoholWarning
     rdfs:label "alcohol warning" ;
     rdfs:comment "Any precaution, guidance, contraindication, etc. related to consumption of alcohol while taking this drug." ;
 .
 
-sdo:algorithm
+schema:algorithm
     rdfs:label "algorithm" ;
     rdfs:comment "The algorithm or rules to follow to compute the score." ;
 .
 
-sdo:alignmentType
+schema:alignmentType
     rdfs:label "alignment type" ;
     rdfs:comment "A category of alignment between the learning resource and the framework node. Recommended values include: 'requires', 'textComplexity', 'readingLevel', and 'educationalSubject'." ;
 .
 
-sdo:alternateName
+schema:alternateName
     rdfs:label "alternate name" ;
     rdfs:comment "An alias for the item." ;
 .
 
-sdo:alternativeHeadline
+schema:alternativeHeadline
     rdfs:label "alternative headline" ;
     rdfs:comment "A secondary title of the CreativeWork." ;
 .
 
-sdo:alternativeOf
+schema:alternativeOf
     rdfs:label "alternative of" ;
     rdfs:comment "Another gene which is a variation of this one." ;
 .
 
-sdo:alumni
+schema:alumni
     rdfs:label "alumni" ;
     rdfs:comment "Alumni of an organization." ;
 .
 
-sdo:alumniOf
+schema:alumniOf
     rdfs:label "alumni of" ;
     rdfs:comment "An organization that the person is an alumni of." ;
 .
 
-sdo:amenityFeature
+schema:amenityFeature
     rdfs:label "amenity feature" ;
     rdfs:comment "An amenity feature (e.g. a characteristic or service) of the Accommodation. This generic property does not make a statement about whether the feature is included in an offer for the main accommodation or available at extra costs." ;
 .
 
-sdo:amount
+schema:amount
     rdfs:label "amount" ;
     rdfs:comment "The amount of money." ;
 .
 
-sdo:amountOfThisGood
+schema:amountOfThisGood
     rdfs:label "amount of This Good" ;
     rdfs:comment "The quantity of the goods included in the offer." ;
 .
 
-sdo:announcementLocation
+schema:announcementLocation
     rdfs:label "announcement location" ;
     rdfs:comment "Indicates a specific [[CivicStructure]] or [[LocalBusiness]] associated with the SpecialAnnouncement. For example, a specific testing facility or business with special opening hours. For a larger geographic region like a quarantine of an entire region, use [[spatialCoverage]]." ;
 .
 
-sdo:annualPercentageRate
+schema:annualPercentageRate
     rdfs:label "annual percentageRate" ;
     rdfs:comment "The annual rate that is charged for borrowing (or made by investing), expressed as a single percentage number that represents the actual yearly cost of funds over the term of a loan. This includes any fees or additional costs associated with the transaction." ;
 .
 
-sdo:answerCount
+schema:answerCount
     rdfs:label "answer count" ;
     rdfs:comment "The number of answers this question has received." ;
 .
 
-sdo:answerExplanation
+schema:answerExplanation
     rdfs:label "answer explanation" ;
     rdfs:comment "A step-by-step or full explanation about Answer. Can outline how this Answer was achieved or contain more broad clarification or statement about it. " ;
 .
 
-sdo:antagonist
+schema:antagonist
     rdfs:label "antagonist" ;
     rdfs:comment "The muscle whose action counteracts the specified muscle." ;
 .
 
-sdo:appearance
+schema:appearance
     rdfs:label "appearance" ;
     rdfs:comment "Indicates an occurence of a [[Claim]] in some [[CreativeWork]]." ;
 .
 
-sdo:applicableLocation
+schema:applicableLocation
     rdfs:label "applicable location" ;
     rdfs:comment "The location in which the status applies." ;
 .
 
-sdo:applicantLocationRequirements
+schema:applicantLocationRequirements
     rdfs:label "applicant locationRequirements" ;
     rdfs:comment "The location(s) applicants can apply from. This is usually used for telecommuting jobs where the applicant does not need to be in a physical office. Note: This should not be used for citizenship or work visa requirements." ;
 .
 
-sdo:application
+schema:application
     rdfs:label "application" ;
     rdfs:comment "An application that can complete the request." ;
 .
 
-sdo:applicationCategory
+schema:applicationCategory
     rdfs:label "application category" ;
     rdfs:comment "Type of software application, e.g. 'Game, Multimedia'." ;
 .
 
-sdo:applicationContact
+schema:applicationContact
     rdfs:label "application contact" ;
     rdfs:comment "Contact details for further information relevant to this job posting." ;
 .
 
-sdo:applicationDeadline
+schema:applicationDeadline
     rdfs:label "application deadline" ;
     rdfs:comment "The date at which the program stops collecting applications for the next enrollment cycle." ;
 .
 
-sdo:applicationStartDate
+schema:applicationStartDate
     rdfs:label "application startDate" ;
     rdfs:comment "The date at which the program begins collecting applications for the next enrollment cycle." ;
 .
 
-sdo:applicationSubCategory
+schema:applicationSubCategory
     rdfs:label "application subCategory" ;
     rdfs:comment "Subcategory of the application, e.g. 'Arcade Game'." ;
 .
 
-sdo:applicationSuite
+schema:applicationSuite
     rdfs:label "application suite" ;
     rdfs:comment "The name of the application suite to which the application belongs (e.g. Excel belongs to Office)." ;
 .
 
-sdo:appliesToDeliveryMethod
+schema:appliesToDeliveryMethod
     rdfs:label "applies to Delivery Method" ;
     rdfs:comment "The delivery method(s) to which the delivery charge or payment charge specification applies." ;
 .
 
-sdo:appliesToPaymentMethod
+schema:appliesToPaymentMethod
     rdfs:label "applies to Payment Method" ;
     rdfs:comment "The payment method(s) to which the payment charge specification applies." ;
 .
 
-sdo:archiveHeld
+schema:archiveHeld
     rdfs:label "archive held"@en ;
     rdfs:comment "Collection, [fonds](https://en.wikipedia.org/wiki/Fonds), or item held, kept or maintained by an [[ArchiveOrganization]]."@en ;
 .
 
-sdo:archivedAt
+schema:archivedAt
     rdfs:label "archived at" ;
     rdfs:comment "Indicates a page or other link involved in archival of a [[CreativeWork]]. In the case of [[MediaReview]], the items in a [[MediaReviewItem]] may often become inaccessible, but be archived by archival, journalistic, activist, or law enforcement organizations. In such cases, the referenced page may not directly publish the content." ;
 .
 
-sdo:area
+schema:area
     rdfs:label "area" ;
     rdfs:comment "The area within which users can expect to reach the broadcast service." ;
 .
 
-sdo:areaServed
+schema:areaServed
     rdfs:label "area served" ;
     rdfs:comment "The geographic area where a service or offered item is provided." ;
 .
 
-sdo:arrivalAirport
+schema:arrivalAirport
     rdfs:label "arrival airport" ;
     rdfs:comment "The airport where the flight terminates." ;
 .
 
-sdo:arrivalBoatTerminal
+schema:arrivalBoatTerminal
     rdfs:label "arrival boatTerminal" ;
     rdfs:comment "The terminal or port from which the boat arrives." ;
 .
 
-sdo:arrivalBusStop
+schema:arrivalBusStop
     rdfs:label "arrival busStop" ;
     rdfs:comment "The stop or station from which the bus arrives." ;
 .
 
-sdo:arrivalGate
+schema:arrivalGate
     rdfs:label "arrival gate" ;
     rdfs:comment "Identifier of the flight's arrival gate." ;
 .
 
-sdo:arrivalPlatform
+schema:arrivalPlatform
     rdfs:label "arrival platform" ;
     rdfs:comment "The platform where the train arrives." ;
 .
 
-sdo:arrivalStation
+schema:arrivalStation
     rdfs:label "arrival station" ;
     rdfs:comment "The station where the train trip ends." ;
 .
 
-sdo:arrivalTerminal
+schema:arrivalTerminal
     rdfs:label "arrival terminal" ;
     rdfs:comment "Identifier of the flight's arrival terminal." ;
 .
 
-sdo:arrivalTime
+schema:arrivalTime
     rdfs:label "arrival time" ;
     rdfs:comment "The expected arrival time." ;
 .
 
-sdo:artEdition
+schema:artEdition
     rdfs:label "art edition" ;
     rdfs:comment "The number of copies when multiple copies of a piece of artwork are produced - e.g. for a limited edition of 20 prints, 'artEdition' refers to the total number of copies (in this example \"20\")." ;
 .
 
-sdo:artMedium
+schema:artMedium
     rdfs:label "art medium" ;
     rdfs:comment "The material used. (e.g. Oil, Watercolour, Acrylic, Linoprint, Marble, Cyanotype, Digital, Lithograph, DryPoint, Intaglio, Pastel, Woodcut, Pencil, Mixed Media, etc.)" ;
 .
 
-sdo:arterialBranch
+schema:arterialBranch
     rdfs:label "arterial branch" ;
     rdfs:comment "The branches that comprise the arterial structure." ;
 .
 
-sdo:artform
+schema:artform
     rdfs:label "artform" ;
     rdfs:comment "e.g. Painting, Drawing, Sculpture, Print, Photograph, Assemblage, Collage, etc." ;
 .
 
-sdo:articleBody
+schema:articleBody
     rdfs:label "article body" ;
     rdfs:comment "The actual body of the article." ;
 .
 
-sdo:articleSection
+schema:articleSection
     rdfs:label "article section" ;
     rdfs:comment "Articles may belong to one or more 'sections' in a magazine or newspaper, such as Sports, Lifestyle, etc." ;
 .
 
-sdo:artist
+schema:artist
     rdfs:label "artist" ;
     rdfs:comment """The primary artist for a work
     	in a medium other than pencils or digital line art--for example, if the
     	primary artwork is done in watercolors or digital paints.""" ;
 .
 
-sdo:artworkSurface
+schema:artworkSurface
     rdfs:label "artwork surface" ;
     rdfs:comment "The supporting materials for the artwork, e.g. Canvas, Paper, Wood, Board, etc." ;
 .
 
-sdo:aspect
+schema:aspect
     rdfs:label "aspect" ;
     rdfs:comment "An aspect of medical practice that is considered on the page, such as 'diagnosis', 'treatment', 'causes', 'prognosis', 'etiology', 'epidemiology', etc." ;
 .
 
-sdo:assembly
+schema:assembly
     rdfs:label "assembly" ;
     rdfs:comment "Library file name e.g., mscorlib.dll, system.web.dll." ;
 .
 
-sdo:assemblyVersion
+schema:assemblyVersion
     rdfs:label "assembly version" ;
     rdfs:comment "Associated product/technology version. e.g., .NET Framework 4.5." ;
 .
 
-sdo:assesses
+schema:assesses
     rdfs:label "assesses" ;
     rdfs:comment "The item being described is intended to assess the competency or learning outcome defined by the referenced term." ;
 .
 
-sdo:associatedAnatomy
+schema:associatedAnatomy
     rdfs:label "associated anatomy" ;
     rdfs:comment "The anatomy of the underlying organ system or structures associated with this entity." ;
 .
 
-sdo:associatedArticle
+schema:associatedArticle
     rdfs:label "associated article" ;
     rdfs:comment "A NewsArticle associated with the Media Object." ;
 .
 
-sdo:associatedClaimReview
+schema:associatedClaimReview
     rdfs:label "associated claimReview" ;
     rdfs:comment "An associated [[ClaimReview]], related by specific common content, topic or claim. The expectation is that this property would be most typically used in cases where a single activity is conducting both claim reviews and media reviews, in which case [[relatedMediaReview]] would commonly be used on a [[ClaimReview]], while [[relatedClaimReview]] would be used on [[MediaReview]]." ;
 .
 
-sdo:associatedDisease
+schema:associatedDisease
     rdfs:label "associated disease" ;
     rdfs:comment "Disease associated to this BioChemEntity. Such disease can be a MedicalCondition or a URL. If you want to add an evidence supporting the association, please use PropertyValue." ;
 .
 
-sdo:associatedMedia
+schema:associatedMedia
     rdfs:label "associated media" ;
     rdfs:comment "A media object that encodes this CreativeWork. This property is a synonym for encoding." ;
 .
 
-sdo:associatedMediaReview
+schema:associatedMediaReview
     rdfs:label "associated mediaReview" ;
     rdfs:comment "An associated [[MediaReview]], related by specific common content, topic or claim. The expectation is that this property would be most typically used in cases where a single activity is conducting both claim reviews and media reviews, in which case [[relatedMediaReview]] would commonly be used on a [[ClaimReview]], while [[relatedClaimReview]] would be used on [[MediaReview]]." ;
 .
 
-sdo:associatedPathophysiology
+schema:associatedPathophysiology
     rdfs:label "associated pathophysiology" ;
     rdfs:comment "If applicable, a description of the pathophysiology associated with the anatomical system, including potential abnormal changes in the mechanical, physical, and biochemical functions of the system." ;
 .
 
-sdo:associatedReview
+schema:associatedReview
     rdfs:label "associated review" ;
     rdfs:comment "An associated [[Review]]." ;
 .
 
-sdo:athlete
+schema:athlete
     rdfs:label "athlete" ;
     rdfs:comment "A person that acts as performing member of a sports team; a player as opposed to a coach." ;
 .
 
-sdo:attendee
+schema:attendee
     rdfs:label "attendee" ;
     rdfs:comment "A person or organization attending the event." ;
 .
 
-sdo:attendees
+schema:attendees
     rdfs:label "attendees" ;
     rdfs:comment "A person attending the event." ;
 .
 
-sdo:audience
+schema:audience
     rdfs:label "audience" ;
     rdfs:comment "An intended audience, i.e. a group for whom something was created." ;
 .
 
-sdo:audienceType
+schema:audienceType
     rdfs:label "audience type" ;
     rdfs:comment "The target group associated with a given audience (e.g. veterans, car owners, musicians, etc.)." ;
 .
 
-sdo:audio
+schema:audio
     rdfs:label "audio" ;
     rdfs:comment "An embedded audio object." ;
 .
 
-sdo:authenticator
+schema:authenticator
     rdfs:label "authenticator" ;
     rdfs:comment "The Organization responsible for authenticating the user's subscription. For example, many media apps require a cable/satellite provider to authenticate your subscription before playing media." ;
 .
 
-sdo:author
+schema:author
     rdfs:label "author" ;
     rdfs:comment "The author of this content or rating. Please note that author is special in that HTML 5 provides a special mechanism for indicating authorship via the rel tag. That is equivalent to this and may be used interchangeably." ;
 .
 
-sdo:availability
+schema:availability
     rdfs:label "availability" ;
     rdfs:comment "The availability of this item—for example In stock, Out of stock, Pre-order, etc." ;
 .
 
-sdo:availabilityEnds
+schema:availabilityEnds
     rdfs:label "availability ends" ;
     rdfs:comment "The end of the availability of the product or service included in the offer." ;
 .
 
-sdo:availabilityStarts
+schema:availabilityStarts
     rdfs:label "availability starts" ;
     rdfs:comment "The beginning of the availability of the product or service included in the offer." ;
 .
 
-sdo:availableAtOrFrom
+schema:availableAtOrFrom
     rdfs:label "available at Or From" ;
     rdfs:comment "The place(s) from which the offer can be obtained (e.g. store locations)." ;
 .
 
-sdo:availableChannel
+schema:availableChannel
     rdfs:label "available channel" ;
     rdfs:comment "A means of accessing the service (e.g. a phone bank, a web site, a location, etc.)." ;
 .
 
-sdo:availableDeliveryMethod
+schema:availableDeliveryMethod
     rdfs:label "available deliveryMethod" ;
     rdfs:comment "The delivery method(s) available for this offer." ;
 .
 
-sdo:availableFrom
+schema:availableFrom
     rdfs:label "available from" ;
     rdfs:comment "When the item is available for pickup from the store, locker, etc." ;
 .
 
-sdo:availableIn
+schema:availableIn
     rdfs:label "available in" ;
     rdfs:comment "The location in which the strength is available." ;
 .
 
-sdo:availableLanguage
+schema:availableLanguage
     rdfs:label "available language" ;
     rdfs:comment "A language someone may use with or at the item, service or place. Please use one of the language codes from the [IETF BCP 47 standard](http://tools.ietf.org/html/bcp47). See also [[inLanguage]]" ;
 .
 
-sdo:availableOnDevice
+schema:availableOnDevice
     rdfs:label "available onDevice" ;
     rdfs:comment "Device required to run the application. Used in cases where a specific make/model is required to run the application." ;
 .
 
-sdo:availableService
+schema:availableService
     rdfs:label "available service" ;
     rdfs:comment "A medical service available from this provider." ;
 .
 
-sdo:availableStrength
+schema:availableStrength
     rdfs:label "available strength" ;
     rdfs:comment "An available dosage strength for the drug." ;
 .
 
-sdo:availableTest
+schema:availableTest
     rdfs:label "available test" ;
     rdfs:comment "A diagnostic test or procedure offered by this lab." ;
 .
 
-sdo:availableThrough
+schema:availableThrough
     rdfs:label "available through" ;
     rdfs:comment "After this date, the item will no longer be available for pickup." ;
 .
 
-sdo:award
+schema:award
     rdfs:label "award" ;
     rdfs:comment "An award won by or for this item." ;
 .
 
-sdo:awards
+schema:awards
     rdfs:label "awards" ;
     rdfs:comment "Awards won by or for this item." ;
 .
 
-sdo:awayTeam
+schema:awayTeam
     rdfs:label "away team" ;
     rdfs:comment "The away team in a sports event." ;
 .
 
-sdo:backstory
+schema:backstory
     rdfs:label "backstory" ;
     rdfs:comment "For an [[Article]], typically a [[NewsArticle]], the backstory property provides a textual summary giving a brief explanation of why and how an article was created. In a journalistic setting this could include information about reporting process, methods, interviews, data sources, etc." ;
 .
 
-sdo:bankAccountType
+schema:bankAccountType
     rdfs:label "bank accountType" ;
     rdfs:comment "The type of a bank account." ;
 .
 
-sdo:baseSalary
+schema:baseSalary
     rdfs:label "base salary" ;
     rdfs:comment "The base salary of the job or of an employee in an EmployeeRole." ;
 .
 
-sdo:bccRecipient
+schema:bccRecipient
     rdfs:label "bcc recipient" ;
     rdfs:comment "A sub property of recipient. The recipient blind copied on a message." ;
 .
 
-sdo:bed
+schema:bed
     rdfs:label "bed" ;
     rdfs:comment """The type of bed or beds included in the accommodation. For the single case of just one bed of a certain type, you use bed directly with a text.
       If you want to indicate the quantity of a certain kind of bed, use an instance of BedDetails. For more detailed information, use the amenityFeature property.""" ;
 .
 
-sdo:beforeMedia
+schema:beforeMedia
     rdfs:label "before media" ;
     rdfs:comment "A media object representing the circumstances before performing this direction." ;
 .
 
-sdo:beneficiaryBank
+schema:beneficiaryBank
     rdfs:label "beneficiary bank" ;
     rdfs:comment "A bank or bank’s branch, financial institution or international financial institution operating the beneficiary’s bank account or releasing funds for the beneficiary." ;
 .
 
-sdo:benefits
+schema:benefits
     rdfs:label "benefits" ;
     rdfs:comment "Description of benefits associated with the job." ;
 .
 
-sdo:benefitsSummaryUrl
+schema:benefitsSummaryUrl
     rdfs:label "benefits summaryUrl" ;
     rdfs:comment "The URL that goes directly to the summary of benefits and coverage for the specific standard plan or plan variation." ;
 .
 
-sdo:bestRating
+schema:bestRating
     rdfs:label "best rating" ;
     rdfs:comment "The highest value allowed in this rating system. If bestRating is omitted, 5 is assumed." ;
 .
 
-sdo:billingAddress
+schema:billingAddress
     rdfs:label "billing address" ;
     rdfs:comment "The billing address for the order." ;
 .
 
-sdo:billingDuration
+schema:billingDuration
     rdfs:label "billing duration" ;
     rdfs:comment "Specifies for how long this price (or price component) will be billed. Can be used, for example, to model the contractual duration of a subscription or payment plan. Type can be either a Duration or a Number (in which case the unit of measurement, for example month, is specified by the unitCode property)." ;
 .
 
-sdo:billingIncrement
+schema:billingIncrement
     rdfs:label "billing increment" ;
     rdfs:comment "This property specifies the minimal quantity and rounding increment that will be the basis for the billing. The unit of measurement is specified by the unitCode property." ;
 .
 
-sdo:billingPeriod
+schema:billingPeriod
     rdfs:label "billing period" ;
     rdfs:comment "The time interval used to compute the invoice." ;
 .
 
-sdo:billingStart
+schema:billingStart
     rdfs:label "billing start" ;
     rdfs:comment "Specifies after how much time this price (or price component) becomes valid and billing starts. Can be used, for example, to model a price increase after the first year of a subscription. The unit of measurement is specified by the unitCode property." ;
 .
 
-sdo:bioChemInteraction
+schema:bioChemInteraction
     rdfs:label "bio chemInteraction" ;
     rdfs:comment "A BioChemEntity that is known to interact with this item." ;
 .
 
-sdo:bioChemSimilarity
+schema:bioChemSimilarity
     rdfs:label "bio chemSimilarity" ;
     rdfs:comment "A similar BioChemEntity, e.g., obtained by fingerprint similarity algorithms." ;
 .
 
-sdo:biologicalRole
+schema:biologicalRole
     rdfs:label "biological role" ;
     rdfs:comment "A role played by the BioChemEntity within a biological context." ;
 .
 
-sdo:biomechnicalClass
+schema:biomechnicalClass
     rdfs:label "biomechnical class" ;
     rdfs:comment "The biomechanical properties of the bone." ;
 .
 
-sdo:birthDate
+schema:birthDate
     rdfs:label "birth date" ;
     rdfs:comment "Date of birth." ;
 .
 
-sdo:birthPlace
+schema:birthPlace
     rdfs:label "birth place" ;
     rdfs:comment "The place where the person was born." ;
 .
 
-sdo:bitrate
+schema:bitrate
     rdfs:label "bitrate" ;
     rdfs:comment "The bitrate of the media object." ;
 .
 
-sdo:blogPost
+schema:blogPost
     rdfs:label "blog post" ;
     rdfs:comment "A posting that is part of this blog." ;
 .
 
-sdo:blogPosts
+schema:blogPosts
     rdfs:label "blog posts" ;
     rdfs:comment "Indicates a post that is part of a [[Blog]]. Note that historically, what we term a \"Blog\" was once known as a \"weblog\", and that what we term a \"BlogPosting\" is now often colloquially referred to as a \"blog\"." ;
 .
 
-sdo:bloodSupply
+schema:bloodSupply
     rdfs:label "blood supply" ;
     rdfs:comment "The blood vessel that carries blood from the heart to the muscle." ;
 .
 
-sdo:boardingGroup
+schema:boardingGroup
     rdfs:label "boarding group" ;
     rdfs:comment "The airline-specific indicator of boarding order / preference." ;
 .
 
-sdo:boardingPolicy
+schema:boardingPolicy
     rdfs:label "boarding policy" ;
     rdfs:comment "The type of boarding policy used by the airline (e.g. zone-based or group-based)." ;
 .
 
-sdo:bodyLocation
+schema:bodyLocation
     rdfs:label "body location" ;
     rdfs:comment "Location in the body of the anatomical structure." ;
 .
 
-sdo:bodyType
+schema:bodyType
     rdfs:label "body type" ;
     rdfs:comment "Indicates the design and body style of the vehicle (e.g. station wagon, hatchback, etc.)." ;
 .
 
-sdo:bookEdition
+schema:bookEdition
     rdfs:label "book edition" ;
     rdfs:comment "The edition of the book." ;
 .
 
-sdo:bookFormat
+schema:bookFormat
     rdfs:label "book format" ;
     rdfs:comment "The format of the book." ;
 .
 
-sdo:bookingAgent
+schema:bookingAgent
     rdfs:label "booking agent" ;
     rdfs:comment "'bookingAgent' is an out-dated term indicating a 'broker' that serves as a booking agent." ;
 .
 
-sdo:bookingTime
+schema:bookingTime
     rdfs:label "booking time" ;
     rdfs:comment "The date and time the reservation was booked." ;
 .
 
-sdo:borrower
+schema:borrower
     rdfs:label "borrower" ;
     rdfs:comment "A sub property of participant. The person that borrows the object being lent." ;
 .
 
-sdo:box
+schema:box
     rdfs:label "box" ;
     rdfs:comment "A box is the area enclosed by the rectangle formed by two points. The first point is the lower corner, the second point is the upper corner. A box is expressed as two points separated by a space character." ;
 .
 
-sdo:branch
+schema:branch
     rdfs:label "branch" ;
     rdfs:comment "The branches that delineate from the nerve bundle. Not to be confused with [[branchOf]]." ;
 .
 
-sdo:branchCode
+schema:branchCode
     rdfs:label "branch code" ;
     rdfs:comment """A short textual code (also called "store code") that uniquely identifies a place of business. The code is typically assigned by the parentOrganization and used in structured URLs.\\n\\nFor example, in the URL http://www.starbucks.co.uk/store-locator/etc/detail/3047 the code "3047" is a branchCode for a particular branch.
       """ ;
 .
 
-sdo:branchOf
+schema:branchOf
     rdfs:label "branch of" ;
     rdfs:comment "The larger organization that this local business is a branch of, if any. Not to be confused with (anatomical)[[branch]]." ;
 .
 
-sdo:brand
+schema:brand
     rdfs:label "brand" ;
     rdfs:comment "The brand(s) associated with a product or service, or the brand(s) maintained by an organization or business person." ;
 .
 
-sdo:breadcrumb
+schema:breadcrumb
     rdfs:label "breadcrumb" ;
     rdfs:comment "A set of links that can help a user understand and navigate a website hierarchy." ;
 .
 
-sdo:breastfeedingWarning
+schema:breastfeedingWarning
     rdfs:label "breastfeeding warning" ;
     rdfs:comment "Any precaution, guidance, contraindication, etc. related to this drug's use by breastfeeding mothers." ;
 .
 
-sdo:broadcastAffiliateOf
+schema:broadcastAffiliateOf
     rdfs:label "broadcast affiliateOf" ;
     rdfs:comment "The media network(s) whose content is broadcast on this station." ;
 .
 
-sdo:broadcastChannelId
+schema:broadcastChannelId
     rdfs:label "broadcast channelId" ;
     rdfs:comment "The unique address by which the BroadcastService can be identified in a provider lineup. In US, this is typically a number." ;
 .
 
-sdo:broadcastDisplayName
+schema:broadcastDisplayName
     rdfs:label "broadcast displayName" ;
     rdfs:comment "The name displayed in the channel guide. For many US affiliates, it is the network name." ;
 .
 
-sdo:broadcastFrequency
+schema:broadcastFrequency
     rdfs:label "broadcast frequency" ;
     rdfs:comment "The frequency used for over-the-air broadcasts. Numeric values or simple ranges e.g. 87-99. In addition a shortcut idiom is supported for frequences of AM and FM radio channels, e.g. \"87 FM\"." ;
 .
 
-sdo:broadcastFrequencyValue
+schema:broadcastFrequencyValue
     rdfs:label "broadcast frequencyValue" ;
     rdfs:comment "The frequency in MHz for a particular broadcast." ;
 .
 
-sdo:broadcastOfEvent
+schema:broadcastOfEvent
     rdfs:label "broadcast ofEvent" ;
     rdfs:comment "The event being broadcast such as a sporting event or awards ceremony." ;
 .
 
-sdo:broadcastServiceTier
+schema:broadcastServiceTier
     rdfs:label "broadcast serviceTier" ;
     rdfs:comment "The type of service required to have access to the channel (e.g. Standard or Premium)." ;
 .
 
-sdo:broadcastSignalModulation
+schema:broadcastSignalModulation
     rdfs:label "broadcast signalModulation" ;
     rdfs:comment "The modulation (e.g. FM, AM, etc) used by a particular broadcast service." ;
 .
 
-sdo:broadcastSubChannel
+schema:broadcastSubChannel
     rdfs:label "broadcast subChannel" ;
     rdfs:comment "The subchannel used for the broadcast." ;
 .
 
-sdo:broadcastTimezone
+schema:broadcastTimezone
     rdfs:label "broadcast timezone" ;
     rdfs:comment "The timezone in [ISO 8601 format](http://en.wikipedia.org/wiki/ISO_8601) for which the service bases its broadcasts" ;
 .
 
-sdo:broadcaster
+schema:broadcaster
     rdfs:label "broadcaster" ;
     rdfs:comment "The organization owning or operating the broadcast service." ;
 .
 
-sdo:broker
+schema:broker
     rdfs:label "broker" ;
     rdfs:comment "An entity that arranges for an exchange between a buyer and a seller.  In most cases a broker never acquires or releases ownership of a product or service involved in an exchange.  If it is not clear whether an entity is a broker, seller, or buyer, the latter two terms are preferred." ;
 .
 
-sdo:browserRequirements
+schema:browserRequirements
     rdfs:label "browser requirements" ;
     rdfs:comment "Specifies browser requirements in human-readable text. For example, 'requires HTML5 support'." ;
 .
 
-sdo:busName
+schema:busName
     rdfs:label "bus name" ;
     rdfs:comment "The name of the bus (e.g. Bolt Express)." ;
 .
 
-sdo:busNumber
+schema:busNumber
     rdfs:label "bus number" ;
     rdfs:comment "The unique identifier for the bus." ;
 .
 
-sdo:businessDays
+schema:businessDays
     rdfs:label "business days" ;
     rdfs:comment "Days of the week when the merchant typically operates, indicated via opening hours markup." ;
 .
 
-sdo:businessFunction
+schema:businessFunction
     rdfs:label "business function" ;
     rdfs:comment "The business function (e.g. sell, lease, repair, dispose) of the offer or component of a bundle (TypeAndQuantityNode). The default is http://purl.org/goodrelations/v1#Sell." ;
 .
 
-sdo:buyer
+schema:buyer
     rdfs:label "buyer" ;
     rdfs:comment "A sub property of participant. The participant/person/organization that bought the object." ;
 .
 
-sdo:byArtist
+schema:byArtist
     rdfs:label "by artist" ;
     rdfs:comment "The artist that performed this album or recording." ;
 .
 
-sdo:byDay
+schema:byDay
     rdfs:label "by day" ;
     rdfs:comment "Defines the day(s) of the week on which a recurring [[Event]] takes place. May be specified using either [[DayOfWeek]], or alternatively [[Text]] conforming to iCal's syntax for byDay recurrence rules." ;
 .
 
-sdo:byMonth
+schema:byMonth
     rdfs:label "by month" ;
     rdfs:comment "Defines the month(s) of the year on which a recurring [[Event]] takes place. Specified as an [[Integer]] between 1-12. January is 1." ;
 .
 
-sdo:byMonthDay
+schema:byMonthDay
     rdfs:label "by monthDay" ;
     rdfs:comment "Defines the day(s) of the month on which a recurring [[Event]] takes place. Specified as an [[Integer]] between 1-31." ;
 .
 
-sdo:byMonthWeek
+schema:byMonthWeek
     rdfs:label "by monthWeek" ;
     rdfs:comment "Defines the week(s) of the month on which a recurring Event takes place. Specified as an Integer between 1-5. For clarity, byMonthWeek is best used in conjunction with byDay to indicate concepts like the first and third Mondays of a month." ;
 .
 
-sdo:callSign
+schema:callSign
     rdfs:label "call sign" ;
     rdfs:comment "A [callsign](https://en.wikipedia.org/wiki/Call_sign), as used in broadcasting and radio communications to identify people, radio and TV stations, or vehicles." ;
 .
 
-sdo:calories
+schema:calories
     rdfs:label "calories" ;
     rdfs:comment "The number of calories." ;
 .
 
-sdo:candidate
+schema:candidate
     rdfs:label "candidate" ;
     rdfs:comment "A sub property of object. The candidate subject of this action." ;
 .
 
-sdo:caption
+schema:caption
     rdfs:label "caption" ;
     rdfs:comment "The caption for this object. For downloadable machine formats (closed caption, subtitles etc.) use MediaObject and indicate the [[encodingFormat]]." ;
 .
 
-sdo:carbohydrateContent
+schema:carbohydrateContent
     rdfs:label "carbohydrate content" ;
     rdfs:comment "The number of grams of carbohydrates." ;
 .
 
-sdo:cargoVolume
+schema:cargoVolume
     rdfs:label "cargo volume" ;
     rdfs:comment "The available volume for cargo or luggage. For automobiles, this is usually the trunk volume.\\n\\nTypical unit code(s): LTR for liters, FTQ for cubic foot/feet\\n\\nNote: You can use [[minValue]] and [[maxValue]] to indicate ranges." ;
 .
 
-sdo:carrier
+schema:carrier
     rdfs:label "carrier" ;
     rdfs:comment "'carrier' is an out-dated term indicating the 'provider' for parcel delivery and flights." ;
 .
 
-sdo:carrierRequirements
+schema:carrierRequirements
     rdfs:label "carrier requirements" ;
     rdfs:comment "Specifies specific carrier(s) requirements for the application (e.g. an application may only work on a specific carrier network)." ;
 .
 
-sdo:cashBack
+schema:cashBack
     rdfs:label "cash back" ;
     rdfs:comment "A cardholder benefit that pays the cardholder a small percentage of their net expenditures." ;
 .
 
-sdo:catalog
+schema:catalog
     rdfs:label "catalog" ;
     rdfs:comment "A data catalog which contains this dataset." ;
 .
 
-sdo:catalogNumber
+schema:catalogNumber
     rdfs:label "catalog number" ;
     rdfs:comment "The catalog number for the release." ;
 .
 
-sdo:category
+schema:category
     rdfs:label "category" ;
     rdfs:comment "A category for the item. Greater signs or slashes can be used to informally indicate a category hierarchy." ;
 .
 
-sdo:causeOf
+schema:causeOf
     rdfs:label "cause of" ;
     rdfs:comment "The condition, complication, symptom, sign, etc. caused." ;
 .
 
-sdo:ccRecipient
+schema:ccRecipient
     rdfs:label "cc recipient" ;
     rdfs:comment "A sub property of recipient. The recipient copied on a message." ;
 .
 
-sdo:character
+schema:character
     rdfs:label "character" ;
     rdfs:comment "Fictional person connected with a creative work." ;
 .
 
-sdo:characterAttribute
+schema:characterAttribute
     rdfs:label "character attribute" ;
     rdfs:comment "A piece of data that represents a particular aspect of a fictional character (skill, power, character points, advantage, disadvantage)." ;
 .
 
-sdo:characterName
+schema:characterName
     rdfs:label "character name" ;
     rdfs:comment "The name of a character played in some acting or performing role, i.e. in a PerformanceRole." ;
 .
 
-sdo:cheatCode
+schema:cheatCode
     rdfs:label "cheat code" ;
     rdfs:comment "Cheat codes to the game." ;
 .
 
-sdo:checkinTime
+schema:checkinTime
     rdfs:label "checkin time" ;
     rdfs:comment "The earliest someone may check into a lodging establishment." ;
 .
 
-sdo:checkoutTime
+schema:checkoutTime
     rdfs:label "checkout time" ;
     rdfs:comment "The latest someone may check out of a lodging establishment." ;
 .
 
-sdo:chemicalComposition
+schema:chemicalComposition
     rdfs:label "chemical composition" ;
     rdfs:comment "The chemical composition describes the identity and relative ratio of the chemical elements that make up the substance." ;
 .
 
-sdo:chemicalRole
+schema:chemicalRole
     rdfs:label "chemical role" ;
     rdfs:comment "A role played by the BioChemEntity within a chemical context." ;
 .
 
-sdo:childMaxAge
+schema:childMaxAge
     rdfs:label "child maxAge" ;
     rdfs:comment "Maximal age of the child." ;
 .
 
-sdo:childMinAge
+schema:childMinAge
     rdfs:label "child minAge" ;
     rdfs:comment "Minimal age of the child." ;
 .
 
-sdo:childTaxon
+schema:childTaxon
     rdfs:label "child taxon" ;
     rdfs:comment "Closest child taxa of the taxon in question." ;
 .
 
-sdo:children
+schema:children
     rdfs:label "children" ;
     rdfs:comment "A child of the person." ;
 .
 
-sdo:cholesterolContent
+schema:cholesterolContent
     rdfs:label "cholesterol content" ;
     rdfs:comment "The number of milligrams of cholesterol." ;
 .
 
-sdo:circle
+schema:circle
     rdfs:label "circle" ;
     rdfs:comment "A circle is the circular region of a specified radius centered at a specified latitude and longitude. A circle is expressed as a pair followed by a radius in meters." ;
 .
 
-sdo:citation
+schema:citation
     rdfs:label "citation" ;
     rdfs:comment "A citation or reference to another creative work, such as another publication, web page, scholarly article, etc." ;
 .
 
-sdo:claimInterpreter
+schema:claimInterpreter
     rdfs:label "claim interpreter" ;
     rdfs:comment """For a [[Claim]] interpreted from [[MediaObject]] content
     sed to indicate a claim contained, implied or refined from the content of a [[MediaObject]].""" ;
 .
 
-sdo:claimReviewed
+schema:claimReviewed
     rdfs:label "claim reviewed" ;
     rdfs:comment "A short summary of the specific claims reviewed in a ClaimReview." ;
 .
 
-sdo:clincalPharmacology
+schema:clincalPharmacology
     rdfs:label "clincal pharmacology" ;
     rdfs:comment "Description of the absorption and elimination of drugs, including their concentration (pharmacokinetics, pK) and biological effects (pharmacodynamics, pD)." ;
 .
 
-sdo:clinicalPharmacology
+schema:clinicalPharmacology
     rdfs:label "clinical pharmacology" ;
     rdfs:comment "Description of the absorption and elimination of drugs, including their concentration (pharmacokinetics, pK) and biological effects (pharmacodynamics, pD)." ;
 .
 
-sdo:clipNumber
+schema:clipNumber
     rdfs:label "clip number" ;
     rdfs:comment "Position of the clip within an ordered group of clips." ;
 .
 
-sdo:closes
+schema:closes
     rdfs:label "closes" ;
     rdfs:comment "The closing hour of the place or service on the given day(s) of the week." ;
 .
 
-sdo:coach
+schema:coach
     rdfs:label "coach" ;
     rdfs:comment "A person that acts in a coaching role for a sports team." ;
 .
 
-sdo:code
+schema:code
     rdfs:label "code" ;
     rdfs:comment "A medical code for the entity, taken from a controlled vocabulary or ontology such as ICD-9, DiseasesDB, MeSH, SNOMED-CT, RxNorm, etc." ;
 .
 
-sdo:codeRepository
+schema:codeRepository
     rdfs:label "code repository" ;
     rdfs:comment "Link to the repository where the un-compiled, human readable code and related code is located (SVN, github, CodePlex)." ;
 .
 
-sdo:codeSampleType
+schema:codeSampleType
     rdfs:label "code sampleType" ;
     rdfs:comment "What type of code sample: full (compile ready) solution, code snippet, inline code, scripts, template." ;
 .
 
-sdo:codeValue
+schema:codeValue
     rdfs:label "code value" ;
     rdfs:comment "A short textual code that uniquely identifies the value." ;
 .
 
-sdo:codingSystem
+schema:codingSystem
     rdfs:label "coding system" ;
     rdfs:comment "The coding system, e.g. 'ICD-10'." ;
 .
 
-sdo:colleague
+schema:colleague
     rdfs:label "colleague" ;
     rdfs:comment "A colleague of the person." ;
 .
 
-sdo:colleagues
+schema:colleagues
     rdfs:label "colleagues" ;
     rdfs:comment "A colleague of the person." ;
 .
 
-sdo:collection
+schema:collection
     rdfs:label "collection" ;
     rdfs:comment "A sub property of object. The collection target of the action." ;
 .
 
-sdo:collectionSize
+schema:collectionSize
     rdfs:label "collection size"@en ;
     rdfs:comment "The number of items in the [[Collection]]."@en ;
 .
 
-sdo:color
+schema:color
     rdfs:label "color" ;
     rdfs:comment "The color of the product." ;
 .
 
-sdo:colorist
+schema:colorist
     rdfs:label "colorist" ;
     rdfs:comment "The individual who adds color to inked drawings." ;
 .
 
-sdo:comment
+schema:comment
     rdfs:label "comment" ;
     rdfs:comment "Comments, typically from users." ;
 .
 
-sdo:commentCount
+schema:commentCount
     rdfs:label "comment count" ;
     rdfs:comment "The number of comments this CreativeWork (e.g. Article, Question or Answer) has received. This is most applicable to works published in Web sites with commenting system; additional comments may exist elsewhere." ;
 .
 
-sdo:commentText
+schema:commentText
     rdfs:label "comment text" ;
     rdfs:comment "The text of the UserComment." ;
 .
 
-sdo:commentTime
+schema:commentTime
     rdfs:label "comment time" ;
     rdfs:comment "The time at which the UserComment was made." ;
 .
 
-sdo:competencyRequired
+schema:competencyRequired
     rdfs:label "competency required" ;
     rdfs:comment "Knowledge, skill, ability or personal attribute that must be demonstrated by a person or other entity in order to do something such as earn an Educational Occupational Credential or understand a LearningResource." ;
 .
 
-sdo:competitor
+schema:competitor
     rdfs:label "competitor" ;
     rdfs:comment "A competitor in a sports event." ;
 .
 
-sdo:composer
+schema:composer
     rdfs:label "composer" ;
     rdfs:comment "The person or organization who wrote a composition, or who is the composer of a work performed at some event." ;
 .
 
-sdo:comprisedOf
+schema:comprisedOf
     rdfs:label "comprised of" ;
     rdfs:comment "Specifying something physically contained by something else. Typically used here for the underlying anatomical structures, such as organs, that comprise the anatomical system." ;
 .
 
-sdo:conditionsOfAccess
+schema:conditionsOfAccess
     rdfs:label "conditions ofAccess" ;
     rdfs:comment "Conditions that affect the availability of, or method(s) of access to, an item. Typically used for real world items such as an [[ArchiveComponent]] held by an [[ArchiveOrganization]]. This property is not suitable for use as a general Web access control mechanism. It is expressed only in natural language.\\n\\nFor example \"Available by appointment from the Reading Room\" or \"Accessible only from logged-in accounts \". " ;
 .
 
-sdo:confirmationNumber
+schema:confirmationNumber
     rdfs:label "confirmation number" ;
     rdfs:comment "A number that confirms the given order or payment has been received." ;
 .
 
-sdo:connectedTo
+schema:connectedTo
     rdfs:label "connected to" ;
     rdfs:comment "Other anatomical structures to which this structure is connected." ;
 .
 
-sdo:constrainingProperty
+schema:constrainingProperty
     rdfs:label "constraining property" ;
     rdfs:comment """Indicates a property used as a constraint to define a [[StatisticalPopulation]] with respect to the set of entities
   corresponding to an indicated type (via [[populationType]]).""" ;
 .
 
-sdo:contactOption
+schema:contactOption
     rdfs:label "contact option" ;
     rdfs:comment "An option available on this contact point (e.g. a toll-free number or support for hearing-impaired callers)." ;
 .
 
-sdo:contactPoint
+schema:contactPoint
     rdfs:label "contact point" ;
     rdfs:comment "A contact point for a person or organization." ;
 .
 
-sdo:contactPoints
+schema:contactPoints
     rdfs:label "contact points" ;
     rdfs:comment "A contact point for a person or organization." ;
 .
 
-sdo:contactType
+schema:contactType
     rdfs:label "contact type" ;
     rdfs:comment "A person or organization can have different contact points, for different purposes. For example, a sales contact point, a PR contact point and so on. This property is used to specify the kind of contact point." ;
 .
 
-sdo:contactlessPayment
+schema:contactlessPayment
     rdfs:label "contactless payment" ;
     rdfs:comment "A secure method for consumers to purchase products or services via debit, credit or smartcards by using RFID or NFC technology." ;
 .
 
-sdo:containedIn
+schema:containedIn
     rdfs:label "contained in" ;
     rdfs:comment "The basic containment relation between a place and one that contains it." ;
 .
 
-sdo:containedInPlace
+schema:containedInPlace
     rdfs:label "contained inPlace" ;
     rdfs:comment "The basic containment relation between a place and one that contains it." ;
 .
 
-sdo:containsPlace
+schema:containsPlace
     rdfs:label "contains place" ;
     rdfs:comment "The basic containment relation between a place and another that it contains." ;
 .
 
-sdo:containsSeason
+schema:containsSeason
     rdfs:label "contains season" ;
     rdfs:comment "A season that is part of the media series." ;
 .
 
-sdo:contentLocation
+schema:contentLocation
     rdfs:label "content location" ;
     rdfs:comment "The location depicted or described in the content. For example, the location in a photograph or painting." ;
 .
 
-sdo:contentRating
+schema:contentRating
     rdfs:label "content rating" ;
     rdfs:comment "Official rating of a piece of content—for example,'MPAA PG-13'." ;
 .
 
-sdo:contentReferenceTime
+schema:contentReferenceTime
     rdfs:label "content referenceTime" ;
     rdfs:comment "The specific time described by a creative work, for works (e.g. articles, video objects etc.) that emphasise a particular moment within an Event." ;
 .
 
-sdo:contentSize
+schema:contentSize
     rdfs:label "content size" ;
     rdfs:comment "File size in (mega/kilo) bytes." ;
 .
 
-sdo:contentType
+schema:contentType
     rdfs:label "content type" ;
     rdfs:comment "The supported content type(s) for an EntryPoint response." ;
 .
 
-sdo:contentUrl
+schema:contentUrl
     rdfs:label "content url" ;
     rdfs:comment "Actual bytes of the media object, for example the image file or video file." ;
 .
 
-sdo:contraindication
+schema:contraindication
     rdfs:label "contraindication" ;
     rdfs:comment "A contraindication for this therapy." ;
 .
 
-sdo:contributor
+schema:contributor
     rdfs:label "contributor" ;
     rdfs:comment "A secondary contributor to the CreativeWork or Event." ;
 .
 
-sdo:cookTime
+schema:cookTime
     rdfs:label "cook time" ;
     rdfs:comment "The time it takes to actually cook the dish, in [ISO 8601 duration format](http://en.wikipedia.org/wiki/ISO_8601)." ;
 .
 
-sdo:cookingMethod
+schema:cookingMethod
     rdfs:label "cooking method" ;
     rdfs:comment "The method of cooking, such as Frying, Steaming, ..." ;
 .
 
-sdo:copyrightHolder
+schema:copyrightHolder
     rdfs:label "copyright holder" ;
     rdfs:comment "The party holding the legal copyright to the CreativeWork." ;
 .
 
-sdo:copyrightNotice
+schema:copyrightNotice
     rdfs:label "copyright notice" ;
     rdfs:comment "Text of a notice appropriate for describing the copyright aspects of this Creative Work, ideally indicating the owner of the copyright for the Work." ;
 .
 
-sdo:copyrightYear
+schema:copyrightYear
     rdfs:label "copyright year" ;
     rdfs:comment "The year during which the claimed copyright for the CreativeWork was first asserted." ;
 .
 
-sdo:correction
+schema:correction
     rdfs:label "correction" ;
     rdfs:comment "Indicates a correction to a [[CreativeWork]], either via a [[CorrectionComment]], textually or in another document." ;
 .
 
-sdo:correctionsPolicy
+schema:correctionsPolicy
     rdfs:label "corrections policy" ;
     rdfs:comment "For an [[Organization]] (e.g. [[NewsMediaOrganization]]), a statement describing (in news media, the newsroom’s) disclosure and correction policy for errors." ;
 .
 
-sdo:costCategory
+schema:costCategory
     rdfs:label "cost category" ;
     rdfs:comment "The category of cost, such as wholesale, retail, reimbursement cap, etc." ;
 .
 
-sdo:costCurrency
+schema:costCurrency
     rdfs:label "cost currency" ;
     rdfs:comment "The currency (in 3-letter of the drug cost. See: http://en.wikipedia.org/wiki/ISO_4217. " ;
 .
 
-sdo:costOrigin
+schema:costOrigin
     rdfs:label "cost origin" ;
     rdfs:comment "Additional details to capture the origin of the cost data. For example, 'Medicare Part B'." ;
 .
 
-sdo:costPerUnit
+schema:costPerUnit
     rdfs:label "cost perUnit" ;
     rdfs:comment "The cost per unit of the drug." ;
 .
 
-sdo:countriesNotSupported
+schema:countriesNotSupported
     rdfs:label "countries notSupported" ;
     rdfs:comment "Countries for which the application is not supported. You can also provide the two-letter ISO 3166-1 alpha-2 country code." ;
 .
 
-sdo:countriesSupported
+schema:countriesSupported
     rdfs:label "countries supported" ;
     rdfs:comment "Countries for which the application is supported. You can also provide the two-letter ISO 3166-1 alpha-2 country code." ;
 .
 
-sdo:countryOfAssembly
+schema:countryOfAssembly
     rdfs:label "country ofAssembly" ;
     rdfs:comment "The place where the product was assembled." ;
 .
 
-sdo:countryOfLastProcessing
+schema:countryOfLastProcessing
     rdfs:label "country of Last Processing" ;
     rdfs:comment "The place where the item (typically [[Product]]) was last processed and tested before importation." ;
 .
 
-sdo:countryOfOrigin
+schema:countryOfOrigin
     rdfs:label "country ofOrigin" ;
     rdfs:comment """The country of origin of something, including products as well as creative  works such as movie and TV content.
 
@@ -11084,257 +11084,257 @@ In the case of TV and movie, this would be the country of the principle offices 
 In the case of products, the country of origin of the product. The exact interpretation of this may vary by context and product type, and cannot be fully enumerated here.""" ;
 .
 
-sdo:course
+schema:course
     rdfs:label "course" ;
     rdfs:comment "A sub property of location. The course where this action was taken." ;
 .
 
-sdo:courseCode
+schema:courseCode
     rdfs:label "course code" ;
     rdfs:comment "The identifier for the [[Course]] used by the course [[provider]] (e.g. CS101 or 6.001)." ;
 .
 
-sdo:courseMode
+schema:courseMode
     rdfs:label "course mode" ;
     rdfs:comment "The medium or means of delivery of the course instance or the mode of study, either as a text label (e.g. \"online\", \"onsite\" or \"blended\"; \"synchronous\" or \"asynchronous\"; \"full-time\" or \"part-time\") or as a URL reference to a term from a controlled vocabulary (e.g. https://ceds.ed.gov/element/001311#Asynchronous )." ;
 .
 
-sdo:coursePrerequisites
+schema:coursePrerequisites
     rdfs:label "course prerequisites" ;
     rdfs:comment "Requirements for taking the Course. May be completion of another [[Course]] or a textual description like \"permission of instructor\". Requirements may be a pre-requisite competency, referenced using [[AlignmentObject]]." ;
 .
 
-sdo:courseWorkload
+schema:courseWorkload
     rdfs:label "course workload" ;
     rdfs:comment "The amount of work expected of students taking the course, often provided as a figure per week or per month, and may be broken down by type. For example, \"2 hours of lectures, 1 hour of lab work and 3 hours of independent study per week\"." ;
 .
 
-sdo:coverageEndTime
+schema:coverageEndTime
     rdfs:label "coverage endTime" ;
     rdfs:comment "The time when the live blog will stop covering the Event. Note that coverage may continue after the Event concludes." ;
 .
 
-sdo:coverageStartTime
+schema:coverageStartTime
     rdfs:label "coverage startTime" ;
     rdfs:comment "The time when the live blog will begin covering the Event. Note that coverage may begin before the Event's start time. The LiveBlogPosting may also be created before coverage begins." ;
 .
 
-sdo:creativeWorkStatus
+schema:creativeWorkStatus
     rdfs:label "creative workStatus" ;
     rdfs:comment "The status of a creative work in terms of its stage in a lifecycle. Example terms include Incomplete, Draft, Published, Obsolete. Some organizations define a set of terms for the stages of their publication lifecycle." ;
 .
 
-sdo:creator
+schema:creator
     rdfs:label "creator" ;
     rdfs:comment "The creator/author of this CreativeWork. This is the same as the Author property for CreativeWork." ;
 .
 
-sdo:credentialCategory
+schema:credentialCategory
     rdfs:label "credential category" ;
     rdfs:comment "The category or type of credential being described, for example \"degree”, “certificate”, “badge”, or more specific term." ;
 .
 
-sdo:creditText
+schema:creditText
     rdfs:label "credit text" ;
     rdfs:comment "Text that can be used to credit person(s) and/or organization(s) associated with a published Creative Work." ;
 .
 
-sdo:creditedTo
+schema:creditedTo
     rdfs:label "credited to" ;
     rdfs:comment "The group the release is credited to if different than the byArtist. For example, Red and Blue is credited to \"Stefani Germanotta Band\", but by Lady Gaga." ;
 .
 
-sdo:cssSelector
+schema:cssSelector
     rdfs:label "css selector" ;
     rdfs:comment "A CSS selector, e.g. of a [[SpeakableSpecification]] or [[WebPageElement]]. In the latter case, multiple matches within a page can constitute a single conceptual \"Web page element\"." ;
 .
 
-sdo:currenciesAccepted
+schema:currenciesAccepted
     rdfs:label "currencies accepted" ;
     rdfs:comment "The currency accepted.\\n\\nUse standard formats: [ISO 4217 currency format](http://en.wikipedia.org/wiki/ISO_4217) e.g. \"USD\"; [Ticker symbol](https://en.wikipedia.org/wiki/List_of_cryptocurrencies) for cryptocurrencies e.g. \"BTC\"; well known names for [Local Exchange Tradings Systems](https://en.wikipedia.org/wiki/Local_exchange_trading_system) (LETS) and other currency types e.g. \"Ithaca HOUR\"." ;
 .
 
-sdo:currency
+schema:currency
     rdfs:label "currency" ;
     rdfs:comment "The currency in which the monetary amount is expressed.\\n\\nUse standard formats: [ISO 4217 currency format](http://en.wikipedia.org/wiki/ISO_4217) e.g. \"USD\"; [Ticker symbol](https://en.wikipedia.org/wiki/List_of_cryptocurrencies) for cryptocurrencies e.g. \"BTC\"; well known names for [Local Exchange Tradings Systems](https://en.wikipedia.org/wiki/Local_exchange_trading_system) (LETS) and other currency types e.g. \"Ithaca HOUR\"." ;
 .
 
-sdo:currentExchangeRate
+schema:currentExchangeRate
     rdfs:label "current exchangeRate" ;
     rdfs:comment "The current price of a currency." ;
 .
 
-sdo:customer
+schema:customer
     rdfs:label "customer" ;
     rdfs:comment "Party placing the order or paying the invoice." ;
 .
 
-sdo:customerRemorseReturnFees
+schema:customerRemorseReturnFees
     rdfs:label "customer remorse Return Fees" ;
     rdfs:comment "The type of return fees if the product is returned due to customer remorse." ;
 .
 
-sdo:customerRemorseReturnLabelSource
+schema:customerRemorseReturnLabelSource
     rdfs:label "customer remorseReturn Label Source" ;
     rdfs:comment "The method (from an enumeration) by which the customer obtains a return shipping label for a product returned due to customer remorse." ;
 .
 
-sdo:customerRemorseReturnShippingFeesAmount
+schema:customerRemorseReturnShippingFeesAmount
     rdfs:label "customer remorse Return Shipping Fees Amount" ;
     rdfs:comment "The amount of shipping costs if a product is returned due to customer remorse. Applicable when property [[customerRemorseReturnFees]] equals [[ReturnShippingFees]]." ;
 .
 
-sdo:cutoffTime
+schema:cutoffTime
     rdfs:label "cutoff time" ;
     rdfs:comment "Order cutoff time allows merchants to describe the time after which they will no longer process orders received on that day. For orders processed after cutoff time, one day gets added to the delivery time estimate. This property is expected to be most typically used via the [[ShippingRateSettings]] publication pattern. The time is indicated using the ISO-8601 Time format, e.g. \"23:30:00-05:00\" would represent 6:30 pm Eastern Standard Time (EST) which is 5 hours behind Coordinated Universal Time (UTC)." ;
 .
 
-sdo:cvdCollectionDate
+schema:cvdCollectionDate
     rdfs:label "cvd collectionDate" ;
     rdfs:comment "collectiondate - Date for which patient counts are reported." ;
 .
 
-sdo:cvdFacilityCounty
+schema:cvdFacilityCounty
     rdfs:label "cvd facilityCounty" ;
     rdfs:comment "Name of the County of the NHSN facility that this data record applies to. Use [[cvdFacilityId]] to identify the facility. To provide other details, [[healthcareReportingData]] can be used on a [[Hospital]] entry." ;
 .
 
-sdo:cvdFacilityId
+schema:cvdFacilityId
     rdfs:label "cvd facilityId" ;
     rdfs:comment "Identifier of the NHSN facility that this data record applies to. Use [[cvdFacilityCounty]] to indicate the county. To provide other details, [[healthcareReportingData]] can be used on a [[Hospital]] entry." ;
 .
 
-sdo:cvdNumBeds
+schema:cvdNumBeds
     rdfs:label "cvd numBeds" ;
     rdfs:comment "numbeds - HOSPITAL INPATIENT BEDS: Inpatient beds, including all staffed, licensed, and overflow (surge) beds used for inpatients." ;
 .
 
-sdo:cvdNumBedsOcc
+schema:cvdNumBedsOcc
     rdfs:label "cvd num Beds Occ" ;
     rdfs:comment "numbedsocc - HOSPITAL INPATIENT BED OCCUPANCY: Total number of staffed inpatient beds that are occupied." ;
 .
 
-sdo:cvdNumC19Died
+schema:cvdNumC19Died
     rdfs:label "cvd numC19Died" ;
     rdfs:comment "numc19died - DEATHS: Patients with suspected or confirmed COVID-19 who died in the hospital, ED, or any overflow location." ;
 .
 
-sdo:cvdNumC19HOPats
+schema:cvdNumC19HOPats
     rdfs:label "cvd numC19HOPats" ;
     rdfs:comment "numc19hopats - HOSPITAL ONSET: Patients hospitalized in an NHSN inpatient care location with onset of suspected or confirmed COVID-19 14 or more days after hospitalization." ;
 .
 
-sdo:cvdNumC19HospPats
+schema:cvdNumC19HospPats
     rdfs:label "cvd numC19 Hosp Pats" ;
     rdfs:comment "numc19hosppats - HOSPITALIZED: Patients currently hospitalized in an inpatient care location who have suspected or confirmed COVID-19." ;
 .
 
-sdo:cvdNumC19MechVentPats
+schema:cvdNumC19MechVentPats
     rdfs:label "cvd numC19Mech Vent Pats" ;
     rdfs:comment "numc19mechventpats - HOSPITALIZED and VENTILATED: Patients hospitalized in an NHSN inpatient care location who have suspected or confirmed COVID-19 and are on a mechanical ventilator." ;
 .
 
-sdo:cvdNumC19OFMechVentPats
+schema:cvdNumC19OFMechVentPats
     rdfs:label "cvd numC19OFMech Vent Pats" ;
     rdfs:comment "numc19ofmechventpats - ED/OVERFLOW and VENTILATED: Patients with suspected or confirmed COVID-19 who are in the ED or any overflow location awaiting an inpatient bed and on a mechanical ventilator." ;
 .
 
-sdo:cvdNumC19OverflowPats
+schema:cvdNumC19OverflowPats
     rdfs:label "cvd numC19 Overflow Pats" ;
     rdfs:comment "numc19overflowpats - ED/OVERFLOW: Patients with suspected or confirmed COVID-19 who are in the ED or any overflow location awaiting an inpatient bed." ;
 .
 
-sdo:cvdNumICUBeds
+schema:cvdNumICUBeds
     rdfs:label "cvd numICUBeds" ;
     rdfs:comment "numicubeds - ICU BEDS: Total number of staffed inpatient intensive care unit (ICU) beds." ;
 .
 
-sdo:cvdNumICUBedsOcc
+schema:cvdNumICUBedsOcc
     rdfs:label "cvd numICU Beds Occ" ;
     rdfs:comment "numicubedsocc - ICU BED OCCUPANCY: Total number of staffed inpatient ICU beds that are occupied." ;
 .
 
-sdo:cvdNumTotBeds
+schema:cvdNumTotBeds
     rdfs:label "cvd num Tot Beds" ;
     rdfs:comment "numtotbeds - ALL HOSPITAL BEDS: Total number of all Inpatient and outpatient beds, including all staffed,ICU, licensed, and overflow (surge) beds used for inpatients or outpatients." ;
 .
 
-sdo:cvdNumVent
+schema:cvdNumVent
     rdfs:label "cvd numVent" ;
     rdfs:comment "numvent - MECHANICAL VENTILATORS: Total number of ventilators available." ;
 .
 
-sdo:cvdNumVentUse
+schema:cvdNumVentUse
     rdfs:label "cvd num Vent Use" ;
     rdfs:comment "numventuse - MECHANICAL VENTILATORS IN USE: Total number of ventilators in use." ;
 .
 
-sdo:dataFeedElement
+schema:dataFeedElement
     rdfs:label "data feedElement" ;
     rdfs:comment "An item within in a data feed. Data feeds may have many elements." ;
 .
 
-sdo:dataset
+schema:dataset
     rdfs:label "dataset" ;
     rdfs:comment "A dataset contained in this catalog." ;
 .
 
-sdo:datasetTimeInterval
+schema:datasetTimeInterval
     rdfs:label "dataset timeInterval" ;
     rdfs:comment "The range of temporal applicability of a dataset, e.g. for a 2011 census dataset, the year 2011 (in ISO 8601 time interval format)." ;
 .
 
-sdo:dateCreated
+schema:dateCreated
     rdfs:label "date created" ;
     rdfs:comment "The date on which the CreativeWork was created or the item was added to a DataFeed." ;
 .
 
-sdo:dateDeleted
+schema:dateDeleted
     rdfs:label "date deleted" ;
     rdfs:comment "The datetime the item was removed from the DataFeed." ;
 .
 
-sdo:dateIssued
+schema:dateIssued
     rdfs:label "date issued" ;
     rdfs:comment "The date the ticket was issued." ;
 .
 
-sdo:dateModified
+schema:dateModified
     rdfs:label "date modified" ;
     rdfs:comment "The date on which the CreativeWork was most recently modified or when the item's entry was modified within a DataFeed." ;
 .
 
-sdo:datePosted
+schema:datePosted
     rdfs:label "date posted" ;
     rdfs:comment "Publication date of an online listing." ;
 .
 
-sdo:datePublished
+schema:datePublished
     rdfs:label "date published" ;
     rdfs:comment "Date of first broadcast/publication." ;
 .
 
-sdo:dateRead
+schema:dateRead
     rdfs:label "date read" ;
     rdfs:comment "The date/time at which the message has been read by the recipient if a single recipient exists." ;
 .
 
-sdo:dateReceived
+schema:dateReceived
     rdfs:label "date received" ;
     rdfs:comment "The date/time the message was received if a single recipient exists." ;
 .
 
-sdo:dateSent
+schema:dateSent
     rdfs:label "date sent" ;
     rdfs:comment "The date/time at which the message was sent." ;
 .
 
-sdo:dateVehicleFirstRegistered
+schema:dateVehicleFirstRegistered
     rdfs:label "date vehicle First Registered" ;
     rdfs:comment "The date of the first registration of the vehicle with the respective public authorities." ;
 .
 
-sdo:dateline
+schema:dateline
     rdfs:label "dateline" ;
     rdfs:comment """A [dateline](https://en.wikipedia.org/wiki/Dateline) is a brief piece of text included in news articles that describes where and when the story was written or filed though the date is often omitted. Sometimes only a placename is provided.
 
@@ -11344,354 +11344,354 @@ Dateline summaries are oriented more towards human readers than towards automate
       """ ;
 .
 
-sdo:dayOfWeek
+schema:dayOfWeek
     rdfs:label "day ofWeek" ;
     rdfs:comment "The day of the week for which these opening hours are valid." ;
 .
 
-sdo:deathDate
+schema:deathDate
     rdfs:label "death date" ;
     rdfs:comment "Date of death." ;
 .
 
-sdo:deathPlace
+schema:deathPlace
     rdfs:label "death place" ;
     rdfs:comment "The place where the person died." ;
 .
 
-sdo:defaultValue
+schema:defaultValue
     rdfs:label "default value" ;
     rdfs:comment "The default value of the input.  For properties that expect a literal, the default is a literal value, for properties that expect an object, it's an ID reference to one of the current values." ;
 .
 
-sdo:deliveryAddress
+schema:deliveryAddress
     rdfs:label "delivery address" ;
     rdfs:comment "Destination address." ;
 .
 
-sdo:deliveryLeadTime
+schema:deliveryLeadTime
     rdfs:label "delivery leadTime" ;
     rdfs:comment "The typical delay between the receipt of the order and the goods either leaving the warehouse or being prepared for pickup, in case the delivery method is on site pickup." ;
 .
 
-sdo:deliveryMethod
+schema:deliveryMethod
     rdfs:label "delivery method" ;
     rdfs:comment "A sub property of instrument. The method of delivery." ;
 .
 
-sdo:deliveryStatus
+schema:deliveryStatus
     rdfs:label "delivery status" ;
     rdfs:comment "New entry added as the package passes through each leg of its journey (from shipment to final delivery)." ;
 .
 
-sdo:deliveryTime
+schema:deliveryTime
     rdfs:label "delivery time" ;
     rdfs:comment "The total delay between the receipt of the order and the goods reaching the final customer." ;
 .
 
-sdo:department
+schema:department
     rdfs:label "department" ;
     rdfs:comment "A relationship between an organization and a department of that organization, also described as an organization (allowing different urls, logos, opening hours). For example: a store with a pharmacy, or a bakery with a cafe." ;
 .
 
-sdo:departureAirport
+schema:departureAirport
     rdfs:label "departure airport" ;
     rdfs:comment "The airport where the flight originates." ;
 .
 
-sdo:departureBoatTerminal
+schema:departureBoatTerminal
     rdfs:label "departure boatTerminal" ;
     rdfs:comment "The terminal or port from which the boat departs." ;
 .
 
-sdo:departureBusStop
+schema:departureBusStop
     rdfs:label "departure busStop" ;
     rdfs:comment "The stop or station from which the bus departs." ;
 .
 
-sdo:departureGate
+schema:departureGate
     rdfs:label "departure gate" ;
     rdfs:comment "Identifier of the flight's departure gate." ;
 .
 
-sdo:departurePlatform
+schema:departurePlatform
     rdfs:label "departure platform" ;
     rdfs:comment "The platform from which the train departs." ;
 .
 
-sdo:departureStation
+schema:departureStation
     rdfs:label "departure station" ;
     rdfs:comment "The station from which the train departs." ;
 .
 
-sdo:departureTerminal
+schema:departureTerminal
     rdfs:label "departure terminal" ;
     rdfs:comment "Identifier of the flight's departure terminal." ;
 .
 
-sdo:departureTime
+schema:departureTime
     rdfs:label "departure time" ;
     rdfs:comment "The expected departure time." ;
 .
 
-sdo:dependencies
+schema:dependencies
     rdfs:label "dependencies" ;
     rdfs:comment "Prerequisites needed to fulfill steps in article." ;
 .
 
-sdo:depth
+schema:depth
     rdfs:label "depth" ;
     rdfs:comment "The depth of the item." ;
 .
 
-sdo:description
+schema:description
     rdfs:label "description" ;
     rdfs:comment "A description of the item." ;
 .
 
-sdo:device
+schema:device
     rdfs:label "device" ;
     rdfs:comment "Device required to run the application. Used in cases where a specific make/model is required to run the application." ;
 .
 
-sdo:diagnosis
+schema:diagnosis
     rdfs:label "diagnosis" ;
     rdfs:comment "One or more alternative conditions considered in the differential diagnosis process as output of a diagnosis process." ;
 .
 
-sdo:diagram
+schema:diagram
     rdfs:label "diagram" ;
     rdfs:comment "An image containing a diagram that illustrates the structure and/or its component substructures and/or connections with other structures." ;
 .
 
-sdo:diet
+schema:diet
     rdfs:label "diet" ;
     rdfs:comment "A sub property of instrument. The diet used in this action." ;
 .
 
-sdo:dietFeatures
+schema:dietFeatures
     rdfs:label "diet features" ;
     rdfs:comment "Nutritional information specific to the dietary plan. May include dietary recommendations on what foods to avoid, what foods to consume, and specific alterations/deviations from the USDA or other regulatory body's approved dietary guidelines." ;
 .
 
-sdo:differentialDiagnosis
+schema:differentialDiagnosis
     rdfs:label "differential diagnosis" ;
     rdfs:comment "One of a set of differential diagnoses for the condition. Specifically, a closely-related or competing diagnosis typically considered later in the cognitive process whereby this medical condition is distinguished from others most likely responsible for a similar collection of signs and symptoms to reach the most parsimonious diagnosis or diagnoses in a patient." ;
 .
 
-sdo:directApply
+schema:directApply
     rdfs:label "direct apply" ;
     rdfs:comment "Indicates whether an [[url]] that is associated with a [[JobPosting]] enables direct application for the job, via the posting website. A job posting is considered to have directApply of [[True]] if an application process for the specified job can be directly initiated via the url(s) given (noting that e.g. multiple internet domains might nevertheless be involved at an implementation level). A value of [[False]] is appropriate if there is no clear path to applying directly online for the specified job, navigating directly from the JobPosting url(s) supplied." ;
 .
 
-sdo:director
+schema:director
     rdfs:label "director" ;
     rdfs:comment "A director of e.g. tv, radio, movie, video gaming etc. content, or of an event. Directors can be associated with individual items or with a series, episode, clip." ;
 .
 
-sdo:directors
+schema:directors
     rdfs:label "directors" ;
     rdfs:comment "A director of e.g. tv, radio, movie, video games etc. content. Directors can be associated with individual items or with a series, episode, clip." ;
 .
 
-sdo:disambiguatingDescription
+schema:disambiguatingDescription
     rdfs:label "disambiguating description" ;
     rdfs:comment "A sub property of description. A short description of the item used to disambiguate from other, similar items. Information from other properties (in particular, name) may be necessary for the description to be useful for disambiguation." ;
 .
 
-sdo:discount
+schema:discount
     rdfs:label "discount" ;
     rdfs:comment "Any discount applied (to an Order)." ;
 .
 
-sdo:discountCode
+schema:discountCode
     rdfs:label "discount code" ;
     rdfs:comment "Code used to redeem a discount." ;
 .
 
-sdo:discountCurrency
+schema:discountCurrency
     rdfs:label "discount currency" ;
     rdfs:comment "The currency of the discount.\\n\\nUse standard formats: [ISO 4217 currency format](http://en.wikipedia.org/wiki/ISO_4217) e.g. \"USD\"; [Ticker symbol](https://en.wikipedia.org/wiki/List_of_cryptocurrencies) for cryptocurrencies e.g. \"BTC\"; well known names for [Local Exchange Tradings Systems](https://en.wikipedia.org/wiki/Local_exchange_trading_system) (LETS) and other currency types e.g. \"Ithaca HOUR\"." ;
 .
 
-sdo:discusses
+schema:discusses
     rdfs:label "discusses" ;
     rdfs:comment "Specifies the CreativeWork associated with the UserComment." ;
 .
 
-sdo:discussionUrl
+schema:discussionUrl
     rdfs:label "discussion url" ;
     rdfs:comment "A link to the page containing the comments of the CreativeWork." ;
 .
 
-sdo:diseasePreventionInfo
+schema:diseasePreventionInfo
     rdfs:label "disease preventionInfo" ;
     rdfs:comment "Information about disease prevention." ;
 .
 
-sdo:diseaseSpreadStatistics
+schema:diseaseSpreadStatistics
     rdfs:label "disease spreadStatistics" ;
     rdfs:comment """Statistical information about the spread of a disease, either as [[WebContent]], or
   described directly as a [[Dataset]], or the specific [[Observation]]s in the dataset. When a [[WebContent]] URL is
   provided, the page indicated might also contain more such markup.""" ;
 .
 
-sdo:dissolutionDate
+schema:dissolutionDate
     rdfs:label "dissolution date" ;
     rdfs:comment "The date that this organization was dissolved." ;
 .
 
-sdo:distance
+schema:distance
     rdfs:label "distance" ;
     rdfs:comment "The distance travelled, e.g. exercising or travelling." ;
 .
 
-sdo:distinguishingSign
+schema:distinguishingSign
     rdfs:label "distinguishing sign" ;
     rdfs:comment "One of a set of signs and symptoms that can be used to distinguish this diagnosis from others in the differential diagnosis." ;
 .
 
-sdo:distribution
+schema:distribution
     rdfs:label "distribution" ;
     rdfs:comment "A downloadable form of this dataset, at a specific location, in a specific format." ;
 .
 
-sdo:diversityPolicy
+schema:diversityPolicy
     rdfs:label "diversity policy" ;
     rdfs:comment "Statement on diversity policy by an [[Organization]] e.g. a [[NewsMediaOrganization]]. For a [[NewsMediaOrganization]], a statement describing the newsroom’s diversity policy on both staffing and sources, typically providing staffing data." ;
 .
 
-sdo:diversityStaffingReport
+schema:diversityStaffingReport
     rdfs:label "diversity staffingReport" ;
     rdfs:comment "For an [[Organization]] (often but not necessarily a [[NewsMediaOrganization]]), a report on staffing diversity issues. In a news context this might be for example ASNE or RTDNA (US) reports, or self-reported." ;
 .
 
-sdo:documentation
+schema:documentation
     rdfs:label "documentation" ;
     rdfs:comment "Further documentation describing the Web API in more detail." ;
 .
 
-sdo:doesNotShip
+schema:doesNotShip
     rdfs:label "does notShip" ;
     rdfs:comment "Indicates when shipping to a particular [[shippingDestination]] is not available." ;
 .
 
-sdo:domainIncludes
+schema:domainIncludes
     rdfs:label "domain includes" ;
     rdfs:comment "Relates a property to a class that is (one of) the type(s) the property is expected to be used on." ;
 .
 
-sdo:domiciledMortgage
+schema:domiciledMortgage
     rdfs:label "domiciled mortgage" ;
     rdfs:comment "Whether borrower is a resident of the jurisdiction where the property is located." ;
 .
 
-sdo:doorTime
+schema:doorTime
     rdfs:label "door time" ;
     rdfs:comment "The time admission will commence." ;
 .
 
-sdo:dosageForm
+schema:dosageForm
     rdfs:label "dosage form" ;
     rdfs:comment "A dosage form in which this drug/supplement is available, e.g. 'tablet', 'suspension', 'injection'." ;
 .
 
-sdo:doseSchedule
+schema:doseSchedule
     rdfs:label "dose schedule" ;
     rdfs:comment "A dosing schedule for the drug for a given population, either observed, recommended, or maximum dose based on the type used." ;
 .
 
-sdo:doseUnit
+schema:doseUnit
     rdfs:label "dose unit" ;
     rdfs:comment "The unit of the dose, e.g. 'mg'." ;
 .
 
-sdo:doseValue
+schema:doseValue
     rdfs:label "dose value" ;
     rdfs:comment "The value of the dose, e.g. 500." ;
 .
 
-sdo:downPayment
+schema:downPayment
     rdfs:label "down payment" ;
     rdfs:comment "a type of payment made in cash during the onset of the purchase of an expensive good/service. The payment typically represents only a percentage of the full purchase price." ;
 .
 
-sdo:downloadUrl
+schema:downloadUrl
     rdfs:label "download url" ;
     rdfs:comment "If the file can be downloaded, URL to download the binary." ;
 .
 
-sdo:downvoteCount
+schema:downvoteCount
     rdfs:label "downvote count" ;
     rdfs:comment "The number of downvotes this question, answer or comment has received from the community." ;
 .
 
-sdo:drainsTo
+schema:drainsTo
     rdfs:label "drains to" ;
     rdfs:comment "The vasculature that the vein drains into." ;
 .
 
-sdo:driveWheelConfiguration
+schema:driveWheelConfiguration
     rdfs:label "drive wheelConfiguration" ;
     rdfs:comment "The drive wheel configuration, i.e. which roadwheels will receive torque from the vehicle's engine via the drivetrain." ;
 .
 
-sdo:dropoffLocation
+schema:dropoffLocation
     rdfs:label "dropoff location" ;
     rdfs:comment "Where a rental car can be dropped off." ;
 .
 
-sdo:dropoffTime
+schema:dropoffTime
     rdfs:label "dropoff time" ;
     rdfs:comment "When a rental car can be dropped off." ;
 .
 
-sdo:drug
+schema:drug
     rdfs:label "drug" ;
     rdfs:comment "Specifying a drug or medicine used in a medication procedure." ;
 .
 
-sdo:drugClass
+schema:drugClass
     rdfs:label "drug class" ;
     rdfs:comment "The class of drug this belongs to (e.g., statins)." ;
 .
 
-sdo:drugUnit
+schema:drugUnit
     rdfs:label "drug unit" ;
     rdfs:comment "The unit in which the drug is measured, e.g. '5 mg tablet'." ;
 .
 
-sdo:duns
+schema:duns
     rdfs:label "duns" ;
     rdfs:comment "The Dun & Bradstreet DUNS number for identifying an organization or business person." ;
 .
 
-sdo:duplicateTherapy
+schema:duplicateTherapy
     rdfs:label "duplicate therapy" ;
     rdfs:comment "A therapy that duplicates or overlaps this one." ;
 .
 
-sdo:duration
+schema:duration
     rdfs:label "duration" ;
     rdfs:comment "The duration of the item (movie, audio recording, event, etc.) in [ISO 8601 date format](http://en.wikipedia.org/wiki/ISO_8601)." ;
 .
 
-sdo:durationOfWarranty
+schema:durationOfWarranty
     rdfs:label "duration ofWarranty" ;
     rdfs:comment "The duration of the warranty promise. Common unitCode values are ANN for year, MON for months, or DAY for days." ;
 .
 
-sdo:duringMedia
+schema:duringMedia
     rdfs:label "during media" ;
     rdfs:comment "A media object representing the circumstances while performing this direction." ;
 .
 
-sdo:earlyPrepaymentPenalty
+schema:earlyPrepaymentPenalty
     rdfs:label "early prepaymentPenalty" ;
     rdfs:comment "The amount to be paid as a penalty in the event of early payment of the loan." ;
 .
 
-sdo:editEIDR
+schema:editEIDR
     rdfs:label "edit eidr" ;
     rdfs:comment """An [EIDR](https://eidr.org/) (Entertainment Identifier Registry) [[identifier]] representing a specific edit / edition for a work of film or television.
 
@@ -11701,155 +11701,155 @@ Since schema.org types like [[Movie]] and [[TVEpisode]] can be used for both wor
 """ ;
 .
 
-sdo:editor
+schema:editor
     rdfs:label "editor" ;
     rdfs:comment "Specifies the Person who edited the CreativeWork." ;
 .
 
-sdo:eduQuestionType
+schema:eduQuestionType
     rdfs:label "edu questionType" ;
     rdfs:comment "For questions that are part of learning resources (e.g. Quiz), eduQuestionType indicates the format of question being given. Example: \"Multiple choice\", \"Open ended\", \"Flashcard\"." ;
 .
 
-sdo:educationRequirements
+schema:educationRequirements
     rdfs:label "education requirements" ;
     rdfs:comment "Educational background needed for the position or Occupation." ;
 .
 
-sdo:educationalAlignment
+schema:educationalAlignment
     rdfs:label "educational alignment" ;
     rdfs:comment """An alignment to an established educational framework.
 
 This property should not be used where the nature of the alignment can be described using a simple property, for example to express that a resource [[teaches]] or [[assesses]] a competency.""" ;
 .
 
-sdo:educationalCredentialAwarded
+schema:educationalCredentialAwarded
     rdfs:label "educational credentialAwarded" ;
     rdfs:comment "A description of the qualification, award, certificate, diploma or other educational credential awarded as a consequence of successful completion of this course or program." ;
 .
 
-sdo:educationalFramework
+schema:educationalFramework
     rdfs:label "educational framework" ;
     rdfs:comment "The framework to which the resource being described is aligned." ;
 .
 
-sdo:educationalLevel
+schema:educationalLevel
     rdfs:label "educational level" ;
     rdfs:comment "The level in terms of progression through an educational or training context. Examples of educational levels include 'beginner', 'intermediate' or 'advanced', and formal sets of level indicators." ;
 .
 
-sdo:educationalProgramMode
+schema:educationalProgramMode
     rdfs:label "educational programMode" ;
     rdfs:comment "Similar to courseMode, The medium or means of delivery of the program as a whole. The value may either be a text label (e.g. \"online\", \"onsite\" or \"blended\"; \"synchronous\" or \"asynchronous\"; \"full-time\" or \"part-time\") or a URL reference to a term from a controlled vocabulary (e.g. https://ceds.ed.gov/element/001311#Asynchronous )." ;
 .
 
-sdo:educationalRole
+schema:educationalRole
     rdfs:label "educational role" ;
     rdfs:comment "An educationalRole of an EducationalAudience." ;
 .
 
-sdo:educationalUse
+schema:educationalUse
     rdfs:label "educational use" ;
     rdfs:comment "The purpose of a work in the context of education; for example, 'assignment', 'group work'." ;
 .
 
-sdo:elevation
+schema:elevation
     rdfs:label "elevation" ;
     rdfs:comment "The elevation of a location ([WGS 84](https://en.wikipedia.org/wiki/World_Geodetic_System)). Values may be of the form 'NUMBER UNIT_OF_MEASUREMENT' (e.g., '1,000 m', '3,200 ft') while numbers alone should be assumed to be a value in meters." ;
 .
 
-sdo:eligibilityToWorkRequirement
+schema:eligibilityToWorkRequirement
     rdfs:label "eligibility to Work Requirement" ;
     rdfs:comment "The legal requirements such as citizenship, visa and other documentation required for an applicant to this job." ;
 .
 
-sdo:eligibleCustomerType
+schema:eligibleCustomerType
     rdfs:label "eligible customerType" ;
     rdfs:comment "The type(s) of customers for which the given offer is valid." ;
 .
 
-sdo:eligibleDuration
+schema:eligibleDuration
     rdfs:label "eligible duration" ;
     rdfs:comment "The duration for which the given offer is valid." ;
 .
 
-sdo:eligibleQuantity
+schema:eligibleQuantity
     rdfs:label "eligible quantity" ;
     rdfs:comment "The interval and unit of measurement of ordering quantities for which the offer or price specification is valid. This allows e.g. specifying that a certain freight charge is valid only for a certain quantity." ;
 .
 
-sdo:eligibleRegion
+schema:eligibleRegion
     rdfs:label "eligible region" ;
     rdfs:comment """The ISO 3166-1 (ISO 3166-1 alpha-2) or ISO 3166-2 code, the place, or the GeoShape for the geo-political region(s) for which the offer or delivery charge specification is valid.\\n\\nSee also [[ineligibleRegion]].
     """ ;
 .
 
-sdo:eligibleTransactionVolume
+schema:eligibleTransactionVolume
     rdfs:label "eligible transactionVolume" ;
     rdfs:comment "The transaction volume, in a monetary unit, for which the offer or price specification is valid, e.g. for indicating a minimal purchasing volume, to express free shipping above a certain order volume, or to limit the acceptance of credit cards to purchases to a certain minimal amount." ;
 .
 
-sdo:email
+schema:email
     rdfs:label "email" ;
     rdfs:comment "Email address." ;
 .
 
-sdo:embedUrl
+schema:embedUrl
     rdfs:label "embed url" ;
     rdfs:comment "A URL pointing to a player for a specific video. In general, this is the information in the ```src``` element of an ```embed``` tag and should not be the same as the content of the ```loc``` tag." ;
 .
 
-sdo:embeddedTextCaption
+schema:embeddedTextCaption
     rdfs:label "embedded textCaption" ;
     rdfs:comment "Represents textual captioning from a [[MediaObject]], e.g. text of a 'meme'." ;
 .
 
-sdo:emissionsCO2
+schema:emissionsCO2
     rdfs:label "emissions co2" ;
     rdfs:comment "The CO2 emissions in g/km. When used in combination with a QuantitativeValue, put \"g/km\" into the unitText property of that value, since there is no UN/CEFACT Common Code for \"g/km\"." ;
 .
 
-sdo:employee
+schema:employee
     rdfs:label "employee" ;
     rdfs:comment "Someone working for this organization." ;
 .
 
-sdo:employees
+schema:employees
     rdfs:label "employees" ;
     rdfs:comment "People working for this organization." ;
 .
 
-sdo:employerOverview
+schema:employerOverview
     rdfs:label "employer overview" ;
     rdfs:comment "A description of the employer, career opportunities and work environment for this position." ;
 .
 
-sdo:employmentType
+schema:employmentType
     rdfs:label "employment type" ;
     rdfs:comment "Type of employment (e.g. full-time, part-time, contract, temporary, seasonal, internship)." ;
 .
 
-sdo:employmentUnit
+schema:employmentUnit
     rdfs:label "employment unit" ;
     rdfs:comment "Indicates the department, unit and/or facility where the employee reports and/or in which the job is to be performed." ;
 .
 
-sdo:encodesBioChemEntity
+schema:encodesBioChemEntity
     rdfs:label "encodes bio Chem Entity" ;
     rdfs:comment "Another BioChemEntity encoded by this one. " ;
 .
 
-sdo:encodesCreativeWork
+schema:encodesCreativeWork
     rdfs:label "encodes creativeWork" ;
     rdfs:comment "The CreativeWork encoded by this media object." ;
 .
 
-sdo:encoding
+schema:encoding
     rdfs:label "encoding" ;
     rdfs:comment "A media object that encodes this CreativeWork. This property is a synonym for associatedMedia." ;
 .
 
-sdo:encodingFormat
+schema:encodingFormat
     rdfs:label "encoding format" ;
     rdfs:comment """Media type typically expressed using a MIME format (see [IANA site](http://www.iana.org/assignments/media-types/media-types.xhtml) and [MDN reference](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types)) e.g. application/zip for a SoftwareApplication binary, audio/mpeg for .mp3 etc.).
 
@@ -11858,138 +11858,138 @@ In cases where a [[CreativeWork]] has several media type representations, [[enco
 Unregistered or niche encoding and file formats can be indicated instead via the most appropriate URL, e.g. defining Web page or a Wikipedia/Wikidata entry.""" ;
 .
 
-sdo:encodingType
+schema:encodingType
     rdfs:label "encoding type" ;
     rdfs:comment "The supported encoding type(s) for an EntryPoint request." ;
 .
 
-sdo:encodings
+schema:encodings
     rdfs:label "encodings" ;
     rdfs:comment "A media object that encodes this CreativeWork." ;
 .
 
-sdo:endDate
+schema:endDate
     rdfs:label "end date" ;
     rdfs:comment "The end date and time of the item (in [ISO 8601 date format](http://en.wikipedia.org/wiki/ISO_8601))." ;
 .
 
-sdo:endOffset
+schema:endOffset
     rdfs:label "end offset" ;
     rdfs:comment "The end time of the clip expressed as the number of seconds from the beginning of the work." ;
 .
 
-sdo:endTime
+schema:endTime
     rdfs:label "end time" ;
     rdfs:comment "The endTime of something. For a reserved event or service (e.g. FoodEstablishmentReservation), the time that it is expected to end. For actions that span a period of time, when the action was performed. e.g. John wrote a book from January to *December*. For media, including audio and video, it's the time offset of the end of a clip within a larger file.\\n\\nNote that Event uses startDate/endDate instead of startTime/endTime, even when describing dates with times. This situation may be clarified in future revisions." ;
 .
 
-sdo:endorsee
+schema:endorsee
     rdfs:label "endorsee" ;
     rdfs:comment "A sub property of participant. The person/organization being supported." ;
 .
 
-sdo:endorsers
+schema:endorsers
     rdfs:label "endorsers" ;
     rdfs:comment "People or organizations that endorse the plan." ;
 .
 
-sdo:energyEfficiencyScaleMax
+schema:energyEfficiencyScaleMax
     rdfs:label "energy efficiency Scale Max" ;
     rdfs:comment "Specifies the most energy efficient class on the regulated EU energy consumption scale for the product category a product belongs to. For example, energy consumption for televisions placed on the market after January 1, 2020 is scaled from D to A+++." ;
 .
 
-sdo:energyEfficiencyScaleMin
+schema:energyEfficiencyScaleMin
     rdfs:label "energy efficiency Scale Min" ;
     rdfs:comment "Specifies the least energy efficient class on the regulated EU energy consumption scale for the product category a product belongs to. For example, energy consumption for televisions placed on the market after January 1, 2020 is scaled from D to A+++." ;
 .
 
-sdo:engineDisplacement
+schema:engineDisplacement
     rdfs:label "engine displacement" ;
     rdfs:comment "The volume swept by all of the pistons inside the cylinders of an internal combustion engine in a single movement. \\n\\nTypical unit code(s): CMQ for cubic centimeter, LTR for liters, INQ for cubic inches\\n* Note 1: You can link to information about how the given value has been determined using the [[valueReference]] property.\\n* Note 2: You can use [[minValue]] and [[maxValue]] to indicate ranges." ;
 .
 
-sdo:enginePower
+schema:enginePower
     rdfs:label "engine power" ;
     rdfs:comment """The power of the vehicle's engine.
     Typical unit code(s): KWT for kilowatt, BHP for brake horsepower, N12 for metric horsepower (PS, with 1 PS = 735,49875 W)\\n\\n* Note 1: There are many different ways of measuring an engine's power. For an overview, see  [http://en.wikipedia.org/wiki/Horsepower#Engine_power_test_codes](http://en.wikipedia.org/wiki/Horsepower#Engine_power_test_codes).\\n* Note 2: You can link to information about how the given value has been determined using the [[valueReference]] property.\\n* Note 3: You can use [[minValue]] and [[maxValue]] to indicate ranges.""" ;
 .
 
-sdo:engineType
+schema:engineType
     rdfs:label "engine type" ;
     rdfs:comment "The type of engine or engines powering the vehicle." ;
 .
 
-sdo:entertainmentBusiness
+schema:entertainmentBusiness
     rdfs:label "entertainment business" ;
     rdfs:comment "A sub property of location. The entertainment business where the action occurred." ;
 .
 
-sdo:epidemiology
+schema:epidemiology
     rdfs:label "epidemiology" ;
     rdfs:comment "The characteristics of associated patients, such as age, gender, race etc." ;
 .
 
-sdo:episode
+schema:episode
     rdfs:label "episode" ;
     rdfs:comment "An episode of a tv, radio or game media within a series or season." ;
 .
 
-sdo:episodeNumber
+schema:episodeNumber
     rdfs:label "episode number" ;
     rdfs:comment "Position of the episode within an ordered group of episodes." ;
 .
 
-sdo:episodes
+schema:episodes
     rdfs:label "episodes" ;
     rdfs:comment "An episode of a TV/radio series or season." ;
 .
 
-sdo:equal
+schema:equal
     rdfs:label "equal" ;
     rdfs:comment "This ordering relation for qualitative values indicates that the subject is equal to the object." ;
 .
 
-sdo:error
+schema:error
     rdfs:label "error" ;
     rdfs:comment "For failed actions, more information on the cause of the failure." ;
 .
 
-sdo:estimatedCost
+schema:estimatedCost
     rdfs:label "estimated cost" ;
     rdfs:comment "The estimated cost of the supply or supplies consumed when performing instructions." ;
 .
 
-sdo:estimatedFlightDuration
+schema:estimatedFlightDuration
     rdfs:label "estimated flightDuration" ;
     rdfs:comment "The estimated time the flight will take." ;
 .
 
-sdo:estimatedSalary
+schema:estimatedSalary
     rdfs:label "estimated salary" ;
     rdfs:comment "An estimated salary for a job posting or occupation, based on a variety of variables including, but not limited to industry, job title, and location. Estimated salaries  are often computed by outside organizations rather than the hiring organization, who may not have committed to the estimated value." ;
 .
 
-sdo:estimatesRiskOf
+schema:estimatesRiskOf
     rdfs:label "estimates riskOf" ;
     rdfs:comment "The condition, complication, or symptom whose risk is being estimated." ;
 .
 
-sdo:ethicsPolicy
+schema:ethicsPolicy
     rdfs:label "ethics policy" ;
     rdfs:comment "Statement about ethics policy, e.g. of a [[NewsMediaOrganization]] regarding journalistic and publishing practices, or of a [[Restaurant]], a page describing food source policies. In the case of a [[NewsMediaOrganization]], an ethicsPolicy is typically a statement describing the personal, organizational, and corporate standards of behavior expected by the organization." ;
 .
 
-sdo:event
+schema:event
     rdfs:label "event" ;
     rdfs:comment "Upcoming or past event associated with this place, organization, or action." ;
 .
 
-sdo:eventAttendanceMode
+schema:eventAttendanceMode
     rdfs:label "event attendanceMode" ;
     rdfs:comment "The eventAttendanceMode of an event indicates whether it occurs online, offline, or a mix." ;
 .
 
-sdo:eventSchedule
+schema:eventSchedule
     rdfs:label "event schedule" ;
     rdfs:comment """Associates an [[Event]] with a [[Schedule]]. There are circumstances where it is preferable to share a schedule for a series of
       repeating events rather than data on the individual events themselves. For example, a website or application might prefer to publish a schedule for a weekly
@@ -11999,32 +11999,32 @@ sdo:eventSchedule
       or seasons.""" ;
 .
 
-sdo:eventStatus
+schema:eventStatus
     rdfs:label "event status" ;
     rdfs:comment "An eventStatus of an event represents its status; particularly useful when an event is cancelled or rescheduled." ;
 .
 
-sdo:events
+schema:events
     rdfs:label "events" ;
     rdfs:comment "Upcoming or past events associated with this place or organization." ;
 .
 
-sdo:evidenceLevel
+schema:evidenceLevel
     rdfs:label "evidence level" ;
     rdfs:comment "Strength of evidence of the data used to formulate the guideline (enumerated)." ;
 .
 
-sdo:evidenceOrigin
+schema:evidenceOrigin
     rdfs:label "evidence origin" ;
     rdfs:comment "Source of the data used to formulate the guidance, e.g. RCT, consensus opinion, etc." ;
 .
 
-sdo:exampleOfWork
+schema:exampleOfWork
     rdfs:label "example ofWork" ;
     rdfs:comment "A creative work that this work is an example/instance/realization/derivation of." ;
 .
 
-sdo:exceptDate
+schema:exceptDate
     rdfs:label "except date" ;
     rdfs:comment """Defines a [[Date]] or [[DateTime]] during which a scheduled [[Event]] will not take place. The property allows exceptions to
       a [[Schedule]] to be specified. If an exception is specified as a [[DateTime]] then only the event that would have started at that specific date and time
@@ -12032,1643 +12032,1643 @@ sdo:exceptDate
       excluded from the schedule. This allows a whole day to be excluded from the schedule without having to itemise every scheduled event.""" ;
 .
 
-sdo:exchangeRateSpread
+schema:exchangeRateSpread
     rdfs:label "exchange rateSpread" ;
     rdfs:comment "The difference between the price at which a broker or other intermediary buys and sells foreign currency." ;
 .
 
-sdo:executableLibraryName
+schema:executableLibraryName
     rdfs:label "executable libraryName" ;
     rdfs:comment "Library file name e.g., mscorlib.dll, system.web.dll." ;
 .
 
-sdo:exerciseCourse
+schema:exerciseCourse
     rdfs:label "exercise course" ;
     rdfs:comment "A sub property of location. The course where this action was taken." ;
 .
 
-sdo:exercisePlan
+schema:exercisePlan
     rdfs:label "exercise plan" ;
     rdfs:comment "A sub property of instrument. The exercise plan used on this action." ;
 .
 
-sdo:exerciseRelatedDiet
+schema:exerciseRelatedDiet
     rdfs:label "exercise relatedDiet" ;
     rdfs:comment "A sub property of instrument. The diet used in this action." ;
 .
 
-sdo:exerciseType
+schema:exerciseType
     rdfs:label "exercise type" ;
     rdfs:comment "Type(s) of exercise or activity, such as strength training, flexibility training, aerobics, cardiac rehabilitation, etc." ;
 .
 
-sdo:exifData
+schema:exifData
     rdfs:label "exif data" ;
     rdfs:comment "exif data for this object." ;
 .
 
-sdo:expectedArrivalFrom
+schema:expectedArrivalFrom
     rdfs:label "expected arrivalFrom" ;
     rdfs:comment "The earliest date the package may arrive." ;
 .
 
-sdo:expectedArrivalUntil
+schema:expectedArrivalUntil
     rdfs:label "expected arrivalUntil" ;
     rdfs:comment "The latest date the package may arrive." ;
 .
 
-sdo:expectedPrognosis
+schema:expectedPrognosis
     rdfs:label "expected prognosis" ;
     rdfs:comment "The likely outcome in either the short term or long term of the medical condition." ;
 .
 
-sdo:expectsAcceptanceOf
+schema:expectsAcceptanceOf
     rdfs:label "expects acceptanceOf" ;
     rdfs:comment "An Offer which must be accepted before the user can perform the Action. For example, the user may need to buy a movie before being able to watch it." ;
 .
 
-sdo:experienceInPlaceOfEducation
+schema:experienceInPlaceOfEducation
     rdfs:label "experience inPlace Of Education" ;
     rdfs:comment "Indicates whether a [[JobPosting]] will accept experience (as indicated by [[OccupationalExperienceRequirements]]) in place of its formal educational qualifications (as indicated by [[educationRequirements]]). If true, indicates that satisfying one of these requirements is sufficient." ;
 .
 
-sdo:experienceRequirements
+schema:experienceRequirements
     rdfs:label "experience requirements" ;
     rdfs:comment "Description of skills and experience needed for the position or Occupation." ;
 .
 
-sdo:expertConsiderations
+schema:expertConsiderations
     rdfs:label "expert considerations" ;
     rdfs:comment "Medical expert advice related to the plan." ;
 .
 
-sdo:expires
+schema:expires
     rdfs:label "expires" ;
     rdfs:comment "Date the content expires and is no longer useful or available. For example a [[VideoObject]] or [[NewsArticle]] whose availability or relevance is time-limited, or a [[ClaimReview]] fact check whose publisher wants to indicate that it may no longer be relevant (or helpful to highlight) after some date." ;
 .
 
-sdo:expressedIn
+schema:expressedIn
     rdfs:label "expressed in" ;
     rdfs:comment "Tissue, organ, biological sample, etc in which activity of this gene has been observed experimentally. For example brain, digestive system." ;
 .
 
-sdo:familyName
+schema:familyName
     rdfs:label "family name" ;
     rdfs:comment "Family name. In the U.S., the last name of a Person." ;
 .
 
-sdo:fatContent
+schema:fatContent
     rdfs:label "fat content" ;
     rdfs:comment "The number of grams of fat." ;
 .
 
-sdo:faxNumber
+schema:faxNumber
     rdfs:label "fax number" ;
     rdfs:comment "The fax number." ;
 .
 
-sdo:featureList
+schema:featureList
     rdfs:label "feature list" ;
     rdfs:comment "Features or modules provided by this application (and possibly required by other applications)." ;
 .
 
-sdo:feesAndCommissionsSpecification
+schema:feesAndCommissionsSpecification
     rdfs:label "fees and Commissions Specification" ;
     rdfs:comment "Description of fees, commissions, and other terms applied either to a class of financial product, or by a financial service organization." ;
 .
 
-sdo:fiberContent
+schema:fiberContent
     rdfs:label "fiber content" ;
     rdfs:comment "The number of grams of fiber." ;
 .
 
-sdo:fileFormat
+schema:fileFormat
     rdfs:label "file format" ;
     rdfs:comment "Media type, typically MIME format (see [IANA site](http://www.iana.org/assignments/media-types/media-types.xhtml)) of the content e.g. application/zip of a SoftwareApplication binary. In cases where a CreativeWork has several media type representations, 'encoding' can be used to indicate each MediaObject alongside particular fileFormat information. Unregistered or niche file formats can be indicated instead via the most appropriate URL, e.g. defining Web page or a Wikipedia entry." ;
 .
 
-sdo:fileSize
+schema:fileSize
     rdfs:label "file size" ;
     rdfs:comment "Size of the application / package (e.g. 18MB). In the absence of a unit (MB, KB etc.), KB will be assumed." ;
 .
 
-sdo:financialAidEligible
+schema:financialAidEligible
     rdfs:label "financial aidEligible" ;
     rdfs:comment "A financial aid type or program which students may use to pay for tuition or fees associated with the program." ;
 .
 
-sdo:firstAppearance
+schema:firstAppearance
     rdfs:label "first appearance" ;
     rdfs:comment "Indicates the first known occurence of a [[Claim]] in some [[CreativeWork]]." ;
 .
 
-sdo:firstPerformance
+schema:firstPerformance
     rdfs:label "first performance" ;
     rdfs:comment "The date and place the work was first performed." ;
 .
 
-sdo:flightDistance
+schema:flightDistance
     rdfs:label "flight distance" ;
     rdfs:comment "The distance of the flight." ;
 .
 
-sdo:flightNumber
+schema:flightNumber
     rdfs:label "flight number" ;
     rdfs:comment "The unique identifier for a flight including the airline IATA code. For example, if describing United flight 110, where the IATA code for United is 'UA', the flightNumber is 'UA110'." ;
 .
 
-sdo:floorLevel
+schema:floorLevel
     rdfs:label "floor level" ;
     rdfs:comment """The floor level for an [[Accommodation]] in a multi-storey building. Since counting
   systems [vary internationally](https://en.wikipedia.org/wiki/Storey#Consecutive_number_floor_designations), the local system should be used where possible.""" ;
 .
 
-sdo:floorLimit
+schema:floorLimit
     rdfs:label "floor limit" ;
     rdfs:comment "A floor limit is the amount of money above which credit card transactions must be authorized." ;
 .
 
-sdo:floorSize
+schema:floorSize
     rdfs:label "floor size" ;
     rdfs:comment """The size of the accommodation, e.g. in square meter or squarefoot.
 Typical unit code(s): MTK for square meter, FTK for square foot, or YDK for square yard """ ;
 .
 
-sdo:followee
+schema:followee
     rdfs:label "followee" ;
     rdfs:comment "A sub property of object. The person or organization being followed." ;
 .
 
-sdo:follows
+schema:follows
     rdfs:label "follows" ;
     rdfs:comment "The most generic uni-directional social relation." ;
 .
 
-sdo:followup
+schema:followup
     rdfs:label "followup" ;
     rdfs:comment "Typical or recommended followup care after the procedure is performed." ;
 .
 
-sdo:foodEstablishment
+schema:foodEstablishment
     rdfs:label "food establishment" ;
     rdfs:comment "A sub property of location. The specific food establishment where the action occurred." ;
 .
 
-sdo:foodEvent
+schema:foodEvent
     rdfs:label "food event" ;
     rdfs:comment "A sub property of location. The specific food event where the action occurred." ;
 .
 
-sdo:foodWarning
+schema:foodWarning
     rdfs:label "food warning" ;
     rdfs:comment "Any precaution, guidance, contraindication, etc. related to consumption of specific foods while taking this drug." ;
 .
 
-sdo:founder
+schema:founder
     rdfs:label "founder" ;
     rdfs:comment "A person who founded this organization." ;
 .
 
-sdo:founders
+schema:founders
     rdfs:label "founders" ;
     rdfs:comment "A person who founded this organization." ;
 .
 
-sdo:foundingDate
+schema:foundingDate
     rdfs:label "founding date" ;
     rdfs:comment "The date that this organization was founded." ;
 .
 
-sdo:foundingLocation
+schema:foundingLocation
     rdfs:label "founding location" ;
     rdfs:comment "The place where the Organization was founded." ;
 .
 
-sdo:free
+schema:free
     rdfs:label "free" ;
     rdfs:comment "A flag to signal that the item, event, or place is accessible for free." ;
 .
 
-sdo:freeShippingThreshold
+schema:freeShippingThreshold
     rdfs:label "free shippingThreshold" ;
     rdfs:comment "A monetary value above which (or equal to) the shipping rate becomes free. Intended to be used via an [[OfferShippingDetails]] with [[shippingSettingsLink]] matching this [[ShippingRateSettings]]." ;
 .
 
-sdo:frequency
+schema:frequency
     rdfs:label "frequency" ;
     rdfs:comment "How often the dose is taken, e.g. 'daily'." ;
 .
 
-sdo:fromLocation
+schema:fromLocation
     rdfs:label "from location" ;
     rdfs:comment "A sub property of location. The original location of the object or the agent before the action." ;
 .
 
-sdo:fuelCapacity
+schema:fuelCapacity
     rdfs:label "fuel capacity" ;
     rdfs:comment "The capacity of the fuel tank or in the case of electric cars, the battery. If there are multiple components for storage, this should indicate the total of all storage of the same type.\\n\\nTypical unit code(s): LTR for liters, GLL of US gallons, GLI for UK / imperial gallons, AMH for ampere-hours (for electrical vehicles)." ;
 .
 
-sdo:fuelConsumption
+schema:fuelConsumption
     rdfs:label "fuel consumption" ;
     rdfs:comment "The amount of fuel consumed for traveling a particular distance or temporal duration with the given vehicle (e.g. liters per 100 km).\\n\\n* Note 1: There are unfortunately no standard unit codes for liters per 100 km.  Use [[unitText]] to indicate the unit of measurement, e.g. L/100 km.\\n* Note 2: There are two ways of indicating the fuel consumption, [[fuelConsumption]] (e.g. 8 liters per 100 km) and [[fuelEfficiency]] (e.g. 30 miles per gallon). They are reciprocal.\\n* Note 3: Often, the absolute value is useful only when related to driving speed (\"at 80 km/h\") or usage pattern (\"city traffic\"). You can use [[valueReference]] to link the value for the fuel consumption to another value." ;
 .
 
-sdo:fuelEfficiency
+schema:fuelEfficiency
     rdfs:label "fuel efficiency" ;
     rdfs:comment "The distance traveled per unit of fuel used; most commonly miles per gallon (mpg) or kilometers per liter (km/L).\\n\\n* Note 1: There are unfortunately no standard unit codes for miles per gallon or kilometers per liter. Use [[unitText]] to indicate the unit of measurement, e.g. mpg or km/L.\\n* Note 2: There are two ways of indicating the fuel consumption, [[fuelConsumption]] (e.g. 8 liters per 100 km) and [[fuelEfficiency]] (e.g. 30 miles per gallon). They are reciprocal.\\n* Note 3: Often, the absolute value is useful only when related to driving speed (\"at 80 km/h\") or usage pattern (\"city traffic\"). You can use [[valueReference]] to link the value for the fuel economy to another value." ;
 .
 
-sdo:fuelType
+schema:fuelType
     rdfs:label "fuel type" ;
     rdfs:comment "The type of fuel suitable for the engine or engines of the vehicle. If the vehicle has only one engine, this property can be attached directly to the vehicle." ;
 .
 
-sdo:functionalClass
+schema:functionalClass
     rdfs:label "functional class" ;
     rdfs:comment "The degree of mobility the joint allows." ;
 .
 
-sdo:fundedItem
+schema:fundedItem
     rdfs:label "funded item" ;
     rdfs:comment "Indicates an item funded or sponsored through a [[Grant]]." ;
 .
 
-sdo:funder
+schema:funder
     rdfs:label "funder" ;
     rdfs:comment "A person or organization that supports (sponsors) something through some kind of financial contribution." ;
 .
 
-sdo:game
+schema:game
     rdfs:label "game" ;
     rdfs:comment "Video game which is played on this server." ;
 .
 
-sdo:gameItem
+schema:gameItem
     rdfs:label "game item" ;
     rdfs:comment "An item is an object within the game world that can be collected by a player or, occasionally, a non-player character." ;
 .
 
-sdo:gameLocation
+schema:gameLocation
     rdfs:label "game location" ;
     rdfs:comment "Real or fictional location of the game (or part of game)." ;
 .
 
-sdo:gamePlatform
+schema:gamePlatform
     rdfs:label "game platform" ;
     rdfs:comment "The electronic systems used to play <a href=\"http://en.wikipedia.org/wiki/Category:Video_game_platforms\">video games</a>." ;
 .
 
-sdo:gameServer
+schema:gameServer
     rdfs:label "game server" ;
     rdfs:comment "The server on which  it is possible to play the game." ;
 .
 
-sdo:gameTip
+schema:gameTip
     rdfs:label "game tip" ;
     rdfs:comment "Links to tips, tactics, etc." ;
 .
 
-sdo:gender
+schema:gender
     rdfs:label "gender" ;
     rdfs:comment "Gender of something, typically a [[Person]], but possibly also fictional characters, animals, etc. While https://schema.org/Male and https://schema.org/Female may be used, text strings are also acceptable for people who do not identify as a binary gender. The [[gender]] property can also be used in an extended sense to cover e.g. the gender of sports teams. As with the gender of individuals, we do not try to enumerate all possibilities. A mixed-gender [[SportsTeam]] can be indicated with a text value of \"Mixed\"." ;
 .
 
-sdo:genre
+schema:genre
     rdfs:label "genre" ;
     rdfs:comment "Genre of the creative work, broadcast channel or group." ;
 .
 
-sdo:geo
+schema:geo
     rdfs:label "geo" ;
     rdfs:comment "The geo coordinates of the place." ;
 .
 
-sdo:geoContains
+schema:geoContains
     rdfs:label "geo contains" ;
     rdfs:comment "Represents a relationship between two geometries (or the places they represent), relating a containing geometry to a contained geometry. \"a contains b iff no points of b lie in the exterior of a, and at least one point of the interior of b lies in the interior of a\". As defined in [DE-9IM](https://en.wikipedia.org/wiki/DE-9IM)." ;
 .
 
-sdo:geoCoveredBy
+schema:geoCoveredBy
     rdfs:label "geo coveredBy" ;
     rdfs:comment "Represents a relationship between two geometries (or the places they represent), relating a geometry to another that covers it. As defined in [DE-9IM](https://en.wikipedia.org/wiki/DE-9IM)." ;
 .
 
-sdo:geoCovers
+schema:geoCovers
     rdfs:label "geo covers" ;
     rdfs:comment "Represents a relationship between two geometries (or the places they represent), relating a covering geometry to a covered geometry. \"Every point of b is a point of (the interior or boundary of) a\". As defined in [DE-9IM](https://en.wikipedia.org/wiki/DE-9IM)." ;
 .
 
-sdo:geoCrosses
+schema:geoCrosses
     rdfs:label "geo crosses" ;
     rdfs:comment "Represents a relationship between two geometries (or the places they represent), relating a geometry to another that crosses it: \"a crosses b: they have some but not all interior points in common, and the dimension of the intersection is less than that of at least one of them\". As defined in [DE-9IM](https://en.wikipedia.org/wiki/DE-9IM)." ;
 .
 
-sdo:geoDisjoint
+schema:geoDisjoint
     rdfs:label "geo disjoint" ;
     rdfs:comment "Represents spatial relations in which two geometries (or the places they represent) are topologically disjoint: they have no point in common. They form a set of disconnected geometries.\" (a symmetric relationship, as defined in [DE-9IM](https://en.wikipedia.org/wiki/DE-9IM))" ;
 .
 
-sdo:geoEquals
+schema:geoEquals
     rdfs:label "geo equals" ;
     rdfs:comment "Represents spatial relations in which two geometries (or the places they represent) are topologically equal, as defined in [DE-9IM](https://en.wikipedia.org/wiki/DE-9IM). \"Two geometries are topologically equal if their interiors intersect and no part of the interior or boundary of one geometry intersects the exterior of the other\" (a symmetric relationship)" ;
 .
 
-sdo:geoIntersects
+schema:geoIntersects
     rdfs:label "geo intersects" ;
     rdfs:comment "Represents spatial relations in which two geometries (or the places they represent) have at least one point in common. As defined in [DE-9IM](https://en.wikipedia.org/wiki/DE-9IM)." ;
 .
 
-sdo:geoMidpoint
+schema:geoMidpoint
     rdfs:label "geo midpoint" ;
     rdfs:comment "Indicates the GeoCoordinates at the centre of a GeoShape e.g. GeoCircle." ;
 .
 
-sdo:geoOverlaps
+schema:geoOverlaps
     rdfs:label "geo overlaps" ;
     rdfs:comment "Represents a relationship between two geometries (or the places they represent), relating a geometry to another that geospatially overlaps it, i.e. they have some but not all points in common. As defined in [DE-9IM](https://en.wikipedia.org/wiki/DE-9IM)." ;
 .
 
-sdo:geoRadius
+schema:geoRadius
     rdfs:label "geo radius" ;
     rdfs:comment "Indicates the approximate radius of a GeoCircle (metres unless indicated otherwise via Distance notation)." ;
 .
 
-sdo:geoTouches
+schema:geoTouches
     rdfs:label "geo touches" ;
     rdfs:comment "Represents spatial relations in which two geometries (or the places they represent) touch: they have at least one boundary point in common, but no interior points.\" (a symmetric relationship, as defined in [DE-9IM](https://en.wikipedia.org/wiki/DE-9IM) )" ;
 .
 
-sdo:geoWithin
+schema:geoWithin
     rdfs:label "geo within" ;
     rdfs:comment "Represents a relationship between two geometries (or the places they represent), relating a geometry to one that contains it, i.e. it is inside (i.e. within) its interior. As defined in [DE-9IM](https://en.wikipedia.org/wiki/DE-9IM)." ;
 .
 
-sdo:geographicArea
+schema:geographicArea
     rdfs:label "geographic area" ;
     rdfs:comment "The geographic area associated with the audience." ;
 .
 
-sdo:gettingTestedInfo
+schema:gettingTestedInfo
     rdfs:label "getting testedInfo" ;
     rdfs:comment "Information about getting tested (for a [[MedicalCondition]]), e.g. in the context of a pandemic." ;
 .
 
-sdo:givenName
+schema:givenName
     rdfs:label "given name" ;
     rdfs:comment "Given name. In the U.S., the first name of a Person." ;
 .
 
-sdo:globalLocationNumber
+schema:globalLocationNumber
     rdfs:label "global locationNumber" ;
     rdfs:comment "The [Global Location Number](http://www.gs1.org/gln) (GLN, sometimes also referred to as International Location Number or ILN) of the respective organization, person, or place. The GLN is a 13-digit number used to identify parties and physical locations." ;
 .
 
-sdo:governmentBenefitsInfo
+schema:governmentBenefitsInfo
     rdfs:label "government benefitsInfo" ;
     rdfs:comment "governmentBenefitsInfo provides information about government benefits associated with a SpecialAnnouncement." ;
 .
 
-sdo:gracePeriod
+schema:gracePeriod
     rdfs:label "grace period" ;
     rdfs:comment "The period of time after any due date that the borrower has to fulfil its obligations before a default (failure to pay) is deemed to have occurred." ;
 .
 
-sdo:grantee
+schema:grantee
     rdfs:label "grantee" ;
     rdfs:comment "The person, organization, contact point, or audience that has been granted this permission." ;
 .
 
-sdo:greater
+schema:greater
     rdfs:label "greater" ;
     rdfs:comment "This ordering relation for qualitative values indicates that the subject is greater than the object." ;
 .
 
-sdo:greaterOrEqual
+schema:greaterOrEqual
     rdfs:label "greater orEqual" ;
     rdfs:comment "This ordering relation for qualitative values indicates that the subject is greater than or equal to the object." ;
 .
 
-sdo:gtin
+schema:gtin
     rdfs:label "gtin" ;
     rdfs:comment """A Global Trade Item Number ([GTIN](https://www.gs1.org/standards/id-keys/gtin)). GTINs identify trade items, including products and services, using numeric identification codes. The [[gtin]] property generalizes the earlier [[gtin8]], [[gtin12]], [[gtin13]], and [[gtin14]] properties. The GS1 [digital link specifications](https://www.gs1.org/standards/Digital-Link/) express GTINs as URLs. A correct [[gtin]] value should be a valid GTIN, which means that it should be an all-numeric string of either 8, 12, 13 or 14 digits, or a "GS1 Digital Link" URL based on such a string. The numeric component should also have a [valid GS1 check digit](https://www.gs1.org/services/check-digit-calculator) and meet the other rules for valid GTINs. See also [GS1's GTIN Summary](http://www.gs1.org/barcodes/technical/idkeys/gtin) and [Wikipedia](https://en.wikipedia.org/wiki/Global_Trade_Item_Number) for more details. Left-padding of the gtin values is not required or encouraged.
    """ ;
 .
 
-sdo:gtin12
+schema:gtin12
     rdfs:label "gtin12" ;
     rdfs:comment "The GTIN-12 code of the product, or the product to which the offer refers. The GTIN-12 is the 12-digit GS1 Identification Key composed of a U.P.C. Company Prefix, Item Reference, and Check Digit used to identify trade items. See [GS1 GTIN Summary](http://www.gs1.org/barcodes/technical/idkeys/gtin) for more details." ;
 .
 
-sdo:gtin13
+schema:gtin13
     rdfs:label "gtin13" ;
     rdfs:comment "The GTIN-13 code of the product, or the product to which the offer refers. This is equivalent to 13-digit ISBN codes and EAN UCC-13. Former 12-digit UPC codes can be converted into a GTIN-13 code by simply adding a preceding zero. See [GS1 GTIN Summary](http://www.gs1.org/barcodes/technical/idkeys/gtin) for more details." ;
 .
 
-sdo:gtin14
+schema:gtin14
     rdfs:label "gtin14" ;
     rdfs:comment "The GTIN-14 code of the product, or the product to which the offer refers. See [GS1 GTIN Summary](http://www.gs1.org/barcodes/technical/idkeys/gtin) for more details." ;
 .
 
-sdo:gtin8
+schema:gtin8
     rdfs:label "gtin8" ;
     rdfs:comment "The GTIN-8 code of the product, or the product to which the offer refers. This code is also known as EAN/UCC-8 or 8-digit EAN. See [GS1 GTIN Summary](http://www.gs1.org/barcodes/technical/idkeys/gtin) for more details." ;
 .
 
-sdo:guideline
+schema:guideline
     rdfs:label "guideline" ;
     rdfs:comment "A medical guideline related to this entity." ;
 .
 
-sdo:guidelineDate
+schema:guidelineDate
     rdfs:label "guideline date" ;
     rdfs:comment "Date on which this guideline's recommendation was made." ;
 .
 
-sdo:guidelineSubject
+schema:guidelineSubject
     rdfs:label "guideline subject" ;
     rdfs:comment "The medical conditions, treatments, etc. that are the subject of the guideline." ;
 .
 
-sdo:handlingTime
+schema:handlingTime
     rdfs:label "handling time" ;
     rdfs:comment "The typical delay between the receipt of the order and the goods either leaving the warehouse or being prepared for pickup, in case the delivery method is on site pickup. Typical properties: minValue, maxValue, unitCode (d for DAY).  This is by common convention assumed to mean business days (if a unitCode is used, coded as \"d\"), i.e. only counting days when the business normally operates." ;
 .
 
-sdo:hasBioChemEntityPart
+schema:hasBioChemEntityPart
     rdfs:label "has bioChem Entity Part" ;
     rdfs:comment "Indicates a BioChemEntity that (in some sense) has this BioChemEntity as a part. " ;
 .
 
-sdo:hasBioPolymerSequence
+schema:hasBioPolymerSequence
     rdfs:label "has bio Polymer Sequence" ;
     rdfs:comment "A symbolic representation of a BioChemEnity. For example, a nucleotide sequence of a Gene or an amino acid sequence of a Protein." ;
 .
 
-sdo:hasBroadcastChannel
+schema:hasBroadcastChannel
     rdfs:label "has broadcastChannel" ;
     rdfs:comment "A broadcast channel of a broadcast service." ;
 .
 
-sdo:hasCategoryCode
+schema:hasCategoryCode
     rdfs:label "has categoryCode" ;
     rdfs:comment "A Category code contained in this code set." ;
 .
 
-sdo:hasCourse
+schema:hasCourse
     rdfs:label "has course" ;
     rdfs:comment "A course or class that is one of the learning opportunities that constitute an educational / occupational program. No information is implied about whether the course is mandatory or optional; no guarantee is implied about whether the course will be available to everyone on the program." ;
 .
 
-sdo:hasCourseInstance
+schema:hasCourseInstance
     rdfs:label "has courseInstance" ;
     rdfs:comment "An offering of the course at a specific time and place or through specific media or mode of study or to a specific section of students." ;
 .
 
-sdo:hasCredential
+schema:hasCredential
     rdfs:label "has credential" ;
     rdfs:comment "A credential awarded to the Person or Organization." ;
 .
 
-sdo:hasDefinedTerm
+schema:hasDefinedTerm
     rdfs:label "has definedTerm" ;
     rdfs:comment "A Defined Term contained in this term set." ;
 .
 
-sdo:hasDeliveryMethod
+schema:hasDeliveryMethod
     rdfs:label "has deliveryMethod" ;
     rdfs:comment "Method used for delivery or shipping." ;
 .
 
-sdo:hasDigitalDocumentPermission
+schema:hasDigitalDocumentPermission
     rdfs:label "has digital Document Permission" ;
     rdfs:comment "A permission related to the access to this document (e.g. permission to read or write an electronic document). For a public document, specify a grantee with an Audience with audienceType equal to \"public\"." ;
 .
 
-sdo:hasDriveThroughService
+schema:hasDriveThroughService
     rdfs:label "has drive Through Service" ;
     rdfs:comment "Indicates whether some facility (e.g. [[FoodEstablishment]], [[CovidTestingFacility]]) offers a service that can be used by driving through in a car. In the case of [[CovidTestingFacility]] such facilities could potentially help with social distancing from other potentially-infected users." ;
 .
 
-sdo:hasEnergyConsumptionDetails
+schema:hasEnergyConsumptionDetails
     rdfs:label "has energy Consumption Details" ;
     rdfs:comment "Defines the energy efficiency Category (also known as \"class\" or \"rating\") for a product according to an international energy efficiency standard." ;
 .
 
-sdo:hasEnergyEfficiencyCategory
+schema:hasEnergyEfficiencyCategory
     rdfs:label "has energy Efficiency Category" ;
     rdfs:comment "Defines the energy efficiency Category (which could be either a rating out of range of values or a yes/no certification) for a product according to an international energy efficiency standard." ;
 .
 
-sdo:hasHealthAspect
+schema:hasHealthAspect
     rdfs:label "has healthAspect" ;
     rdfs:comment "Indicates the aspect or aspects specifically addressed in some [[HealthTopicContent]]. For example, that the content is an overview, or that it talks about treatment, self-care, treatments or their side-effects." ;
 .
 
-sdo:hasMap
+schema:hasMap
     rdfs:label "has map" ;
     rdfs:comment "A URL to a map of the place." ;
 .
 
-sdo:hasMeasurement
+schema:hasMeasurement
     rdfs:label "has measurement" ;
     rdfs:comment "A product measurement, for example the inseam of pants, the wheel size of a bicycle, or the gauge of a screw. Usually an exact measurement, but can also be a range of measurements for adjustable products, for example belts and ski bindings." ;
 .
 
-sdo:hasMenu
+schema:hasMenu
     rdfs:label "has menu" ;
     rdfs:comment "Either the actual menu as a structured representation, as text, or a URL of the menu." ;
 .
 
-sdo:hasMenuItem
+schema:hasMenuItem
     rdfs:label "has menuItem" ;
     rdfs:comment "A food or drink item contained in a menu or menu section." ;
 .
 
-sdo:hasMenuSection
+schema:hasMenuSection
     rdfs:label "has menuSection" ;
     rdfs:comment "A subgrouping of the menu (by dishes, course, serving time period, etc.)." ;
 .
 
-sdo:hasMerchantReturnPolicy
+schema:hasMerchantReturnPolicy
     rdfs:label "has merchant Return Policy" ;
     rdfs:comment "Specifies a MerchantReturnPolicy that may be applicable." ;
 .
 
-sdo:hasMolecularFunction
+schema:hasMolecularFunction
     rdfs:label "has molecularFunction" ;
     rdfs:comment "Molecular function performed by this BioChemEntity; please use PropertyValue if you want to include any evidence." ;
 .
 
-sdo:hasOccupation
+schema:hasOccupation
     rdfs:label "has occupation" ;
     rdfs:comment "The Person's occupation. For past professions, use Role for expressing dates." ;
 .
 
-sdo:hasOfferCatalog
+schema:hasOfferCatalog
     rdfs:label "has offerCatalog" ;
     rdfs:comment "Indicates an OfferCatalog listing for this Organization, Person, or Service." ;
 .
 
-sdo:hasPOS
+schema:hasPOS
     rdfs:label "has pos" ;
     rdfs:comment "Points-of-Sales operated by the organization or person." ;
 .
 
-sdo:hasPart
+schema:hasPart
     rdfs:label "has part" ;
     rdfs:comment "Indicates an item or CreativeWork that is part of this item, or CreativeWork (in some sense)." ;
 .
 
-sdo:hasRepresentation
+schema:hasRepresentation
     rdfs:label "has representation" ;
     rdfs:comment "A common representation such as a protein sequence or chemical structure for this entity. For images use schema.org/image." ;
 .
 
-sdo:hasVariant
+schema:hasVariant
     rdfs:label "has variant" ;
     rdfs:comment "Indicates a [[Product]] that is a member of this [[ProductGroup]] (or [[ProductModel]])." ;
 .
 
-sdo:headline
+schema:headline
     rdfs:label "headline" ;
     rdfs:comment "Headline of the article." ;
 .
 
-sdo:healthCondition
+schema:healthCondition
     rdfs:label "health condition" ;
     rdfs:comment "Specifying the health condition(s) of a patient, medical study, or other target audience." ;
 .
 
-sdo:healthPlanCoinsuranceOption
+schema:healthPlanCoinsuranceOption
     rdfs:label "health plan Coinsurance Option" ;
     rdfs:comment "Whether the coinsurance applies before or after deductible, etc." ;
 .
 
-sdo:healthPlanCoinsuranceRate
+schema:healthPlanCoinsuranceRate
     rdfs:label "health plan Coinsurance Rate" ;
     rdfs:comment "Whether The rate of coinsurance expressed as a number between 0.0 and 1.0." ;
 .
 
-sdo:healthPlanCopay
+schema:healthPlanCopay
     rdfs:label "health planCopay" ;
     rdfs:comment "Whether The copay amount." ;
 .
 
-sdo:healthPlanCopayOption
+schema:healthPlanCopayOption
     rdfs:label "health plan Copay Option" ;
     rdfs:comment "Whether the copay is before or after deductible, etc." ;
 .
 
-sdo:healthPlanCostSharing
+schema:healthPlanCostSharing
     rdfs:label "health plan Cost Sharing" ;
     rdfs:comment "Whether The costs to the patient for services under this network or formulary." ;
 .
 
-sdo:healthPlanDrugOption
+schema:healthPlanDrugOption
     rdfs:label "health plan Drug Option" ;
     rdfs:comment "" ;
 .
 
-sdo:healthPlanDrugTier
+schema:healthPlanDrugTier
     rdfs:label "health plan Drug Tier" ;
     rdfs:comment "The tier(s) of drugs offered by this formulary or insurance plan." ;
 .
 
-sdo:healthPlanId
+schema:healthPlanId
     rdfs:label "health planId" ;
     rdfs:comment "The 14-character, HIOS-generated Plan ID number. (Plan IDs must be unique, even across different markets.)" ;
 .
 
-sdo:healthPlanMarketingUrl
+schema:healthPlanMarketingUrl
     rdfs:label "health plan Marketing Url" ;
     rdfs:comment "The URL that goes directly to the plan brochure for the specific standard plan or plan variation." ;
 .
 
-sdo:healthPlanNetworkId
+schema:healthPlanNetworkId
     rdfs:label "health plan Network Id" ;
     rdfs:comment "Name or unique ID of network. (Networks are often reused across different insurance plans)." ;
 .
 
-sdo:healthPlanNetworkTier
+schema:healthPlanNetworkTier
     rdfs:label "health plan Network Tier" ;
     rdfs:comment "The tier(s) for this network." ;
 .
 
-sdo:healthPlanPharmacyCategory
+schema:healthPlanPharmacyCategory
     rdfs:label "health plan Pharmacy Category" ;
     rdfs:comment "The category or type of pharmacy associated with this cost sharing." ;
 .
 
-sdo:healthcareReportingData
+schema:healthcareReportingData
     rdfs:label "healthcare reportingData" ;
     rdfs:comment "Indicates data describing a hospital, e.g. a CDC [[CDCPMDRecord]] or as some kind of [[Dataset]]." ;
 .
 
-sdo:height
+schema:height
     rdfs:label "height" ;
     rdfs:comment "The height of the item." ;
 .
 
-sdo:highPrice
+schema:highPrice
     rdfs:label "high price" ;
     rdfs:comment "The highest price of all offers available.\\n\\nUsage guidelines:\\n\\n* Use values from 0123456789 (Unicode 'DIGIT ZERO' (U+0030) to 'DIGIT NINE' (U+0039)) rather than superficially similiar Unicode symbols.\\n* Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a decimal point. Avoid using these symbols as a readability separator." ;
 .
 
-sdo:hiringOrganization
+schema:hiringOrganization
     rdfs:label "hiring organization" ;
     rdfs:comment "Organization offering the job position." ;
 .
 
-sdo:holdingArchive
+schema:holdingArchive
     rdfs:label "holding archive"@en ;
     rdfs:comment "[[ArchiveOrganization]] that holds, keeps or maintains the [[ArchiveComponent]]."@en ;
 .
 
-sdo:homeLocation
+schema:homeLocation
     rdfs:label "home location" ;
     rdfs:comment "A contact location for a person's residence." ;
 .
 
-sdo:homeTeam
+schema:homeTeam
     rdfs:label "home team" ;
     rdfs:comment "The home team in a sports event." ;
 .
 
-sdo:honorificPrefix
+schema:honorificPrefix
     rdfs:label "honorific prefix" ;
     rdfs:comment "An honorific prefix preceding a Person's name such as Dr/Mrs/Mr." ;
 .
 
-sdo:honorificSuffix
+schema:honorificSuffix
     rdfs:label "honorific suffix" ;
     rdfs:comment "An honorific suffix following a Person's name such as M.D. /PhD/MSCSW." ;
 .
 
-sdo:hospitalAffiliation
+schema:hospitalAffiliation
     rdfs:label "hospital affiliation" ;
     rdfs:comment "A hospital with which the physician or office is affiliated." ;
 .
 
-sdo:hostingOrganization
+schema:hostingOrganization
     rdfs:label "hosting organization" ;
     rdfs:comment "The organization (airline, travelers' club, etc.) the membership is made with." ;
 .
 
-sdo:hoursAvailable
+schema:hoursAvailable
     rdfs:label "hours available" ;
     rdfs:comment "The hours during which this service or contact is available." ;
 .
 
-sdo:howPerformed
+schema:howPerformed
     rdfs:label "how performed" ;
     rdfs:comment "How the procedure is performed." ;
 .
 
-sdo:httpMethod
+schema:httpMethod
     rdfs:label "http method" ;
     rdfs:comment "An HTTP method that specifies the appropriate HTTP method for a request to an HTTP EntryPoint. Values are capitalized strings as used in HTTP." ;
 .
 
-sdo:iataCode
+schema:iataCode
     rdfs:label "iata code" ;
     rdfs:comment "IATA identifier for an airline or airport." ;
 .
 
-sdo:icaoCode
+schema:icaoCode
     rdfs:label "icao code" ;
     rdfs:comment "ICAO identifier for an airport." ;
 .
 
-sdo:identifier
+schema:identifier
     rdfs:label "identifier" ;
     rdfs:comment """The identifier property represents any kind of identifier for any kind of [[Thing]], such as ISBNs, GTIN codes, UUIDs etc. Schema.org provides dedicated properties for representing many of these, either as textual strings or as URL (URI) links. See [background notes](/docs/datamodel.html#identifierBg) for more details.
         """ ;
 .
 
-sdo:identifyingExam
+schema:identifyingExam
     rdfs:label "identifying exam" ;
     rdfs:comment "A physical examination that can identify this sign." ;
 .
 
-sdo:identifyingTest
+schema:identifyingTest
     rdfs:label "identifying test" ;
     rdfs:comment "A diagnostic test that can identify this sign." ;
 .
 
-sdo:illustrator
+schema:illustrator
     rdfs:label "illustrator" ;
     rdfs:comment "The illustrator of the book." ;
 .
 
-sdo:image
+schema:image
     rdfs:label "image" ;
     rdfs:comment "An image of the item. This can be a [[URL]] or a fully described [[ImageObject]]." ;
 .
 
-sdo:imagingTechnique
+schema:imagingTechnique
     rdfs:label "imaging technique" ;
     rdfs:comment "Imaging technique used." ;
 .
 
-sdo:inAlbum
+schema:inAlbum
     rdfs:label "in album" ;
     rdfs:comment "The album to which this recording belongs." ;
 .
 
-sdo:inBroadcastLineup
+schema:inBroadcastLineup
     rdfs:label "in broadcastLineup" ;
     rdfs:comment "The CableOrSatelliteService offering the channel." ;
 .
 
-sdo:inChI
+schema:inChI
     rdfs:label "in chI" ;
     rdfs:comment "Non-proprietary identifier for molecular entity that can be used in printed and electronic data sources thus enabling easier linking of diverse data compilations." ;
 .
 
-sdo:inChIKey
+schema:inChIKey
     rdfs:label "in chIKey" ;
     rdfs:comment "InChIKey is a hashed version of the full InChI (using the SHA-256 algorithm)." ;
 .
 
-sdo:inCodeSet
+schema:inCodeSet
     rdfs:label "in codeSet" ;
     rdfs:comment "A [[CategoryCodeSet]] that contains this category code." ;
 .
 
-sdo:inDefinedTermSet
+schema:inDefinedTermSet
     rdfs:label "in defined Term Set" ;
     rdfs:comment "A [[DefinedTermSet]] that contains this term." ;
 .
 
-sdo:inLanguage
+schema:inLanguage
     rdfs:label "in language" ;
     rdfs:comment "The language of the content or performance or used in an action. Please use one of the language codes from the [IETF BCP 47 standard](http://tools.ietf.org/html/bcp47). See also [[availableLanguage]]." ;
 .
 
-sdo:inPlaylist
+schema:inPlaylist
     rdfs:label "in playlist" ;
     rdfs:comment "The playlist to which this recording belongs." ;
 .
 
-sdo:inProductGroupWithID
+schema:inProductGroupWithID
     rdfs:label "in product Group WithID" ;
     rdfs:comment "Indicates the [[productGroupID]] for a [[ProductGroup]] that this product [[isVariantOf]]. " ;
 .
 
-sdo:inStoreReturnsOffered
+schema:inStoreReturnsOffered
     rdfs:label "in store Returns Offered" ;
     rdfs:comment "Are in-store returns offered? (for more advanced return methods use the [[returnMethod]] property)" ;
 .
 
-sdo:inSupportOf
+schema:inSupportOf
     rdfs:label "in supportOf" ;
     rdfs:comment "Qualification, candidature, degree, application that Thesis supports." ;
 .
 
-sdo:incentiveCompensation
+schema:incentiveCompensation
     rdfs:label "incentive compensation" ;
     rdfs:comment "Description of bonus and commission compensation aspects of the job." ;
 .
 
-sdo:incentives
+schema:incentives
     rdfs:label "incentives" ;
     rdfs:comment "Description of bonus and commission compensation aspects of the job." ;
 .
 
-sdo:includedComposition
+schema:includedComposition
     rdfs:label "included composition" ;
     rdfs:comment "Smaller compositions included in this work (e.g. a movement in a symphony)." ;
 .
 
-sdo:includedDataCatalog
+schema:includedDataCatalog
     rdfs:label "included dataCatalog" ;
     rdfs:comment "A data catalog which contains this dataset (this property was previously 'catalog', preferred name is now 'includedInDataCatalog')." ;
 .
 
-sdo:includedInDataCatalog
+schema:includedInDataCatalog
     rdfs:label "included in Data Catalog" ;
     rdfs:comment "A data catalog which contains this dataset." ;
 .
 
-sdo:includedInHealthInsurancePlan
+schema:includedInHealthInsurancePlan
     rdfs:label "included inHealth Insurance Plan" ;
     rdfs:comment "The insurance plans that cover this drug." ;
 .
 
-sdo:includedRiskFactor
+schema:includedRiskFactor
     rdfs:label "included riskFactor" ;
     rdfs:comment "A modifiable or non-modifiable risk factor included in the calculation, e.g. age, coexisting condition." ;
 .
 
-sdo:includesAttraction
+schema:includesAttraction
     rdfs:label "includes attraction" ;
     rdfs:comment "Attraction located at destination." ;
 .
 
-sdo:includesHealthPlanFormulary
+schema:includesHealthPlanFormulary
     rdfs:label "includes health Plan Formulary" ;
     rdfs:comment "Formularies covered by this plan." ;
 .
 
-sdo:includesHealthPlanNetwork
+schema:includesHealthPlanNetwork
     rdfs:label "includes health Plan Network" ;
     rdfs:comment "Networks covered by this plan." ;
 .
 
-sdo:includesObject
+schema:includesObject
     rdfs:label "includes object" ;
     rdfs:comment "This links to a node or nodes indicating the exact quantity of the products included in  an [[Offer]] or [[ProductCollection]]." ;
 .
 
-sdo:increasesRiskOf
+schema:increasesRiskOf
     rdfs:label "increases riskOf" ;
     rdfs:comment "The condition, complication, etc. influenced by this factor." ;
 .
 
-sdo:industry
+schema:industry
     rdfs:label "industry" ;
     rdfs:comment "The industry associated with the job position." ;
 .
 
-sdo:ineligibleRegion
+schema:ineligibleRegion
     rdfs:label "ineligible region" ;
     rdfs:comment """The ISO 3166-1 (ISO 3166-1 alpha-2) or ISO 3166-2 code, the place, or the GeoShape for the geo-political region(s) for which the offer or delivery charge specification is not valid, e.g. a region where the transaction is not allowed.\\n\\nSee also [[eligibleRegion]].
       """ ;
 .
 
-sdo:infectiousAgent
+schema:infectiousAgent
     rdfs:label "infectious agent" ;
     rdfs:comment "The actual infectious agent, such as a specific bacterium." ;
 .
 
-sdo:infectiousAgentClass
+schema:infectiousAgentClass
     rdfs:label "infectious agentClass" ;
     rdfs:comment "The class of infectious agent (bacteria, prion, etc.) that causes the disease." ;
 .
 
-sdo:ingredients
+schema:ingredients
     rdfs:label "ingredients" ;
     rdfs:comment "A single ingredient used in the recipe, e.g. sugar, flour or garlic." ;
 .
 
-sdo:inker
+schema:inker
     rdfs:label "inker" ;
     rdfs:comment "The individual who traces over the pencil drawings in ink after pencils are complete." ;
 .
 
-sdo:insertion
+schema:insertion
     rdfs:label "insertion" ;
     rdfs:comment "The place of attachment of a muscle, or what the muscle moves." ;
 .
 
-sdo:installUrl
+schema:installUrl
     rdfs:label "install url" ;
     rdfs:comment "URL at which the app may be installed, if different from the URL of the item." ;
 .
 
-sdo:instructor
+schema:instructor
     rdfs:label "instructor" ;
     rdfs:comment "A person assigned to instruct or provide instructional assistance for the [[CourseInstance]]." ;
 .
 
-sdo:instrument
+schema:instrument
     rdfs:label "instrument" ;
     rdfs:comment "The object that helped the agent perform the action. e.g. John wrote a book with *a pen*." ;
 .
 
-sdo:intensity
+schema:intensity
     rdfs:label "intensity" ;
     rdfs:comment "Quantitative measure gauging the degree of force involved in the exercise, for example, heartbeats per minute. May include the velocity of the movement." ;
 .
 
-sdo:interactingDrug
+schema:interactingDrug
     rdfs:label "interacting drug" ;
     rdfs:comment "Another drug that is known to interact with this drug in a way that impacts the effect of this drug or causes a risk to the patient. Note: disease interactions are typically captured as contraindications." ;
 .
 
-sdo:interactionCount
+schema:interactionCount
     rdfs:label "interaction count" ;
     rdfs:comment "This property is deprecated, alongside the UserInteraction types on which it depended." ;
 .
 
-sdo:interactionService
+schema:interactionService
     rdfs:label "interaction service" ;
     rdfs:comment "The WebSite or SoftwareApplication where the interactions took place." ;
 .
 
-sdo:interactionStatistic
+schema:interactionStatistic
     rdfs:label "interaction statistic" ;
     rdfs:comment "The number of interactions for the CreativeWork using the WebSite or SoftwareApplication. The most specific child type of InteractionCounter should be used." ;
 .
 
-sdo:interactionType
+schema:interactionType
     rdfs:label "interaction type" ;
     rdfs:comment "The Action representing the type of interaction. For up votes, +1s, etc. use [[LikeAction]]. For down votes use [[DislikeAction]]. Otherwise, use the most specific Action." ;
 .
 
-sdo:interactivityType
+schema:interactivityType
     rdfs:label "interactivity type" ;
     rdfs:comment "The predominant mode of learning supported by the learning resource. Acceptable values are 'active', 'expositive', or 'mixed'." ;
 .
 
-sdo:interestRate
+schema:interestRate
     rdfs:label "interest rate" ;
     rdfs:comment "The interest rate, charged or paid, applicable to the financial product. Note: This is different from the calculated annualPercentageRate." ;
 .
 
-sdo:interpretedAsClaim
+schema:interpretedAsClaim
     rdfs:label "interpreted asClaim" ;
     rdfs:comment "Used to indicate a specific claim contained, implied, translated or refined from the content of a [[MediaObject]] or other [[CreativeWork]]. The interpreting party can be indicated using [[claimInterpreter]]." ;
 .
 
-sdo:inventoryLevel
+schema:inventoryLevel
     rdfs:label "inventory level" ;
     rdfs:comment "The current approximate inventory level for the item or items." ;
 .
 
-sdo:inverseOf
+schema:inverseOf
     rdfs:label "inverse of" ;
     rdfs:comment "Relates a property to a property that is its inverse. Inverse properties relate the same pairs of items to each other, but in reversed direction. For example, the 'alumni' and 'alumniOf' properties are inverseOf each other. Some properties don't have explicit inverses; in these situations RDFa and JSON-LD syntax for reverse properties can be used." ;
 .
 
-sdo:isAcceptingNewPatients
+schema:isAcceptingNewPatients
     rdfs:label "is accepting New Patients" ;
     rdfs:comment "Whether the provider is accepting new patients." ;
 .
 
-sdo:isAccessibleForFree
+schema:isAccessibleForFree
     rdfs:label "is accessible For Free" ;
     rdfs:comment "A flag to signal that the item, event, or place is accessible for free." ;
 .
 
-sdo:isAccessoryOrSparePartFor
+schema:isAccessoryOrSparePartFor
     rdfs:label "is accessoryOrSpare Part For" ;
     rdfs:comment "A pointer to another product (or multiple products) for which this product is an accessory or spare part." ;
 .
 
-sdo:isAvailableGenerically
+schema:isAvailableGenerically
     rdfs:label "is availableGenerically" ;
     rdfs:comment "True if the drug is available in a generic form (regardless of name)." ;
 .
 
-sdo:isBasedOn
+schema:isBasedOn
     rdfs:label "is basedOn" ;
     rdfs:comment "A resource from which this work is derived or from which it is a modification or adaption." ;
 .
 
-sdo:isBasedOnUrl
+schema:isBasedOnUrl
     rdfs:label "is based On Url" ;
     rdfs:comment "A resource that was used in the creation of this resource. This term can be repeated for multiple sources. For example, http://example.com/great-multiplication-intro.html." ;
 .
 
-sdo:isConsumableFor
+schema:isConsumableFor
     rdfs:label "is consumableFor" ;
     rdfs:comment "A pointer to another product (or multiple products) for which this product is a consumable." ;
 .
 
-sdo:isEncodedByBioChemEntity
+schema:isEncodedByBioChemEntity
     rdfs:label "is encodedByBio Chem Entity" ;
     rdfs:comment "Another BioChemEntity encoding by this one." ;
 .
 
-sdo:isFamilyFriendly
+schema:isFamilyFriendly
     rdfs:label "is familyFriendly" ;
     rdfs:comment "Indicates whether this content is family friendly." ;
 .
 
-sdo:isGift
+schema:isGift
     rdfs:label "is gift" ;
     rdfs:comment "Was the offer accepted as a gift for someone other than the buyer." ;
 .
 
-sdo:isInvolvedInBiologicalProcess
+schema:isInvolvedInBiologicalProcess
     rdfs:label "is involvedIn Biological Process" ;
     rdfs:comment "Biological process this BioChemEntity is involved in; please use PropertyValue if you want to include any evidence." ;
 .
 
-sdo:isLiveBroadcast
+schema:isLiveBroadcast
     rdfs:label "is liveBroadcast" ;
     rdfs:comment "True if the broadcast is of a live event." ;
 .
 
-sdo:isLocatedInSubcellularLocation
+schema:isLocatedInSubcellularLocation
     rdfs:label "is locatedIn Subcellular Location" ;
     rdfs:comment "Subcellular location where this BioChemEntity is located; please use PropertyValue if you want to include any evidence." ;
 .
 
-sdo:isPartOf
+schema:isPartOf
     rdfs:label "is partOf" ;
     rdfs:comment "Indicates an item or CreativeWork that this item, or CreativeWork (in some sense), is part of." ;
 .
 
-sdo:isPartOfBioChemEntity
+schema:isPartOfBioChemEntity
     rdfs:label "is partOfBio Chem Entity" ;
     rdfs:comment "Indicates a BioChemEntity that is (in some sense) a part of this BioChemEntity. " ;
 .
 
-sdo:isPlanForApartment
+schema:isPlanForApartment
     rdfs:label "is plan For Apartment" ;
     rdfs:comment "Indicates some accommodation that this floor plan describes." ;
 .
 
-sdo:isProprietary
+schema:isProprietary
     rdfs:label "is proprietary" ;
     rdfs:comment "True if this item's name is a proprietary/brand name (vs. generic name)." ;
 .
 
-sdo:isRelatedTo
+schema:isRelatedTo
     rdfs:label "is relatedTo" ;
     rdfs:comment "A pointer to another, somehow related product (or multiple products)." ;
 .
 
-sdo:isResizable
+schema:isResizable
     rdfs:label "is resizable" ;
     rdfs:comment "Whether the 3DModel allows resizing. For example, room layout applications often do not allow 3DModel elements to be resized to reflect reality." ;
 .
 
-sdo:isSimilarTo
+schema:isSimilarTo
     rdfs:label "is similarTo" ;
     rdfs:comment "A pointer to another, functionally similar product (or multiple products)." ;
 .
 
-sdo:isUnlabelledFallback
+schema:isUnlabelledFallback
     rdfs:label "is unlabelledFallback" ;
     rdfs:comment "This can be marked 'true' to indicate that some published [[DeliveryTimeSettings]] or [[ShippingRateSettings]] are intended to apply to all [[OfferShippingDetails]] published by the same merchant, when referenced by a [[shippingSettingsLink]] in those settings. It is not meaningful to use a 'true' value for this property alongside a transitTimeLabel (for [[DeliveryTimeSettings]]) or shippingLabel (for [[ShippingRateSettings]]), since this property is for use with unlabelled settings." ;
 .
 
-sdo:isVariantOf
+schema:isVariantOf
     rdfs:label "is variantOf" ;
     rdfs:comment "Indicates the kind of product that this is a variant of. In the case of [[ProductModel]], this is a pointer (from a ProductModel) to a base product from which this product is a variant. It is safe to infer that the variant inherits all product features from the base model, unless defined locally. This is not transitive. In the case of a [[ProductGroup]], the group description also serves as a template, representing a set of Products that vary on explicitly defined, specific dimensions only (so it defines both a set of variants, as well as which values distinguish amongst those variants). When used with [[ProductGroup]], this property can apply to any [[Product]] included in the group." ;
 .
 
-sdo:isbn
+schema:isbn
     rdfs:label "isbn" ;
     rdfs:comment "The ISBN of the book." ;
 .
 
-sdo:isicV4
+schema:isicV4
     rdfs:label "isic v4" ;
     rdfs:comment "The International Standard of Industrial Classification of All Economic Activities (ISIC), Revision 4 code for a particular organization, business person, or place." ;
 .
 
-sdo:isrcCode
+schema:isrcCode
     rdfs:label "isrc code" ;
     rdfs:comment "The International Standard Recording Code for the recording." ;
 .
 
-sdo:issn
+schema:issn
     rdfs:label "issn" ;
     rdfs:comment "The International Standard Serial Number (ISSN) that identifies this serial publication. You can repeat this property to identify different formats of, or the linking ISSN (ISSN-L) for, this serial publication." ;
 .
 
-sdo:issueNumber
+schema:issueNumber
     rdfs:label "issue number" ;
     rdfs:comment "Identifies the issue of publication; for example, \"iii\" or \"2\"." ;
 .
 
-sdo:issuedBy
+schema:issuedBy
     rdfs:label "issued by" ;
     rdfs:comment "The organization issuing the ticket or permit." ;
 .
 
-sdo:issuedThrough
+schema:issuedThrough
     rdfs:label "issued through" ;
     rdfs:comment "The service through with the permit was granted." ;
 .
 
-sdo:iswcCode
+schema:iswcCode
     rdfs:label "iswc code" ;
     rdfs:comment "The International Standard Musical Work Code for the composition." ;
 .
 
-sdo:item
+schema:item
     rdfs:label "item" ;
     rdfs:comment "An entity represented by an entry in a list or data feed (e.g. an 'artist' in a list of 'artists')’." ;
 .
 
-sdo:itemCondition
+schema:itemCondition
     rdfs:label "item condition" ;
     rdfs:comment "A predefined value from OfferItemCondition specifying the condition of the product or service, or the products or services included in the offer. Also used for product return policies to specify the condition of products accepted for returns." ;
 .
 
-sdo:itemDefectReturnFees
+schema:itemDefectReturnFees
     rdfs:label "item defect Return Fees" ;
     rdfs:comment "The type of return fees for returns of defect products." ;
 .
 
-sdo:itemDefectReturnLabelSource
+schema:itemDefectReturnLabelSource
     rdfs:label "item defectReturn Label Source" ;
     rdfs:comment "The method (from an enumeration) by which the customer obtains a return shipping label for a defect product." ;
 .
 
-sdo:itemDefectReturnShippingFeesAmount
+schema:itemDefectReturnShippingFeesAmount
     rdfs:label "item defectReturnShipping Fees Amount" ;
     rdfs:comment "Amount of shipping costs for defect product returns. Applicable when property [[itemDefectReturnFees]] equals [[ReturnShippingFees]]." ;
 .
 
-sdo:itemListElement
+schema:itemListElement
     rdfs:label "item listElement" ;
     rdfs:comment "For itemListElement values, you can use simple strings (e.g. \"Peter\", \"Paul\", \"Mary\"), existing entities, or use ListItem.\\n\\nText values are best if the elements in the list are plain strings. Existing entities are best for a simple, unordered list of existing things in your data. ListItem is used with ordered lists when you want to provide additional context about the element in that list or when the same item might be in different places in different lists.\\n\\nNote: The order of elements in your mark-up is not sufficient for indicating the order or elements.  Use ListItem with a 'position' property in such cases." ;
 .
 
-sdo:itemListOrder
+schema:itemListOrder
     rdfs:label "item listOrder" ;
     rdfs:comment "Type of ordering (e.g. Ascending, Descending, Unordered)." ;
 .
 
-sdo:itemLocation
+schema:itemLocation
     rdfs:label "item location"@en ;
     rdfs:comment "Current location of the item."@en ;
 .
 
-sdo:itemOffered
+schema:itemOffered
     rdfs:label "item offered" ;
     rdfs:comment "An item being offered (or demanded). The transactional nature of the offer or demand is documented using [[businessFunction]], e.g. sell, lease etc. While several common expected types are listed explicitly in this definition, others can be used. Using a second type, such as Product or a subtype of Product, can clarify the nature of the offer." ;
 .
 
-sdo:itemReviewed
+schema:itemReviewed
     rdfs:label "item reviewed" ;
     rdfs:comment "The item that is being reviewed/rated." ;
 .
 
-sdo:itemShipped
+schema:itemShipped
     rdfs:label "item shipped" ;
     rdfs:comment "Item(s) being shipped." ;
 .
 
-sdo:itinerary
+schema:itinerary
     rdfs:label "itinerary" ;
     rdfs:comment "Destination(s) ( [[Place]] ) that make up a trip. For a trip where destination order is important use [[ItemList]] to specify that order (see examples)." ;
 .
 
-sdo:iupacName
+schema:iupacName
     rdfs:label "iupac name" ;
     rdfs:comment "Systematic method of naming chemical compounds as recommended by the International Union of Pure and Applied Chemistry (IUPAC)." ;
 .
 
-sdo:jobBenefits
+schema:jobBenefits
     rdfs:label "job benefits" ;
     rdfs:comment "Description of benefits associated with the job." ;
 .
 
-sdo:jobImmediateStart
+schema:jobImmediateStart
     rdfs:label "job immediateStart" ;
     rdfs:comment "An indicator as to whether a position is available for an immediate start." ;
 .
 
-sdo:jobLocation
+schema:jobLocation
     rdfs:label "job location" ;
     rdfs:comment "A (typically single) geographic location associated with the job position." ;
 .
 
-sdo:jobLocationType
+schema:jobLocationType
     rdfs:label "job locationType" ;
     rdfs:comment "A description of the job location (e.g TELECOMMUTE for telecommute jobs)." ;
 .
 
-sdo:jobStartDate
+schema:jobStartDate
     rdfs:label "job startDate" ;
     rdfs:comment "The date on which a successful applicant for this job would be expected to start work. Choose a specific date in the future or use the jobImmediateStart property to indicate the position is to be filled as soon as possible." ;
 .
 
-sdo:jobTitle
+schema:jobTitle
     rdfs:label "job title" ;
     rdfs:comment "The job title of the person (for example, Financial Manager)." ;
 .
 
-sdo:jurisdiction
+schema:jurisdiction
     rdfs:label "jurisdiction" ;
     rdfs:comment "Indicates a legal jurisdiction, e.g. of some legislation, or where some government service is based." ;
 .
 
-sdo:keywords
+schema:keywords
     rdfs:label "keywords" ;
     rdfs:comment "Keywords or tags used to describe this content. Multiple entries in a keywords list are typically delimited by commas." ;
 .
 
-sdo:knownVehicleDamages
+schema:knownVehicleDamages
     rdfs:label "known vehicleDamages" ;
     rdfs:comment "A textual description of known damages, both repaired and unrepaired." ;
 .
 
-sdo:knows
+schema:knows
     rdfs:label "knows" ;
     rdfs:comment "The most generic bi-directional social/work relation." ;
 .
 
-sdo:knowsAbout
+schema:knowsAbout
     rdfs:label "knows about" ;
     rdfs:comment "Of a [[Person]], and less typically of an [[Organization]], to indicate a topic that is known about - suggesting possible expertise but not implying it. We do not distinguish skill levels here, or relate this to educational content, events, objectives or [[JobPosting]] descriptions." ;
 .
 
-sdo:knowsLanguage
+schema:knowsLanguage
     rdfs:label "knows language" ;
     rdfs:comment "Of a [[Person]], and less typically of an [[Organization]], to indicate a known language. We do not distinguish skill levels or reading/writing/speaking/signing here. Use language codes from the [IETF BCP 47 standard](http://tools.ietf.org/html/bcp47)." ;
 .
 
-sdo:labelDetails
+schema:labelDetails
     rdfs:label "label details" ;
     rdfs:comment "Link to the drug's label details." ;
 .
 
-sdo:landlord
+schema:landlord
     rdfs:label "landlord" ;
     rdfs:comment "A sub property of participant. The owner of the real estate property." ;
 .
 
-sdo:language
+schema:language
     rdfs:label "language" ;
     rdfs:comment "A sub property of instrument. The language used on this action." ;
 .
 
-sdo:lastReviewed
+schema:lastReviewed
     rdfs:label "last reviewed" ;
     rdfs:comment "Date on which the content on this web page was last reviewed for accuracy and/or completeness." ;
 .
 
-sdo:latitude
+schema:latitude
     rdfs:label "latitude" ;
     rdfs:comment "The latitude of a location. For example ```37.42242``` ([WGS 84](https://en.wikipedia.org/wiki/World_Geodetic_System))." ;
 .
 
-sdo:layoutImage
+schema:layoutImage
     rdfs:label "layout image" ;
     rdfs:comment "A schematic image showing the floorplan layout." ;
 .
 
-sdo:learningResourceType
+schema:learningResourceType
     rdfs:label "learning resourceType" ;
     rdfs:comment "The predominant type or kind characterizing the learning resource. For example, 'presentation', 'handout'." ;
 .
 
-sdo:leaseLength
+schema:leaseLength
     rdfs:label "lease length" ;
     rdfs:comment "Length of the lease for some [[Accommodation]], either particular to some [[Offer]] or in some cases intrinsic to the property." ;
 .
 
-sdo:legalName
+schema:legalName
     rdfs:label "legal name" ;
     rdfs:comment "The official name of the organization, e.g. the registered company name." ;
 .
 
-sdo:legalStatus
+schema:legalStatus
     rdfs:label "legal status" ;
     rdfs:comment "The drug or supplement's legal status, including any controlled substance schedules that apply." ;
 .
 
-sdo:legislationApplies
+schema:legislationApplies
     rdfs:label "legislation applies" ;
     rdfs:comment "Indicates that this legislation (or part of a legislation) somehow transfers another legislation in a different legislative context. This is an informative link, and it has no legal value. For legally-binding links of transposition, use the <a href=\"/legislationTransposes\">legislationTransposes</a> property. For example an informative consolidated law of a European Union's member state \"applies\" the consolidated version of the European Directive implemented in it." ;
 .
 
-sdo:legislationChanges
+schema:legislationChanges
     rdfs:label "legislation changes" ;
     rdfs:comment "Another legislation that this legislation changes. This encompasses the notions of amendment, replacement, correction, repeal, or other types of change. This may be a direct change (textual or non-textual amendment) or a consequential or indirect change. The property is to be used to express the existence of a change relationship between two acts rather than the existence of a consolidated version of the text that shows the result of the change. For consolidation relationships, use the <a href=\"/legislationConsolidates\">legislationConsolidates</a> property." ;
 .
 
-sdo:legislationConsolidates
+schema:legislationConsolidates
     rdfs:label "legislation consolidates" ;
     rdfs:comment "Indicates another legislation taken into account in this consolidated legislation (which is usually the product of an editorial process that revises the legislation). This property should be used multiple times to refer to both the original version or the previous consolidated version, and to the legislations making the change." ;
 .
 
-sdo:legislationDate
+schema:legislationDate
     rdfs:label "legislation date" ;
     rdfs:comment "The date of adoption or signature of the legislation. This is the date at which the text is officially aknowledged to be a legislation, even though it might not even be published or in force." ;
 .
 
-sdo:legislationDateVersion
+schema:legislationDateVersion
     rdfs:label "legislation dateVersion" ;
     rdfs:comment "The point-in-time at which the provided description of the legislation is valid (e.g. : when looking at the law on the 2016-04-07 (= dateVersion), I get the consolidation of 2015-04-12 of the \"National Insurance Contributions Act 2015\")" ;
 .
 
-sdo:legislationIdentifier
+schema:legislationIdentifier
     rdfs:label "legislation identifier" ;
     rdfs:comment "An identifier for the legislation. This can be either a string-based identifier, like the CELEX at EU level or the NOR in France, or a web-based, URL/URI identifier, like an ELI (European Legislation Identifier) or an URN-Lex." ;
 .
 
-sdo:legislationJurisdiction
+schema:legislationJurisdiction
     rdfs:label "legislation jurisdiction" ;
     rdfs:comment "The jurisdiction from which the legislation originates." ;
 .
 
-sdo:legislationLegalForce
+schema:legislationLegalForce
     rdfs:label "legislation legalForce" ;
     rdfs:comment "Whether the legislation is currently in force, not in force, or partially in force." ;
 .
 
-sdo:legislationLegalValue
+schema:legislationLegalValue
     rdfs:label "legislation legalValue" ;
     rdfs:comment "The legal value of this legislation file. The same legislation can be written in multiple files with different legal values. Typically a digitally signed PDF have a \"stronger\" legal value than the HTML file of the same act." ;
 .
 
-sdo:legislationPassedBy
+schema:legislationPassedBy
     rdfs:label "legislation passedBy" ;
     rdfs:comment "The person or organization that originally passed or made the law : typically parliament (for primary legislation) or government (for secondary legislation). This indicates the \"legal author\" of the law, as opposed to its physical author." ;
 .
 
-sdo:legislationResponsible
+schema:legislationResponsible
     rdfs:label "legislation responsible" ;
     rdfs:comment "An individual or organization that has some kind of responsibility for the legislation. Typically the ministry who is/was in charge of elaborating the legislation, or the adressee for potential questions about the legislation once it is published." ;
 .
 
-sdo:legislationTransposes
+schema:legislationTransposes
     rdfs:label "legislation transposes" ;
     rdfs:comment "Indicates that this legislation (or part of legislation) fulfills the objectives set by another legislation, by passing appropriate implementation measures. Typically, some legislations of European Union's member states or regions transpose European Directives. This indicates a legally binding link between the 2 legislations." ;
 .
 
-sdo:legislationType
+schema:legislationType
     rdfs:label "legislation type" ;
     rdfs:comment "The type of the legislation. Examples of values are \"law\", \"act\", \"directive\", \"decree\", \"regulation\", \"statutory instrument\", \"loi organique\", \"règlement grand-ducal\", etc., depending on the country." ;
 .
 
-sdo:leiCode
+schema:leiCode
     rdfs:label "lei code" ;
     rdfs:comment "An organization identifier that uniquely identifies a legal entity as defined in ISO 17442." ;
 .
 
-sdo:lender
+schema:lender
     rdfs:label "lender" ;
     rdfs:comment "A sub property of participant. The person that lends the object being borrowed." ;
 .
 
-sdo:lesser
+schema:lesser
     rdfs:label "lesser" ;
     rdfs:comment "This ordering relation for qualitative values indicates that the subject is lesser than the object." ;
 .
 
-sdo:lesserOrEqual
+schema:lesserOrEqual
     rdfs:label "lesser orEqual" ;
     rdfs:comment "This ordering relation for qualitative values indicates that the subject is lesser than or equal to the object." ;
 .
 
-sdo:letterer
+schema:letterer
     rdfs:label "letterer" ;
     rdfs:comment "The individual who adds lettering, including speech balloons and sound effects, to artwork." ;
 .
 
-sdo:license
+schema:license
     rdfs:label "license" ;
     rdfs:comment "A license document that applies to this content, typically indicated by URL." ;
 .
 
-sdo:line
+schema:line
     rdfs:label "line" ;
     rdfs:comment "A line is a point-to-point path consisting of two or more points. A line is expressed as a series of two or more point objects separated by space." ;
 .
 
-sdo:linkRelationship
+schema:linkRelationship
     rdfs:label "link relationship" ;
     rdfs:comment "Indicates the relationship type of a Web link. " ;
 .
 
-sdo:liveBlogUpdate
+schema:liveBlogUpdate
     rdfs:label "live blogUpdate" ;
     rdfs:comment "An update to the LiveBlog." ;
 .
 
-sdo:loanMortgageMandateAmount
+schema:loanMortgageMandateAmount
     rdfs:label "loan mortgage Mandate Amount" ;
     rdfs:comment "Amount of mortgage mandate that can be converted into a proper mortgage at a later stage." ;
 .
 
-sdo:loanPaymentAmount
+schema:loanPaymentAmount
     rdfs:label "loan paymentAmount" ;
     rdfs:comment "The amount of money to pay in a single payment." ;
 .
 
-sdo:loanPaymentFrequency
+schema:loanPaymentFrequency
     rdfs:label "loan paymentFrequency" ;
     rdfs:comment "Frequency of payments due, i.e. number of months between payments. This is defined as a frequency, i.e. the reciprocal of a period of time." ;
 .
 
-sdo:loanRepaymentForm
+schema:loanRepaymentForm
     rdfs:label "loan repaymentForm" ;
     rdfs:comment "A form of paying back money previously borrowed from a lender. Repayment usually takes the form of periodic payments that normally include part principal plus interest in each payment." ;
 .
 
-sdo:loanTerm
+schema:loanTerm
     rdfs:label "loan term" ;
     rdfs:comment "The duration of the loan or credit agreement." ;
 .
 
-sdo:loanType
+schema:loanType
     rdfs:label "loan type" ;
     rdfs:comment "The type of a loan or credit." ;
 .
 
-sdo:location
+schema:location
     rdfs:label "location" ;
     rdfs:comment "The location of, for example, where an event is happening, where an organization is located, or where an action takes place." ;
 .
 
-sdo:locationCreated
+schema:locationCreated
     rdfs:label "location created" ;
     rdfs:comment "The location where the CreativeWork was created, which may not be the same as the location depicted in the CreativeWork." ;
 .
 
-sdo:lodgingUnitDescription
+schema:lodgingUnitDescription
     rdfs:label "lodging unitDescription" ;
     rdfs:comment "A full description of the lodging unit." ;
 .
 
-sdo:lodgingUnitType
+schema:lodgingUnitType
     rdfs:label "lodging unitType" ;
     rdfs:comment "Textual description of the unit type (including suite vs. room, size of bed, etc.)." ;
 .
 
-sdo:logo
+schema:logo
     rdfs:label "logo" ;
     rdfs:comment "An associated logo." ;
 .
 
-sdo:longitude
+schema:longitude
     rdfs:label "longitude" ;
     rdfs:comment "The longitude of a location. For example ```-122.08585``` ([WGS 84](https://en.wikipedia.org/wiki/World_Geodetic_System))." ;
 .
 
-sdo:loser
+schema:loser
     rdfs:label "loser" ;
     rdfs:comment "A sub property of participant. The loser of the action." ;
 .
 
-sdo:lowPrice
+schema:lowPrice
     rdfs:label "low price" ;
     rdfs:comment "The lowest price of all offers available.\\n\\nUsage guidelines:\\n\\n* Use values from 0123456789 (Unicode 'DIGIT ZERO' (U+0030) to 'DIGIT NINE' (U+0039)) rather than superficially similiar Unicode symbols.\\n* Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a decimal point. Avoid using these symbols as a readability separator." ;
 .
 
-sdo:lyricist
+schema:lyricist
     rdfs:label "lyricist" ;
     rdfs:comment "The person who wrote the words." ;
 .
 
-sdo:lyrics
+schema:lyrics
     rdfs:label "lyrics" ;
     rdfs:comment "The words in the song." ;
 .
 
-sdo:mainContentOfPage
+schema:mainContentOfPage
     rdfs:label "main content Of Page" ;
     rdfs:comment "Indicates if this web page element is the main subject of the page." ;
 .
 
-sdo:mainEntity
+schema:mainEntity
     rdfs:label "main entity" ;
     rdfs:comment "Indicates the primary entity described in some page or other CreativeWork." ;
 .
 
-sdo:mainEntityOfPage
+schema:mainEntityOfPage
     rdfs:label "main entity Of Page" ;
     rdfs:comment "Indicates a page (or other CreativeWork) for which this thing is the main entity being described. See [background notes](/docs/datamodel.html#mainEntityBackground) for details." ;
 .
 
-sdo:maintainer
+schema:maintainer
     rdfs:label "maintainer" ;
     rdfs:comment """A maintainer of a [[Dataset]], software package ([[SoftwareApplication]]), or other [[Project]]. A maintainer is a [[Person]] or [[Organization]] that manages contributions to, and/or publication of, some (typically complex) artifact. It is common for distributions of software and data to be based on "upstream" sources. When [[maintainer]] is applied to a specific version of something e.g. a particular version or packaging of a [[Dataset]], it is always  possible that the upstream source has a different maintainer. The [[isBasedOn]] property can be used to indicate such relationships between datasets to make the different maintenance roles clear. Similarly in the case of software, a package may have dedicated maintainers working on integration into software distributions such as Ubuntu, as well as upstream maintainers of the underlying work.
       """ ;
 .
 
-sdo:makesOffer
+schema:makesOffer
     rdfs:label "makes offer" ;
     rdfs:comment "A pointer to products or services offered by the organization or person." ;
 .
 
-sdo:manufacturer
+schema:manufacturer
     rdfs:label "manufacturer" ;
     rdfs:comment "The manufacturer of the product." ;
 .
 
-sdo:map
+schema:map
     rdfs:label "map" ;
     rdfs:comment "A URL to a map of the place." ;
 .
 
-sdo:mapType
+schema:mapType
     rdfs:label "map type" ;
     rdfs:comment "Indicates the kind of Map, from the MapCategoryType Enumeration." ;
 .
 
-sdo:maps
+schema:maps
     rdfs:label "maps" ;
     rdfs:comment "A URL to a map of the place." ;
 .
 
-sdo:marginOfError
+schema:marginOfError
     rdfs:label "margin of error" ;
     rdfs:comment "A margin of error for an Observation" ;
 .
 
-sdo:masthead
+schema:masthead
     rdfs:label "masthead" ;
     rdfs:comment "For a [[NewsMediaOrganization]], a link to the masthead page or a page listing top editorial management." ;
 .
 
-sdo:material
+schema:material
     rdfs:label "material" ;
     rdfs:comment "A material that something is made from, e.g. leather, wool, cotton, paper." ;
 .
 
-sdo:materialExtent
+schema:materialExtent
     rdfs:label "material extent"@en ;
     rdfs:comment "The quantity of the materials being described or an expression of the physical space they occupy."@en ;
 .
 
-sdo:mathExpression
+schema:mathExpression
     rdfs:label "math expression" ;
     rdfs:comment "A mathematical expression (e.g. 'x^2-3x=0') that may be solved for a specific variable, simplified, or transformed. This can take many formats, e.g. LaTeX, Ascii-Math, or math as you would write with a keyboard." ;
 .
 
-sdo:maxPrice
+schema:maxPrice
     rdfs:label "max price" ;
     rdfs:comment "The highest price if the price is a range." ;
 .
 
-sdo:maxValue
+schema:maxValue
     rdfs:label "max value" ;
     rdfs:comment "The upper value of some characteristic or property." ;
 .
 
-sdo:maximumAttendeeCapacity
+schema:maximumAttendeeCapacity
     rdfs:label "maximum attendeeCapacity" ;
     rdfs:comment "The total number of individuals that may attend an event or venue." ;
 .
 
-sdo:maximumEnrollment
+schema:maximumEnrollment
     rdfs:label "maximum enrollment" ;
     rdfs:comment "The maximum number of students who may be enrolled in the program." ;
 .
 
-sdo:maximumIntake
+schema:maximumIntake
     rdfs:label "maximum intake" ;
     rdfs:comment "Recommended intake of this supplement for a given population as defined by a specific recommending authority." ;
 .
 
-sdo:maximumPhysicalAttendeeCapacity
+schema:maximumPhysicalAttendeeCapacity
     rdfs:label "maximum physical Attendee Capacity" ;
     rdfs:comment "The maximum physical attendee capacity of an [[Event]] whose [[eventAttendanceMode]] is [[OfflineEventAttendanceMode]] (or the offline aspects, in the case of a [[MixedEventAttendanceMode]]). " ;
 .
 
-sdo:maximumVirtualAttendeeCapacity
+schema:maximumVirtualAttendeeCapacity
     rdfs:label "maximum virtual Attendee Capacity" ;
     rdfs:comment "The maximum physical attendee capacity of an [[Event]] whose [[eventAttendanceMode]] is [[OnlineEventAttendanceMode]] (or the online aspects, in the case of a [[MixedEventAttendanceMode]]). " ;
 .
 
-sdo:mealService
+schema:mealService
     rdfs:label "meal service" ;
     rdfs:comment "Description of the meals that will be provided or available for purchase." ;
 .
 
-sdo:measuredProperty
+schema:measuredProperty
     rdfs:label "measured property" ;
     rdfs:comment "The measuredProperty of an [[Observation]], either a schema.org property, a property from other RDF-compatible systems e.g. W3C RDF Data Cube, or schema.org extensions such as [GS1's](https://www.gs1.org/voc/?show=properties)." ;
 .
 
-sdo:measuredValue
+schema:measuredValue
     rdfs:label "measured value" ;
     rdfs:comment "The measuredValue of an [[Observation]]." ;
 .
 
-sdo:measurementTechnique
+schema:measurementTechnique
     rdfs:label "measurement technique" ;
     rdfs:comment """A technique or technology used in a [[Dataset]] (or [[DataDownload]], [[DataCatalog]]),
 corresponding to the method used for measuring the corresponding variable(s) (described using [[variableMeasured]]). This is oriented towards scientific and scholarly dataset publication but may have broader applicability; it is not intended as a full representation of measurement, but rather as a high level summary for dataset discovery.
@@ -13681,1182 +13681,1182 @@ If there are several [[variableMeasured]] properties recorded for some given dat
       """ ;
 .
 
-sdo:mechanismOfAction
+schema:mechanismOfAction
     rdfs:label "mechanism ofAction" ;
     rdfs:comment "The specific biochemical interaction through which this drug or supplement produces its pharmacological effect." ;
 .
 
-sdo:mediaAuthenticityCategory
+schema:mediaAuthenticityCategory
     rdfs:label "media authenticityCategory" ;
     rdfs:comment "Indicates a MediaManipulationRatingEnumeration classification of a media object (in the context of how it was published or shared)." ;
 .
 
-sdo:mediaItemAppearance
+schema:mediaItemAppearance
     rdfs:label "media itemAppearance" ;
     rdfs:comment "In the context of a [[MediaReview]], indicates specific media item(s) that are grouped using a [[MediaReviewItem]]." ;
 .
 
-sdo:median
+schema:median
     rdfs:label "median" ;
     rdfs:comment "The median value." ;
 .
 
-sdo:medicalAudience
+schema:medicalAudience
     rdfs:label "medical audience" ;
     rdfs:comment "Medical audience for page." ;
 .
 
-sdo:medicalSpecialty
+schema:medicalSpecialty
     rdfs:label "medical specialty" ;
     rdfs:comment "A medical specialty of the provider." ;
 .
 
-sdo:medicineSystem
+schema:medicineSystem
     rdfs:label "medicine system" ;
     rdfs:comment "The system of medicine that includes this MedicalEntity, for example 'evidence-based', 'homeopathic', 'chiropractic', etc." ;
 .
 
-sdo:meetsEmissionStandard
+schema:meetsEmissionStandard
     rdfs:label "meets emissionStandard" ;
     rdfs:comment "Indicates that the vehicle meets the respective emission standard." ;
 .
 
-sdo:member
+schema:member
     rdfs:label "member" ;
     rdfs:comment "A member of an Organization or a ProgramMembership. Organizations can be members of organizations; ProgramMembership is typically for individuals." ;
 .
 
-sdo:memberOf
+schema:memberOf
     rdfs:label "member of" ;
     rdfs:comment "An Organization (or ProgramMembership) to which this Person or Organization belongs." ;
 .
 
-sdo:members
+schema:members
     rdfs:label "members" ;
     rdfs:comment "A member of this organization." ;
 .
 
-sdo:membershipNumber
+schema:membershipNumber
     rdfs:label "membership number" ;
     rdfs:comment "A unique identifier for the membership." ;
 .
 
-sdo:membershipPointsEarned
+schema:membershipPointsEarned
     rdfs:label "membership pointsEarned" ;
     rdfs:comment "The number of membership points earned by the member. If necessary, the unitText can be used to express the units the points are issued in. (e.g. stars, miles, etc.)" ;
 .
 
-sdo:memoryRequirements
+schema:memoryRequirements
     rdfs:label "memory requirements" ;
     rdfs:comment "Minimum memory requirements." ;
 .
 
-sdo:mentions
+schema:mentions
     rdfs:label "mentions" ;
     rdfs:comment "Indicates that the CreativeWork contains a reference to, but is not necessarily about a concept." ;
 .
 
-sdo:menu
+schema:menu
     rdfs:label "menu" ;
     rdfs:comment "Either the actual menu as a structured representation, as text, or a URL of the menu." ;
 .
 
-sdo:menuAddOn
+schema:menuAddOn
     rdfs:label "menu addOn" ;
     rdfs:comment "Additional menu item(s) such as a side dish of salad or side order of fries that can be added to this menu item. Additionally it can be a menu section containing allowed add-on menu items for this menu item." ;
 .
 
-sdo:merchant
+schema:merchant
     rdfs:label "merchant" ;
     rdfs:comment "'merchant' is an out-dated term for 'seller'." ;
 .
 
-sdo:merchantReturnDays
+schema:merchantReturnDays
     rdfs:label "merchant returnDays" ;
     rdfs:comment "Specifies either a fixed return date or the number of days (from the delivery date) that a product can be returned. Used when the [[returnPolicyCategory]] property is specified as [[MerchantReturnFiniteReturnWindow]]." ;
 .
 
-sdo:merchantReturnLink
+schema:merchantReturnLink
     rdfs:label "merchant returnLink" ;
     rdfs:comment "Specifies a Web page or service by URL, for product returns." ;
 .
 
-sdo:messageAttachment
+schema:messageAttachment
     rdfs:label "message attachment" ;
     rdfs:comment "A CreativeWork attached to the message." ;
 .
 
-sdo:mileageFromOdometer
+schema:mileageFromOdometer
     rdfs:label "mileage fromOdometer" ;
     rdfs:comment "The total distance travelled by the particular vehicle since its initial production, as read from its odometer.\\n\\nTypical unit code(s): KMT for kilometers, SMI for statute miles" ;
 .
 
-sdo:minPrice
+schema:minPrice
     rdfs:label "min price" ;
     rdfs:comment "The lowest price if the price is a range." ;
 .
 
-sdo:minValue
+schema:minValue
     rdfs:label "min value" ;
     rdfs:comment "The lower value of some characteristic or property." ;
 .
 
-sdo:minimumPaymentDue
+schema:minimumPaymentDue
     rdfs:label "minimum paymentDue" ;
     rdfs:comment "The minimum payment required at this time." ;
 .
 
-sdo:missionCoveragePrioritiesPolicy
+schema:missionCoveragePrioritiesPolicy
     rdfs:label "mission coverage Priorities Policy" ;
     rdfs:comment "For a [[NewsMediaOrganization]], a statement on coverage priorities, including any public agenda or stance on issues." ;
 .
 
-sdo:model
+schema:model
     rdfs:label "model" ;
     rdfs:comment "The model of the product. Use with the URL of a ProductModel or a textual representation of the model identifier. The URL of the ProductModel can be from an external source. It is recommended to additionally provide strong product identifiers via the gtin8/gtin13/gtin14 and mpn properties." ;
 .
 
-sdo:modelDate
+schema:modelDate
     rdfs:label "model date" ;
     rdfs:comment "The release date of a vehicle model (often used to differentiate versions of the same make and model)." ;
 .
 
-sdo:modifiedTime
+schema:modifiedTime
     rdfs:label "modified time" ;
     rdfs:comment "The date and time the reservation was modified." ;
 .
 
-sdo:molecularFormula
+schema:molecularFormula
     rdfs:label "molecular formula" ;
     rdfs:comment "The empirical formula is the simplest whole number ratio of all the atoms in a molecule." ;
 .
 
-sdo:molecularWeight
+schema:molecularWeight
     rdfs:label "molecular weight" ;
     rdfs:comment "This is the molecular weight of the entity being described, not of the parent. Units should be included in the form '<Number> <unit>', for example '12 amu' or as '<QuantitativeValue>." ;
 .
 
-sdo:monoisotopicMolecularWeight
+schema:monoisotopicMolecularWeight
     rdfs:label "monoisotopic molecularWeight" ;
     rdfs:comment "The monoisotopic mass is the sum of the masses of the atoms in a molecule using the unbound, ground-state, rest mass of the principal (most abundant) isotope for each element instead of the isotopic average mass. Please include the units the form '<Number> <unit>', for example '770.230488 g/mol' or as '<QuantitativeValue>." ;
 .
 
-sdo:monthlyMinimumRepaymentAmount
+schema:monthlyMinimumRepaymentAmount
     rdfs:label "monthly minimum Repayment Amount" ;
     rdfs:comment "The minimum payment is the lowest amount of money that one is required to pay on a credit card statement each month." ;
 .
 
-sdo:monthsOfExperience
+schema:monthsOfExperience
     rdfs:label "months ofExperience" ;
     rdfs:comment "Indicates the minimal number of months of experience required for a position." ;
 .
 
-sdo:mpn
+schema:mpn
     rdfs:label "mpn" ;
     rdfs:comment "The Manufacturer Part Number (MPN) of the product, or the product to which the offer refers." ;
 .
 
-sdo:multipleValues
+schema:multipleValues
     rdfs:label "multiple values" ;
     rdfs:comment "Whether multiple values are allowed for the property.  Default is false." ;
 .
 
-sdo:muscleAction
+schema:muscleAction
     rdfs:label "muscle action" ;
     rdfs:comment "The movement the muscle generates." ;
 .
 
-sdo:musicArrangement
+schema:musicArrangement
     rdfs:label "music arrangement" ;
     rdfs:comment "An arrangement derived from the composition." ;
 .
 
-sdo:musicBy
+schema:musicBy
     rdfs:label "music by" ;
     rdfs:comment "The composer of the soundtrack." ;
 .
 
-sdo:musicCompositionForm
+schema:musicCompositionForm
     rdfs:label "music compositionForm" ;
     rdfs:comment "The type of composition (e.g. overture, sonata, symphony, etc.)." ;
 .
 
-sdo:musicGroupMember
+schema:musicGroupMember
     rdfs:label "music groupMember" ;
     rdfs:comment "A member of a music group—for example, John, Paul, George, or Ringo." ;
 .
 
-sdo:musicReleaseFormat
+schema:musicReleaseFormat
     rdfs:label "music releaseFormat" ;
     rdfs:comment "Format of this release (the type of recording media used, ie. compact disc, digital media, LP, etc.)." ;
 .
 
-sdo:musicalKey
+schema:musicalKey
     rdfs:label "musical key" ;
     rdfs:comment "The key, mode, or scale this composition uses." ;
 .
 
-sdo:naics
+schema:naics
     rdfs:label "naics" ;
     rdfs:comment "The North American Industry Classification System (NAICS) code for a particular organization or business person." ;
 .
 
-sdo:name
+schema:name
     rdfs:label "name" ;
     rdfs:comment "The name of the item." ;
 .
 
-sdo:namedPosition
+schema:namedPosition
     rdfs:label "named position" ;
     rdfs:comment "A position played, performed or filled by a person or organization, as part of an organization. For example, an athlete in a SportsTeam might play in the position named 'Quarterback'." ;
 .
 
-sdo:nationality
+schema:nationality
     rdfs:label "nationality" ;
     rdfs:comment "Nationality of the person." ;
 .
 
-sdo:naturalProgression
+schema:naturalProgression
     rdfs:label "natural progression" ;
     rdfs:comment "The expected progression of the condition if it is not treated and allowed to progress naturally." ;
 .
 
-sdo:negativeNotes
+schema:negativeNotes
     rdfs:label "negative notes" ;
     rdfs:comment "Indicates, in the context of a [[Review]] (e.g. framed as 'pro' vs 'con' considerations), negative considerations - either as unstructured text, or a list." ;
 .
 
-sdo:nerve
+schema:nerve
     rdfs:label "nerve" ;
     rdfs:comment "The underlying innervation associated with the muscle." ;
 .
 
-sdo:nerveMotor
+schema:nerveMotor
     rdfs:label "nerve motor" ;
     rdfs:comment "The neurological pathway extension that involves muscle control." ;
 .
 
-sdo:netWorth
+schema:netWorth
     rdfs:label "net worth" ;
     rdfs:comment "The total financial value of the person as calculated by subtracting assets from liabilities." ;
 .
 
-sdo:newsUpdatesAndGuidelines
+schema:newsUpdatesAndGuidelines
     rdfs:label "news updates And Guidelines" ;
     rdfs:comment "Indicates a page with news updates and guidelines. This could often be (but is not required to be) the main page containing [[SpecialAnnouncement]] markup on a site." ;
 .
 
-sdo:nextItem
+schema:nextItem
     rdfs:label "next item" ;
     rdfs:comment "A link to the ListItem that follows the current one." ;
 .
 
-sdo:noBylinesPolicy
+schema:noBylinesPolicy
     rdfs:label "no bylinesPolicy" ;
     rdfs:comment "For a [[NewsMediaOrganization]] or other news-related [[Organization]], a statement explaining when authors of articles are not named in bylines." ;
 .
 
-sdo:nonEqual
+schema:nonEqual
     rdfs:label "non equal" ;
     rdfs:comment "This ordering relation for qualitative values indicates that the subject is not equal to the object." ;
 .
 
-sdo:nonProprietaryName
+schema:nonProprietaryName
     rdfs:label "non proprietaryName" ;
     rdfs:comment "The generic name of this drug or supplement." ;
 .
 
-sdo:nonprofitStatus
+schema:nonprofitStatus
     rdfs:label "nonprofit status" ;
     rdfs:comment "nonprofit Status indicates the legal status of a non-profit organization in its primary place of business." ;
 .
 
-sdo:normalRange
+schema:normalRange
     rdfs:label "normal range" ;
     rdfs:comment "Range of acceptable values for a typical patient, when applicable." ;
 .
 
-sdo:nsn
+schema:nsn
     rdfs:label "nsn" ;
     rdfs:comment "Indicates the [NATO stock number](https://en.wikipedia.org/wiki/NATO_Stock_Number) (nsn) of a [[Product]]. " ;
 .
 
-sdo:numAdults
+schema:numAdults
     rdfs:label "num adults" ;
     rdfs:comment "The number of adults staying in the unit." ;
 .
 
-sdo:numChildren
+schema:numChildren
     rdfs:label "num children" ;
     rdfs:comment "The number of children staying in the unit." ;
 .
 
-sdo:numConstraints
+schema:numConstraints
     rdfs:label "num constraints" ;
     rdfs:comment "Indicates the number of constraints (not counting [[populationType]]) defined for a particular [[StatisticalPopulation]]. This helps applications understand if they have access to a sufficiently complete description of a [[StatisticalPopulation]]." ;
 .
 
-sdo:numTracks
+schema:numTracks
     rdfs:label "num tracks" ;
     rdfs:comment "The number of tracks in this album or playlist." ;
 .
 
-sdo:numberOfAccommodationUnits
+schema:numberOfAccommodationUnits
     rdfs:label "number of Accommodation Units" ;
     rdfs:comment "Indicates the total (available plus unavailable) number of accommodation units in an [[ApartmentComplex]], or the number of accommodation units for a specific [[FloorPlan]] (within its specific [[ApartmentComplex]]). See also [[numberOfAvailableAccommodationUnits]]." ;
 .
 
-sdo:numberOfAirbags
+schema:numberOfAirbags
     rdfs:label "number ofAirbags" ;
     rdfs:comment "The number or type of airbags in the vehicle." ;
 .
 
-sdo:numberOfAvailableAccommodationUnits
+schema:numberOfAvailableAccommodationUnits
     rdfs:label "number ofAvailable Accommodation Units" ;
     rdfs:comment "Indicates the number of available accommodation units in an [[ApartmentComplex]], or the number of accommodation units for a specific [[FloorPlan]] (within its specific [[ApartmentComplex]]). See also [[numberOfAccommodationUnits]]." ;
 .
 
-sdo:numberOfAxles
+schema:numberOfAxles
     rdfs:label "number ofAxles" ;
     rdfs:comment "The number of axles.\\n\\nTypical unit code(s): C62" ;
 .
 
-sdo:numberOfBathroomsTotal
+schema:numberOfBathroomsTotal
     rdfs:label "number of Bathrooms Total" ;
     rdfs:comment "The total integer number of bathrooms in a some [[Accommodation]], following real estate conventions as [documented in RESO](https://ddwiki.reso.org/display/DDW17/BathroomsTotalInteger+Field): \"The simple sum of the number of bathrooms. For example for a property with two Full Bathrooms and one Half Bathroom, the Bathrooms Total Integer will be 3.\". See also [[numberOfRooms]]." ;
 .
 
-sdo:numberOfBedrooms
+schema:numberOfBedrooms
     rdfs:label "number ofBedrooms" ;
     rdfs:comment "The total integer number of bedrooms in a some [[Accommodation]], [[ApartmentComplex]] or [[FloorPlan]]." ;
 .
 
-sdo:numberOfBeds
+schema:numberOfBeds
     rdfs:label "number ofBeds" ;
     rdfs:comment "The quantity of the given bed type available in the HotelRoom, Suite, House, or Apartment." ;
 .
 
-sdo:numberOfCredits
+schema:numberOfCredits
     rdfs:label "number ofCredits" ;
     rdfs:comment "The number of credits or units awarded by a Course or required to complete an EducationalOccupationalProgram." ;
 .
 
-sdo:numberOfDoors
+schema:numberOfDoors
     rdfs:label "number ofDoors" ;
     rdfs:comment "The number of doors.\\n\\nTypical unit code(s): C62" ;
 .
 
-sdo:numberOfEmployees
+schema:numberOfEmployees
     rdfs:label "number ofEmployees" ;
     rdfs:comment "The number of employees in an organization e.g. business." ;
 .
 
-sdo:numberOfEpisodes
+schema:numberOfEpisodes
     rdfs:label "number ofEpisodes" ;
     rdfs:comment "The number of episodes in this season or series." ;
 .
 
-sdo:numberOfForwardGears
+schema:numberOfForwardGears
     rdfs:label "number of Forward Gears" ;
     rdfs:comment "The total number of forward gears available for the transmission system of the vehicle.\\n\\nTypical unit code(s): C62" ;
 .
 
-sdo:numberOfFullBathrooms
+schema:numberOfFullBathrooms
     rdfs:label "number of Full Bathrooms" ;
     rdfs:comment "Number of full bathrooms - The total number of full and ¾ bathrooms in an [[Accommodation]]. This corresponds to the [BathroomsFull field in RESO](https://ddwiki.reso.org/display/DDW17/BathroomsFull+Field)." ;
 .
 
-sdo:numberOfItems
+schema:numberOfItems
     rdfs:label "number ofItems" ;
     rdfs:comment "The number of items in an ItemList. Note that some descriptions might not fully describe all items in a list (e.g., multi-page pagination); in such cases, the numberOfItems would be for the entire list." ;
 .
 
-sdo:numberOfLoanPayments
+schema:numberOfLoanPayments
     rdfs:label "number of Loan Payments" ;
     rdfs:comment "The number of payments contractually required at origination to repay the loan. For monthly paying loans this is the number of months from the contractual first payment date to the maturity date." ;
 .
 
-sdo:numberOfPages
+schema:numberOfPages
     rdfs:label "number ofPages" ;
     rdfs:comment "The number of pages in the book." ;
 .
 
-sdo:numberOfPartialBathrooms
+schema:numberOfPartialBathrooms
     rdfs:label "number of Partial Bathrooms" ;
     rdfs:comment "Number of partial bathrooms - The total number of half and ¼ bathrooms in an [[Accommodation]]. This corresponds to the [BathroomsPartial field in RESO](https://ddwiki.reso.org/display/DDW17/BathroomsPartial+Field). " ;
 .
 
-sdo:numberOfPlayers
+schema:numberOfPlayers
     rdfs:label "number ofPlayers" ;
     rdfs:comment "Indicate how many people can play this game (minimum, maximum, or range)." ;
 .
 
-sdo:numberOfPreviousOwners
+schema:numberOfPreviousOwners
     rdfs:label "number of Previous Owners" ;
     rdfs:comment "The number of owners of the vehicle, including the current one.\\n\\nTypical unit code(s): C62" ;
 .
 
-sdo:numberOfRooms
+schema:numberOfRooms
     rdfs:label "number ofRooms" ;
     rdfs:comment """The number of rooms (excluding bathrooms and closets) of the accommodation or lodging business.
 Typical unit code(s): ROM for room or C62 for no unit. The type of room can be put in the unitText property of the QuantitativeValue.""" ;
 .
 
-sdo:numberOfSeasons
+schema:numberOfSeasons
     rdfs:label "number ofSeasons" ;
     rdfs:comment "The number of seasons in this series." ;
 .
 
-sdo:numberedPosition
+schema:numberedPosition
     rdfs:label "numbered position" ;
     rdfs:comment "A number associated with a role in an organization, for example, the number on an athlete's jersey." ;
 .
 
-sdo:nutrition
+schema:nutrition
     rdfs:label "nutrition" ;
     rdfs:comment "Nutrition information about the recipe or menu item." ;
 .
 
-sdo:object
+schema:object
     rdfs:label "object" ;
     rdfs:comment "The object upon which the action is carried out, whose state is kept intact or changed. Also known as the semantic roles patient, affected or undergoer (which change their state) or theme (which doesn't). e.g. John read *a book*." ;
 .
 
-sdo:observationDate
+schema:observationDate
     rdfs:label "observation date" ;
     rdfs:comment "The observationDate of an [[Observation]]." ;
 .
 
-sdo:observedNode
+schema:observedNode
     rdfs:label "observed node" ;
     rdfs:comment "The observedNode of an [[Observation]], often a [[StatisticalPopulation]]." ;
 .
 
-sdo:occupancy
+schema:occupancy
     rdfs:label "occupancy" ;
     rdfs:comment """The allowed total occupancy for the accommodation in persons (including infants etc). For individual accommodations, this is not necessarily the legal maximum but defines the permitted usage as per the contractual agreement (e.g. a double room used by a single person).
 Typical unit code(s): C62 for person""" ;
 .
 
-sdo:occupationLocation
+schema:occupationLocation
     rdfs:label "occupation location" ;
     rdfs:comment " The region/country for which this occupational description is appropriate. Note that educational requirements and qualifications can vary between jurisdictions." ;
 .
 
-sdo:occupationalCategory
+schema:occupationalCategory
     rdfs:label "occupational category" ;
     rdfs:comment """A category describing the job, preferably using a term from a taxonomy such as [BLS O*NET-SOC](http://www.onetcenter.org/taxonomy.html), [ISCO-08](https://www.ilo.org/public/english/bureau/stat/isco/isco08/) or similar, with the property repeated for each applicable value. Ideally the taxonomy should be identified, and both the textual label and formal code for the category should be provided.\\n
 Note: for historical reasons, any textual label and formal code provided as a literal may be assumed to be from O*NET-SOC.""" ;
 .
 
-sdo:occupationalCredentialAwarded
+schema:occupationalCredentialAwarded
     rdfs:label "occupational credentialAwarded" ;
     rdfs:comment "A description of the qualification, award, certificate, diploma or other occupational credential awarded as a consequence of successful completion of this course or program." ;
 .
 
-sdo:offerCount
+schema:offerCount
     rdfs:label "offer count" ;
     rdfs:comment "The number of offers for the product." ;
 .
 
-sdo:offeredBy
+schema:offeredBy
     rdfs:label "offered by" ;
     rdfs:comment "A pointer to the organization or person making the offer." ;
 .
 
-sdo:offers
+schema:offers
     rdfs:label "offers" ;
     rdfs:comment """An offer to provide this item—for example, an offer to sell a product, rent the DVD of a movie, perform a service, or give away tickets to an event. Use [[businessFunction]] to indicate the kind of transaction offered, i.e. sell, lease, etc. This property can also be used to describe a [[Demand]]. While this property is listed as expected on a number of common types, it can be used in others. In that case, using a second type, such as Product or a subtype of Product, can clarify the nature of the offer.
       """ ;
 .
 
-sdo:offersPrescriptionByMail
+schema:offersPrescriptionByMail
     rdfs:label "offers prescription By Mail" ;
     rdfs:comment "Whether prescriptions can be delivered by mail." ;
 .
 
-sdo:openingHours
+schema:openingHours
     rdfs:label "opening hours" ;
     rdfs:comment """The general opening hours for a business. Opening hours can be specified as a weekly time range, starting with days, then times per day. Multiple days can be listed with commas ',' separating each day. Day or time ranges are specified using a hyphen '-'.\\n\\n* Days are specified using the following two-letter combinations: ```Mo```, ```Tu```, ```We```, ```Th```, ```Fr```, ```Sa```, ```Su```.\\n* Times are specified using 24:00 format. For example, 3pm is specified as ```15:00```, 10am as ```10:00```. \\n* Here is an example: <code><time itemprop=\"openingHours\" datetime="Tu,Th 16:00-20:00">Tuesdays and Thursdays 4-8pm</time></code>.\\n* If a business is open 7 days a week, then it can be specified as <code><time itemprop="openingHours" datetime="Mo-Su">Monday through Sunday, all day</time></code>.""" ;
 .
 
-sdo:openingHoursSpecification
+schema:openingHoursSpecification
     rdfs:label "opening hoursSpecification" ;
     rdfs:comment "The opening hours of a certain place." ;
 .
 
-sdo:opens
+schema:opens
     rdfs:label "opens" ;
     rdfs:comment "The opening hour of the place or service on the given day(s) of the week." ;
 .
 
-sdo:operatingSystem
+schema:operatingSystem
     rdfs:label "operating system" ;
     rdfs:comment "Operating systems supported (Windows 7, OSX 10.6, Android 1.6)." ;
 .
 
-sdo:opponent
+schema:opponent
     rdfs:label "opponent" ;
     rdfs:comment "A sub property of participant. The opponent on this action." ;
 .
 
-sdo:option
+schema:option
     rdfs:label "option" ;
     rdfs:comment "A sub property of object. The options subject to this action." ;
 .
 
-sdo:orderDate
+schema:orderDate
     rdfs:label "order date" ;
     rdfs:comment "Date order was placed." ;
 .
 
-sdo:orderDelivery
+schema:orderDelivery
     rdfs:label "order delivery" ;
     rdfs:comment "The delivery of the parcel related to this order or order item." ;
 .
 
-sdo:orderItemNumber
+schema:orderItemNumber
     rdfs:label "order itemNumber" ;
     rdfs:comment "The identifier of the order item." ;
 .
 
-sdo:orderItemStatus
+schema:orderItemStatus
     rdfs:label "order itemStatus" ;
     rdfs:comment "The current status of the order item." ;
 .
 
-sdo:orderNumber
+schema:orderNumber
     rdfs:label "order number" ;
     rdfs:comment "The identifier of the transaction." ;
 .
 
-sdo:orderQuantity
+schema:orderQuantity
     rdfs:label "order quantity" ;
     rdfs:comment "The number of the item ordered. If the property is not set, assume the quantity is one." ;
 .
 
-sdo:orderStatus
+schema:orderStatus
     rdfs:label "order status" ;
     rdfs:comment "The current status of the order." ;
 .
 
-sdo:orderedItem
+schema:orderedItem
     rdfs:label "ordered item" ;
     rdfs:comment "The item ordered." ;
 .
 
-sdo:organizer
+schema:organizer
     rdfs:label "organizer" ;
     rdfs:comment "An organizer of an Event." ;
 .
 
-sdo:originAddress
+schema:originAddress
     rdfs:label "origin address" ;
     rdfs:comment "Shipper's address." ;
 .
 
-sdo:originalMediaContextDescription
+schema:originalMediaContextDescription
     rdfs:label "original media Context Description" ;
     rdfs:comment "Describes, in a [[MediaReview]] when dealing with [[DecontextualizedContent]], background information that can contribute to better interpretation of the [[MediaObject]]." ;
 .
 
-sdo:originalMediaLink
+schema:originalMediaLink
     rdfs:label "original mediaLink" ;
     rdfs:comment "Link to the page containing an original version of the content, or directly to an online copy of the original [[MediaObject]] content, e.g. video file." ;
 .
 
-sdo:originatesFrom
+schema:originatesFrom
     rdfs:label "originates from" ;
     rdfs:comment "The vasculature the lymphatic structure originates, or afferents, from." ;
 .
 
-sdo:overdosage
+schema:overdosage
     rdfs:label "overdosage" ;
     rdfs:comment "Any information related to overdose on a drug, including signs or symptoms, treatments, contact information for emergency response." ;
 .
 
-sdo:ownedFrom
+schema:ownedFrom
     rdfs:label "owned from" ;
     rdfs:comment "The date and time of obtaining the product." ;
 .
 
-sdo:ownedThrough
+schema:ownedThrough
     rdfs:label "owned through" ;
     rdfs:comment "The date and time of giving up ownership on the product." ;
 .
 
-sdo:ownershipFundingInfo
+schema:ownershipFundingInfo
     rdfs:label "ownership fundingInfo" ;
     rdfs:comment "For an [[Organization]] (often but not necessarily a [[NewsMediaOrganization]]), a description of organizational ownership structure; funding and grants. In a news/media setting, this is with particular reference to editorial independence.   Note that the [[funder]] is also available and can be used to make basic funder information machine-readable." ;
 .
 
-sdo:owns
+schema:owns
     rdfs:label "owns" ;
     rdfs:comment "Products owned by the organization or person." ;
 .
 
-sdo:pageEnd
+schema:pageEnd
     rdfs:label "page end" ;
     rdfs:comment "The page on which the work ends; for example \"138\" or \"xvi\"." ;
 .
 
-sdo:pageStart
+schema:pageStart
     rdfs:label "page start" ;
     rdfs:comment "The page on which the work starts; for example \"135\" or \"xiii\"." ;
 .
 
-sdo:pagination
+schema:pagination
     rdfs:label "pagination" ;
     rdfs:comment "Any description of pages that is not separated into pageStart and pageEnd; for example, \"1-6, 9, 55\" or \"10-12, 46-49\"." ;
 .
 
-sdo:parent
+schema:parent
     rdfs:label "parent" ;
     rdfs:comment "A parent of this person." ;
 .
 
-sdo:parentItem
+schema:parentItem
     rdfs:label "parent item" ;
     rdfs:comment "The parent of a question, answer or item in general." ;
 .
 
-sdo:parentOrganization
+schema:parentOrganization
     rdfs:label "parent organization" ;
     rdfs:comment "The larger organization that this organization is a [[subOrganization]] of, if any." ;
 .
 
-sdo:parentService
+schema:parentService
     rdfs:label "parent service" ;
     rdfs:comment "A broadcast service to which the broadcast service may belong to such as regional variations of a national channel." ;
 .
 
-sdo:parentTaxon
+schema:parentTaxon
     rdfs:label "parent taxon" ;
     rdfs:comment "Closest parent taxon of the taxon in question." ;
 .
 
-sdo:parents
+schema:parents
     rdfs:label "parents" ;
     rdfs:comment "A parents of the person." ;
 .
 
-sdo:partOfEpisode
+schema:partOfEpisode
     rdfs:label "part ofEpisode" ;
     rdfs:comment "The episode to which this clip belongs." ;
 .
 
-sdo:partOfInvoice
+schema:partOfInvoice
     rdfs:label "part ofInvoice" ;
     rdfs:comment "The order is being paid as part of the referenced Invoice." ;
 .
 
-sdo:partOfOrder
+schema:partOfOrder
     rdfs:label "part ofOrder" ;
     rdfs:comment "The overall order the items in this delivery were included in." ;
 .
 
-sdo:partOfSeason
+schema:partOfSeason
     rdfs:label "part ofSeason" ;
     rdfs:comment "The season to which this episode belongs." ;
 .
 
-sdo:partOfSeries
+schema:partOfSeries
     rdfs:label "part ofSeries" ;
     rdfs:comment "The series to which this episode or season belongs." ;
 .
 
-sdo:partOfSystem
+schema:partOfSystem
     rdfs:label "part ofSystem" ;
     rdfs:comment "The anatomical or organ system that this structure is part of." ;
 .
 
-sdo:partOfTVSeries
+schema:partOfTVSeries
     rdfs:label "part ofTVSeries" ;
     rdfs:comment "The TV series to which this episode or season belongs." ;
 .
 
-sdo:partOfTrip
+schema:partOfTrip
     rdfs:label "part ofTrip" ;
     rdfs:comment "Identifies that this [[Trip]] is a subTrip of another Trip.  For example Day 1, Day 2, etc. of a multi-day trip." ;
 .
 
-sdo:participant
+schema:participant
     rdfs:label "participant" ;
     rdfs:comment "Other co-agents that participated in the action indirectly. e.g. John wrote a book with *Steve*." ;
 .
 
-sdo:partySize
+schema:partySize
     rdfs:label "party size" ;
     rdfs:comment "Number of people the reservation should accommodate." ;
 .
 
-sdo:passengerPriorityStatus
+schema:passengerPriorityStatus
     rdfs:label "passenger priorityStatus" ;
     rdfs:comment "The priority status assigned to a passenger for security or boarding (e.g. FastTrack or Priority)." ;
 .
 
-sdo:passengerSequenceNumber
+schema:passengerSequenceNumber
     rdfs:label "passenger sequenceNumber" ;
     rdfs:comment "The passenger's sequence number as assigned by the airline." ;
 .
 
-sdo:pathophysiology
+schema:pathophysiology
     rdfs:label "pathophysiology" ;
     rdfs:comment "Changes in the normal mechanical, physical, and biochemical functions that are associated with this activity or condition." ;
 .
 
-sdo:pattern
+schema:pattern
     rdfs:label "pattern" ;
     rdfs:comment "A pattern that something has, for example 'polka dot', 'striped', 'Canadian flag'. Values are typically expressed as text, although links to controlled value schemes are also supported." ;
 .
 
-sdo:payload
+schema:payload
     rdfs:label "payload" ;
     rdfs:comment "The permitted weight of passengers and cargo, EXCLUDING the weight of the empty vehicle.\\n\\nTypical unit code(s): KGM for kilogram, LBR for pound\\n\\n* Note 1: Many databases specify the permitted TOTAL weight instead, which is the sum of [[weight]] and [[payload]]\\n* Note 2: You can indicate additional information in the [[name]] of the [[QuantitativeValue]] node.\\n* Note 3: You may also link to a [[QualitativeValue]] node that provides additional information using [[valueReference]].\\n* Note 4: Note that you can use [[minValue]] and [[maxValue]] to indicate ranges." ;
 .
 
-sdo:paymentAccepted
+schema:paymentAccepted
     rdfs:label "payment accepted" ;
     rdfs:comment "Cash, Credit Card, Cryptocurrency, Local Exchange Tradings System, etc." ;
 .
 
-sdo:paymentDue
+schema:paymentDue
     rdfs:label "payment due" ;
     rdfs:comment "The date that payment is due." ;
 .
 
-sdo:paymentDueDate
+schema:paymentDueDate
     rdfs:label "payment dueDate" ;
     rdfs:comment "The date that payment is due." ;
 .
 
-sdo:paymentMethod
+schema:paymentMethod
     rdfs:label "payment method" ;
     rdfs:comment "The name of the credit card or other method of payment for the order." ;
 .
 
-sdo:paymentMethodId
+schema:paymentMethodId
     rdfs:label "payment methodId" ;
     rdfs:comment "An identifier for the method of payment used (e.g. the last 4 digits of the credit card)." ;
 .
 
-sdo:paymentStatus
+schema:paymentStatus
     rdfs:label "payment status" ;
     rdfs:comment "The status of payment; whether the invoice has been paid or not." ;
 .
 
-sdo:paymentUrl
+schema:paymentUrl
     rdfs:label "payment url" ;
     rdfs:comment "The URL for sending a payment." ;
 .
 
-sdo:penciler
+schema:penciler
     rdfs:label "penciler" ;
     rdfs:comment "The individual who draws the primary narrative artwork." ;
 .
 
-sdo:percentile10
+schema:percentile10
     rdfs:label "percentile10" ;
     rdfs:comment "The 10th percentile value." ;
 .
 
-sdo:percentile25
+schema:percentile25
     rdfs:label "percentile25" ;
     rdfs:comment "The 25th percentile value." ;
 .
 
-sdo:percentile75
+schema:percentile75
     rdfs:label "percentile75" ;
     rdfs:comment "The 75th percentile value." ;
 .
 
-sdo:percentile90
+schema:percentile90
     rdfs:label "percentile90" ;
     rdfs:comment "The 90th percentile value." ;
 .
 
-sdo:performTime
+schema:performTime
     rdfs:label "perform time" ;
     rdfs:comment "The length of time it takes to perform instructions or a direction (not including time to prepare the supplies), in [ISO 8601 duration format](http://en.wikipedia.org/wiki/ISO_8601)." ;
 .
 
-sdo:performer
+schema:performer
     rdfs:label "performer" ;
     rdfs:comment "A performer at the event—for example, a presenter, musician, musical group or actor." ;
 .
 
-sdo:performerIn
+schema:performerIn
     rdfs:label "performer in" ;
     rdfs:comment "Event that this person is a performer or participant in." ;
 .
 
-sdo:performers
+schema:performers
     rdfs:label "performers" ;
     rdfs:comment "The main performer or performers of the event—for example, a presenter, musician, or actor." ;
 .
 
-sdo:permissionType
+schema:permissionType
     rdfs:label "permission type" ;
     rdfs:comment "The type of permission granted the person, organization, or audience." ;
 .
 
-sdo:permissions
+schema:permissions
     rdfs:label "permissions" ;
     rdfs:comment "Permission(s) required to run the app (for example, a mobile app may require full internet access or may run only on wifi)." ;
 .
 
-sdo:permitAudience
+schema:permitAudience
     rdfs:label "permit audience" ;
     rdfs:comment "The target audience for this permit." ;
 .
 
-sdo:permittedUsage
+schema:permittedUsage
     rdfs:label "permitted usage" ;
     rdfs:comment "Indications regarding the permitted usage of the accommodation." ;
 .
 
-sdo:petsAllowed
+schema:petsAllowed
     rdfs:label "pets allowed" ;
     rdfs:comment "Indicates whether pets are allowed to enter the accommodation or lodging business. More detailed information can be put in a text value." ;
 .
 
-sdo:phoneticText
+schema:phoneticText
     rdfs:label "phonetic text" ;
     rdfs:comment "Representation of a text [[textValue]] using the specified [[speechToTextMarkup]]. For example the city name of Houston in IPA: /ˈhjuːstən/." ;
 .
 
-sdo:photo
+schema:photo
     rdfs:label "photo" ;
     rdfs:comment "A photograph of this place." ;
 .
 
-sdo:photos
+schema:photos
     rdfs:label "photos" ;
     rdfs:comment "Photographs of this place." ;
 .
 
-sdo:physicalRequirement
+schema:physicalRequirement
     rdfs:label "physical requirement" ;
     rdfs:comment "A description of the types of physical activity associated with the job. Defined terms such as those in O*net may be used, but note that there is no way to specify the level of ability as well as its nature when using a defined term." ;
 .
 
-sdo:physiologicalBenefits
+schema:physiologicalBenefits
     rdfs:label "physiological benefits" ;
     rdfs:comment "Specific physiologic benefits associated to the plan." ;
 .
 
-sdo:pickupLocation
+schema:pickupLocation
     rdfs:label "pickup location" ;
     rdfs:comment "Where a taxi will pick up a passenger or a rental car can be picked up." ;
 .
 
-sdo:pickupTime
+schema:pickupTime
     rdfs:label "pickup time" ;
     rdfs:comment "When a taxi will pickup a passenger or a rental car can be picked up." ;
 .
 
-sdo:playMode
+schema:playMode
     rdfs:label "play mode" ;
     rdfs:comment "Indicates whether this game is multi-player, co-op or single-player.  The game can be marked as multi-player, co-op and single-player at the same time." ;
 .
 
-sdo:playerType
+schema:playerType
     rdfs:label "player type" ;
     rdfs:comment "Player type required—for example, Flash or Silverlight." ;
 .
 
-sdo:playersOnline
+schema:playersOnline
     rdfs:label "players online" ;
     rdfs:comment "Number of players on the server." ;
 .
 
-sdo:polygon
+schema:polygon
     rdfs:label "polygon" ;
     rdfs:comment "A polygon is the area enclosed by a point-to-point path for which the starting and ending points are the same. A polygon is expressed as a series of four or more space delimited points where the first and final points are identical." ;
 .
 
-sdo:populationType
+schema:populationType
     rdfs:label "population type" ;
     rdfs:comment "Indicates the populationType common to all members of a [[StatisticalPopulation]]." ;
 .
 
-sdo:position
+schema:position
     rdfs:label "position" ;
     rdfs:comment "The position of an item in a series or sequence of items." ;
 .
 
-sdo:positiveNotes
+schema:positiveNotes
     rdfs:label "positive notes" ;
     rdfs:comment "Indicates, in the context of a [[Review]] (e.g. framed as 'pro' vs 'con' considerations), positive considerations - either as unstructured text, or a list." ;
 .
 
-sdo:possibleComplication
+schema:possibleComplication
     rdfs:label "possible complication" ;
     rdfs:comment "A possible unexpected and unfavorable evolution of a medical condition. Complications may include worsening of the signs or symptoms of the disease, extension of the condition to other organ systems, etc." ;
 .
 
-sdo:possibleTreatment
+schema:possibleTreatment
     rdfs:label "possible treatment" ;
     rdfs:comment "A possible treatment to address this condition, sign or symptom." ;
 .
 
-sdo:postOfficeBoxNumber
+schema:postOfficeBoxNumber
     rdfs:label "post office Box Number" ;
     rdfs:comment "The post office box number for PO box addresses." ;
 .
 
-sdo:postOp
+schema:postOp
     rdfs:label "post op" ;
     rdfs:comment "A description of the postoperative procedures, care, and/or followups for this device." ;
 .
 
-sdo:postalCode
+schema:postalCode
     rdfs:label "postal code" ;
     rdfs:comment "The postal code. For example, 94043." ;
 .
 
-sdo:postalCodeBegin
+schema:postalCodeBegin
     rdfs:label "postal codeBegin" ;
     rdfs:comment "First postal code in a range (included)." ;
 .
 
-sdo:postalCodeEnd
+schema:postalCodeEnd
     rdfs:label "postal codeEnd" ;
     rdfs:comment "Last postal code in the range (included). Needs to be after [[postalCodeBegin]]." ;
 .
 
-sdo:postalCodePrefix
+schema:postalCodePrefix
     rdfs:label "postal codePrefix" ;
     rdfs:comment "A defined range of postal codes indicated by a common textual prefix. Used for non-numeric systems such as UK." ;
 .
 
-sdo:postalCodeRange
+schema:postalCodeRange
     rdfs:label "postal codeRange" ;
     rdfs:comment "A defined range of postal codes." ;
 .
 
-sdo:potentialAction
+schema:potentialAction
     rdfs:label "potential action" ;
     rdfs:comment "Indicates a potential Action, which describes an idealized action in which this thing would play an 'object' role." ;
 .
 
-sdo:potentialUse
+schema:potentialUse
     rdfs:label "potential use" ;
     rdfs:comment "Intended use of the BioChemEntity by humans." ;
 .
 
-sdo:preOp
+schema:preOp
     rdfs:label "pre op" ;
     rdfs:comment "A description of the workup, testing, and other preparations required before implanting this device." ;
 .
 
-sdo:predecessorOf
+schema:predecessorOf
     rdfs:label "predecessor of" ;
     rdfs:comment "A pointer from a previous, often discontinued variant of the product to its newer variant." ;
 .
 
-sdo:pregnancyCategory
+schema:pregnancyCategory
     rdfs:label "pregnancy category" ;
     rdfs:comment "Pregnancy category of this drug." ;
 .
 
-sdo:pregnancyWarning
+schema:pregnancyWarning
     rdfs:label "pregnancy warning" ;
     rdfs:comment "Any precaution, guidance, contraindication, etc. related to this drug's use during pregnancy." ;
 .
 
-sdo:prepTime
+schema:prepTime
     rdfs:label "prep time" ;
     rdfs:comment "The length of time it takes to prepare the items to be used in instructions or a direction, in [ISO 8601 duration format](http://en.wikipedia.org/wiki/ISO_8601)." ;
 .
 
-sdo:preparation
+schema:preparation
     rdfs:label "preparation" ;
     rdfs:comment "Typical preparation that a patient must undergo before having the procedure performed." ;
 .
 
-sdo:prescribingInfo
+schema:prescribingInfo
     rdfs:label "prescribing info" ;
     rdfs:comment "Link to prescribing information for the drug." ;
 .
 
-sdo:prescriptionStatus
+schema:prescriptionStatus
     rdfs:label "prescription status" ;
     rdfs:comment "Indicates the status of drug prescription eg. local catalogs classifications or whether the drug is available by prescription or over-the-counter, etc." ;
 .
 
-sdo:previousItem
+schema:previousItem
     rdfs:label "previous item" ;
     rdfs:comment "A link to the ListItem that preceeds the current one." ;
 .
 
-sdo:previousStartDate
+schema:previousStartDate
     rdfs:label "previous startDate" ;
     rdfs:comment "Used in conjunction with eventStatus for rescheduled or cancelled events. This property contains the previously scheduled start date. For rescheduled events, the startDate property should be used for the newly scheduled start date. In the (rare) case of an event that has been postponed and rescheduled multiple times, this field may be repeated." ;
 .
 
-sdo:price
+schema:price
     rdfs:label "price" ;
     rdfs:comment """The offer price of a product, or of a price component when attached to PriceSpecification and its subtypes.\\n\\nUsage guidelines:\\n\\n* Use the [[priceCurrency]] property (with standard formats: [ISO 4217 currency format](http://en.wikipedia.org/wiki/ISO_4217) e.g. "USD"; [Ticker symbol](https://en.wikipedia.org/wiki/List_of_cryptocurrencies) for cryptocurrencies e.g. "BTC"; well known names for [Local Exchange Tradings Systems](https://en.wikipedia.org/wiki/Local_exchange_trading_system) (LETS) and other currency types e.g. "Ithaca HOUR") instead of including [ambiguous symbols](http://en.wikipedia.org/wiki/Dollar_sign#Currencies_that_use_the_dollar_or_peso_sign) such as '$' in the value.\\n* Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a decimal point. Avoid using these symbols as a readability separator.\\n* Note that both [RDFa](http://www.w3.org/TR/xhtml-rdfa-primer/#using-the-content-attribute) and Microdata syntax allow the use of a "content=" attribute for publishing simple machine-readable values alongside more human-friendly formatting.\\n* Use values from 0123456789 (Unicode 'DIGIT ZERO' (U+0030) to 'DIGIT NINE' (U+0039)) rather than superficially similiar Unicode symbols.
       """ ;
 .
 
-sdo:priceComponent
+schema:priceComponent
     rdfs:label "price component" ;
     rdfs:comment "This property links to all [[UnitPriceSpecification]] nodes that apply in parallel for the [[CompoundPriceSpecification]] node." ;
 .
 
-sdo:priceComponentType
+schema:priceComponentType
     rdfs:label "price componentType" ;
     rdfs:comment "Identifies a price component (for example, a line item on an invoice), part of the total price for an offer." ;
 .
 
-sdo:priceCurrency
+schema:priceCurrency
     rdfs:label "price currency" ;
     rdfs:comment "The currency of the price, or a price component when attached to [[PriceSpecification]] and its subtypes.\\n\\nUse standard formats: [ISO 4217 currency format](http://en.wikipedia.org/wiki/ISO_4217) e.g. \"USD\"; [Ticker symbol](https://en.wikipedia.org/wiki/List_of_cryptocurrencies) for cryptocurrencies e.g. \"BTC\"; well known names for [Local Exchange Tradings Systems](https://en.wikipedia.org/wiki/Local_exchange_trading_system) (LETS) and other currency types e.g. \"Ithaca HOUR\"." ;
 .
 
-sdo:priceRange
+schema:priceRange
     rdfs:label "price range" ;
     rdfs:comment "The price range of the business, for example ```$$$```." ;
 .
 
-sdo:priceSpecification
+schema:priceSpecification
     rdfs:label "price specification" ;
     rdfs:comment "One or more detailed price specifications, indicating the unit price and delivery or payment charges." ;
 .
 
-sdo:priceType
+schema:priceType
     rdfs:label "price type" ;
     rdfs:comment "Defines the type of a price specified for an offered product, for example a list price, a (temporary) sale price or a manufacturer suggested retail price. If multiple prices are specified for an offer the [[priceType]] property can be used to identify the type of each such specified price. The value of priceType can be specified as a value from enumeration PriceTypeEnumeration or as a free form text string for price types that are not already predefined in PriceTypeEnumeration." ;
 .
 
-sdo:priceValidUntil
+schema:priceValidUntil
     rdfs:label "price validUntil" ;
     rdfs:comment "The date after which the price is no longer available." ;
 .
 
-sdo:primaryImageOfPage
+schema:primaryImageOfPage
     rdfs:label "primary image Of Page" ;
     rdfs:comment "Indicates the main image on the page." ;
 .
 
-sdo:primaryPrevention
+schema:primaryPrevention
     rdfs:label "primary prevention" ;
     rdfs:comment "A preventative therapy used to prevent an initial occurrence of the medical condition, such as vaccination." ;
 .
 
-sdo:printColumn
+schema:printColumn
     rdfs:label "print column" ;
     rdfs:comment "The number of the column in which the NewsArticle appears in the print edition." ;
 .
 
-sdo:printEdition
+schema:printEdition
     rdfs:label "print edition" ;
     rdfs:comment "The edition of the print product in which the NewsArticle appears." ;
 .
 
-sdo:printPage
+schema:printPage
     rdfs:label "print page" ;
     rdfs:comment "If this NewsArticle appears in print, this field indicates the name of the page on which the article is found. Please note that this field is intended for the exact page name (e.g. A5, B18)." ;
 .
 
-sdo:printSection
+schema:printSection
     rdfs:label "print section" ;
     rdfs:comment "If this NewsArticle appears in print, this field indicates the print section in which the article appeared." ;
 .
 
-sdo:procedure
+schema:procedure
     rdfs:label "procedure" ;
     rdfs:comment "A description of the procedure involved in setting up, using, and/or installing the device." ;
 .
 
-sdo:procedureType
+schema:procedureType
     rdfs:label "procedure type" ;
     rdfs:comment "The type of procedure, for example Surgical, Noninvasive, or Percutaneous." ;
 .
 
-sdo:processingTime
+schema:processingTime
     rdfs:label "processing time" ;
     rdfs:comment "Estimated processing time for the service using this channel." ;
 .
 
-sdo:processorRequirements
+schema:processorRequirements
     rdfs:label "processor requirements" ;
     rdfs:comment "Processor architecture required to run the application (e.g. IA64)." ;
 .
 
-sdo:producer
+schema:producer
     rdfs:label "producer" ;
     rdfs:comment "The person or organization who produced the work (e.g. music album, movie, tv/radio series etc.)." ;
 .
 
-sdo:produces
+schema:produces
     rdfs:label "produces" ;
     rdfs:comment "The tangible thing generated by the service, e.g. a passport, permit, etc." ;
 .
 
-sdo:productGroupID
+schema:productGroupID
     rdfs:label "product groupID" ;
     rdfs:comment "Indicates a textual identifier for a ProductGroup." ;
 .
 
-sdo:productID
+schema:productID
     rdfs:label "product id" ;
     rdfs:comment "The product identifier, such as ISBN. For example: ``` meta itemprop=\"productID\" content=\"isbn:123-456-789\" ```." ;
 .
 
-sdo:productSupported
+schema:productSupported
     rdfs:label "product supported" ;
     rdfs:comment "The product or service this support contact point is related to (such as product support for a particular product line). This can be a specific product or product line (e.g. \"iPhone\") or a general category of products or services (e.g. \"smartphones\")." ;
 .
 
-sdo:productionCompany
+schema:productionCompany
     rdfs:label "production company" ;
     rdfs:comment "The production company or studio responsible for the item e.g. series, video game, episode etc." ;
 .
 
-sdo:productionDate
+schema:productionDate
     rdfs:label "production date" ;
     rdfs:comment "The date of production of the item, e.g. vehicle." ;
 .
 
-sdo:proficiencyLevel
+schema:proficiencyLevel
     rdfs:label "proficiency level" ;
     rdfs:comment "Proficiency needed for this content; expected values: 'Beginner', 'Expert'." ;
 .
 
-sdo:programMembershipUsed
+schema:programMembershipUsed
     rdfs:label "program membershipUsed" ;
     rdfs:comment "Any membership in a frequent flyer, hotel loyalty program, etc. being applied to the reservation." ;
 .
 
-sdo:programName
+schema:programName
     rdfs:label "program name" ;
     rdfs:comment "The program providing the membership." ;
 .
 
-sdo:programPrerequisites
+schema:programPrerequisites
     rdfs:label "program prerequisites" ;
     rdfs:comment "Prerequisites for enrolling in the program." ;
 .
 
-sdo:programType
+schema:programType
     rdfs:label "program type" ;
     rdfs:comment "The type of educational or occupational program. For example, classroom, internship, alternance, etc.." ;
 .
 
-sdo:programmingLanguage
+schema:programmingLanguage
     rdfs:label "programming language" ;
     rdfs:comment "The computer programming language." ;
 .
 
-sdo:programmingModel
+schema:programmingModel
     rdfs:label "programming model" ;
     rdfs:comment "Indicates whether API is managed or unmanaged." ;
 .
 
-sdo:propertyID
+schema:propertyID
     rdfs:label "property id" ;
     rdfs:comment """A commonly used identifier for the characteristic represented by the property, e.g. a manufacturer or a standard code for a property. propertyID can be
 (1) a prefixed string, mainly meant to be used with standards for product properties; (2) a site-specific, non-prefixed string (e.g. the primary key of the property or the vendor-specific id of the property), or (3)
@@ -14864,77 +14864,77 @@ a URL indicating the type of the property, either pointing to an external vocabu
 Standards bodies should promote a standard prefix for the identifiers of properties from their standards.""" ;
 .
 
-sdo:proprietaryName
+schema:proprietaryName
     rdfs:label "proprietary name" ;
     rdfs:comment "Proprietary name given to the diet plan, typically by its originator or creator." ;
 .
 
-sdo:proteinContent
+schema:proteinContent
     rdfs:label "protein content" ;
     rdfs:comment "The number of grams of protein." ;
 .
 
-sdo:provider
+schema:provider
     rdfs:label "provider" ;
     rdfs:comment "The service provider, service operator, or service performer; the goods producer. Another party (a seller) may offer those services or goods on behalf of the provider. A provider may also serve as the seller." ;
 .
 
-sdo:providerMobility
+schema:providerMobility
     rdfs:label "provider mobility" ;
     rdfs:comment "Indicates the mobility of a provided service (e.g. 'static', 'dynamic')." ;
 .
 
-sdo:providesBroadcastService
+schema:providesBroadcastService
     rdfs:label "provides broadcastService" ;
     rdfs:comment "The BroadcastService offered on this channel." ;
 .
 
-sdo:providesService
+schema:providesService
     rdfs:label "provides service" ;
     rdfs:comment "The service provided by this channel." ;
 .
 
-sdo:publicAccess
+schema:publicAccess
     rdfs:label "public access" ;
     rdfs:comment "A flag to signal that the [[Place]] is open to public visitors.  If this property is omitted there is no assumed default boolean value" ;
 .
 
-sdo:publicTransportClosuresInfo
+schema:publicTransportClosuresInfo
     rdfs:label "public transport Closures Info" ;
     rdfs:comment "Information about public transport closures." ;
 .
 
-sdo:publication
+schema:publication
     rdfs:label "publication" ;
     rdfs:comment "A publication event associated with the item." ;
 .
 
-sdo:publicationType
+schema:publicationType
     rdfs:label "publication type" ;
     rdfs:comment "The type of the medical article, taken from the US NLM MeSH publication type catalog. See also [MeSH documentation](http://www.nlm.nih.gov/mesh/pubtypes.html)." ;
 .
 
-sdo:publishedBy
+schema:publishedBy
     rdfs:label "published by" ;
     rdfs:comment "An agent associated with the publication event." ;
 .
 
-sdo:publishedOn
+schema:publishedOn
     rdfs:label "published on" ;
     rdfs:comment "A broadcast service associated with the publication event." ;
 .
 
-sdo:publisher
+schema:publisher
     rdfs:label "publisher" ;
     rdfs:comment "The publisher of the creative work." ;
 .
 
-sdo:publisherImprint
+schema:publisherImprint
     rdfs:label "publisher imprint" ;
     rdfs:comment "The publishing division which published the comic." ;
 .
 
-sdo:publishingPrinciples
+schema:publishingPrinciples
     rdfs:label "publishing principles" ;
     rdfs:comment """The publishingPrinciples property indicates (typically via [[URL]]) a document describing the editorial principles of an [[Organization]] (or individual e.g. a [[Person]] writing a blog) that relate to their activities as a publisher, e.g. ethics or diversity policies. When applied to a [[CreativeWork]] (e.g. [[NewsArticle]]) the principles are those of the party primarily responsible for the creation of the [[CreativeWork]].
 
@@ -14942,893 +14942,893 @@ While such policies are most typically expressed in natural language, sometimes 
 """ ;
 .
 
-sdo:purchaseDate
+schema:purchaseDate
     rdfs:label "purchase date" ;
     rdfs:comment "The date the item e.g. vehicle was purchased by the current owner." ;
 .
 
-sdo:qualifications
+schema:qualifications
     rdfs:label "qualifications" ;
     rdfs:comment "Specific qualifications required for this role or Occupation." ;
 .
 
-sdo:quarantineGuidelines
+schema:quarantineGuidelines
     rdfs:label "quarantine guidelines" ;
     rdfs:comment "Guidelines about quarantine rules, e.g. in the context of a pandemic." ;
 .
 
-sdo:query
+schema:query
     rdfs:label "query" ;
     rdfs:comment "A sub property of instrument. The query used on this action." ;
 .
 
-sdo:quest
+schema:quest
     rdfs:label "quest" ;
     rdfs:comment "The task that a player-controlled character, or group of characters may complete in order to gain a reward." ;
 .
 
-sdo:question
+schema:question
     rdfs:label "question" ;
     rdfs:comment "A sub property of object. A question." ;
 .
 
-sdo:rangeIncludes
+schema:rangeIncludes
     rdfs:label "range includes" ;
     rdfs:comment "Relates a property to a class that constitutes (one of) the expected type(s) for values of the property." ;
 .
 
-sdo:ratingCount
+schema:ratingCount
     rdfs:label "rating count" ;
     rdfs:comment "The count of total number of ratings." ;
 .
 
-sdo:ratingExplanation
+schema:ratingExplanation
     rdfs:label "rating explanation" ;
     rdfs:comment "A short explanation (e.g. one to two sentences) providing background context and other information that led to the conclusion expressed in the rating. This is particularly applicable to ratings associated with \"fact check\" markup using [[ClaimReview]]." ;
 .
 
-sdo:ratingValue
+schema:ratingValue
     rdfs:label "rating value" ;
     rdfs:comment "The rating for the content.\\n\\nUsage guidelines:\\n\\n* Use values from 0123456789 (Unicode 'DIGIT ZERO' (U+0030) to 'DIGIT NINE' (U+0039)) rather than superficially similiar Unicode symbols.\\n* Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a decimal point. Avoid using these symbols as a readability separator." ;
 .
 
-sdo:readBy
+schema:readBy
     rdfs:label "read by" ;
     rdfs:comment "A person who reads (performs) the audiobook." ;
 .
 
-sdo:readonlyValue
+schema:readonlyValue
     rdfs:label "readonly value" ;
     rdfs:comment "Whether or not a property is mutable.  Default is false. Specifying this for a property that also has a value makes it act similar to a \"hidden\" input in an HTML form." ;
 .
 
-sdo:realEstateAgent
+schema:realEstateAgent
     rdfs:label "real estateAgent" ;
     rdfs:comment "A sub property of participant. The real estate agent involved in the action." ;
 .
 
-sdo:recipe
+schema:recipe
     rdfs:label "recipe" ;
     rdfs:comment "A sub property of instrument. The recipe/instructions used to perform the action." ;
 .
 
-sdo:recipeCategory
+schema:recipeCategory
     rdfs:label "recipe category" ;
     rdfs:comment "The category of the recipe—for example, appetizer, entree, etc." ;
 .
 
-sdo:recipeCuisine
+schema:recipeCuisine
     rdfs:label "recipe cuisine" ;
     rdfs:comment "The cuisine of the recipe (for example, French or Ethiopian)." ;
 .
 
-sdo:recipeIngredient
+schema:recipeIngredient
     rdfs:label "recipe ingredient" ;
     rdfs:comment "A single ingredient used in the recipe, e.g. sugar, flour or garlic." ;
 .
 
-sdo:recipeInstructions
+schema:recipeInstructions
     rdfs:label "recipe instructions" ;
     rdfs:comment "A step in making the recipe, in the form of a single item (document, video, etc.) or an ordered list with HowToStep and/or HowToSection items." ;
 .
 
-sdo:recipeYield
+schema:recipeYield
     rdfs:label "recipe yield" ;
     rdfs:comment "The quantity produced by the recipe (for example, number of people served, number of servings, etc)." ;
 .
 
-sdo:recipient
+schema:recipient
     rdfs:label "recipient" ;
     rdfs:comment "A sub property of participant. The participant who is at the receiving end of the action." ;
 .
 
-sdo:recognizedBy
+schema:recognizedBy
     rdfs:label "recognized by" ;
     rdfs:comment "An organization that acknowledges the validity, value or utility of a credential. Note: recognition may include a process of quality assurance or accreditation." ;
 .
 
-sdo:recognizingAuthority
+schema:recognizingAuthority
     rdfs:label "recognizing authority" ;
     rdfs:comment "If applicable, the organization that officially recognizes this entity as part of its endorsed system of medicine." ;
 .
 
-sdo:recommendationStrength
+schema:recommendationStrength
     rdfs:label "recommendation strength" ;
     rdfs:comment "Strength of the guideline's recommendation (e.g. 'class I')." ;
 .
 
-sdo:recommendedIntake
+schema:recommendedIntake
     rdfs:label "recommended intake" ;
     rdfs:comment "Recommended intake of this supplement for a given population as defined by a specific recommending authority." ;
 .
 
-sdo:recordLabel
+schema:recordLabel
     rdfs:label "record label" ;
     rdfs:comment "The label that issued the release." ;
 .
 
-sdo:recordedAs
+schema:recordedAs
     rdfs:label "recorded as" ;
     rdfs:comment "An audio recording of the work." ;
 .
 
-sdo:recordedAt
+schema:recordedAt
     rdfs:label "recorded at" ;
     rdfs:comment "The Event where the CreativeWork was recorded. The CreativeWork may capture all or part of the event." ;
 .
 
-sdo:recordedIn
+schema:recordedIn
     rdfs:label "recorded in" ;
     rdfs:comment "The CreativeWork that captured all or part of this Event." ;
 .
 
-sdo:recordingOf
+schema:recordingOf
     rdfs:label "recording of" ;
     rdfs:comment "The composition this track is a recording of." ;
 .
 
-sdo:recourseLoan
+schema:recourseLoan
     rdfs:label "recourse loan" ;
     rdfs:comment "The only way you get the money back in the event of default is the security. Recourse is where you still have the opportunity to go back to the borrower for the rest of the money." ;
 .
 
-sdo:referenceQuantity
+schema:referenceQuantity
     rdfs:label "reference quantity" ;
     rdfs:comment "The reference quantity for which a certain price applies, e.g. 1 EUR per 4 kWh of electricity. This property is a replacement for unitOfMeasurement for the advanced cases where the price does not relate to a standard unit." ;
 .
 
-sdo:referencesOrder
+schema:referencesOrder
     rdfs:label "references order" ;
     rdfs:comment "The Order(s) related to this Invoice. One or more Orders may be combined into a single Invoice." ;
 .
 
-sdo:refundType
+schema:refundType
     rdfs:label "refund type" ;
     rdfs:comment "A refund type, from an enumerated list." ;
 .
 
-sdo:regionDrained
+schema:regionDrained
     rdfs:label "region drained" ;
     rdfs:comment "The anatomical or organ system drained by this vessel; generally refers to a specific part of an organ." ;
 .
 
-sdo:regionsAllowed
+schema:regionsAllowed
     rdfs:label "regions allowed" ;
     rdfs:comment "The regions where the media is allowed. If not specified, then it's assumed to be allowed everywhere. Specify the countries in [ISO 3166 format](http://en.wikipedia.org/wiki/ISO_3166)." ;
 .
 
-sdo:relatedAnatomy
+schema:relatedAnatomy
     rdfs:label "related anatomy" ;
     rdfs:comment "Anatomical systems or structures that relate to the superficial anatomy." ;
 .
 
-sdo:relatedCondition
+schema:relatedCondition
     rdfs:label "related condition" ;
     rdfs:comment "A medical condition associated with this anatomy." ;
 .
 
-sdo:relatedDrug
+schema:relatedDrug
     rdfs:label "related drug" ;
     rdfs:comment "Any other drug related to this one, for example commonly-prescribed alternatives." ;
 .
 
-sdo:relatedLink
+schema:relatedLink
     rdfs:label "related link" ;
     rdfs:comment "A link related to this web page, for example to other related web pages." ;
 .
 
-sdo:relatedStructure
+schema:relatedStructure
     rdfs:label "related structure" ;
     rdfs:comment "Related anatomical structure(s) that are not part of the system but relate or connect to it, such as vascular bundles associated with an organ system." ;
 .
 
-sdo:relatedTherapy
+schema:relatedTherapy
     rdfs:label "related therapy" ;
     rdfs:comment "A medical therapy related to this anatomy." ;
 .
 
-sdo:relatedTo
+schema:relatedTo
     rdfs:label "related to" ;
     rdfs:comment "The most generic familial relation." ;
 .
 
-sdo:releaseDate
+schema:releaseDate
     rdfs:label "release date" ;
     rdfs:comment "The release date of a product or product model. This can be used to distinguish the exact variant of a product." ;
 .
 
-sdo:releaseNotes
+schema:releaseNotes
     rdfs:label "release notes" ;
     rdfs:comment "Description of what changed in this version." ;
 .
 
-sdo:releaseOf
+schema:releaseOf
     rdfs:label "release of" ;
     rdfs:comment "The album this is a release of." ;
 .
 
-sdo:releasedEvent
+schema:releasedEvent
     rdfs:label "released event" ;
     rdfs:comment "The place and time the release was issued, expressed as a PublicationEvent." ;
 .
 
-sdo:relevantOccupation
+schema:relevantOccupation
     rdfs:label "relevant occupation" ;
     rdfs:comment "The Occupation for the JobPosting." ;
 .
 
-sdo:relevantSpecialty
+schema:relevantSpecialty
     rdfs:label "relevant specialty" ;
     rdfs:comment "If applicable, a medical specialty in which this entity is relevant." ;
 .
 
-sdo:remainingAttendeeCapacity
+schema:remainingAttendeeCapacity
     rdfs:label "remaining attendeeCapacity" ;
     rdfs:comment "The number of attendee places for an event that remain unallocated." ;
 .
 
-sdo:renegotiableLoan
+schema:renegotiableLoan
     rdfs:label "renegotiable loan" ;
     rdfs:comment "Whether the terms for payment of interest can be renegotiated during the life of the loan." ;
 .
 
-sdo:repeatCount
+schema:repeatCount
     rdfs:label "repeat count" ;
     rdfs:comment "Defines the number of times a recurring [[Event]] will take place" ;
 .
 
-sdo:repeatFrequency
+schema:repeatFrequency
     rdfs:label "repeat frequency" ;
     rdfs:comment """Defines the frequency at which [[Event]]s will occur according to a schedule [[Schedule]]. The intervals between
       events should be defined as a [[Duration]] of time.""" ;
 .
 
-sdo:repetitions
+schema:repetitions
     rdfs:label "repetitions" ;
     rdfs:comment "Number of times one should repeat the activity." ;
 .
 
-sdo:replacee
+schema:replacee
     rdfs:label "replacee" ;
     rdfs:comment "A sub property of object. The object that is being replaced." ;
 .
 
-sdo:replacer
+schema:replacer
     rdfs:label "replacer" ;
     rdfs:comment "A sub property of object. The object that replaces." ;
 .
 
-sdo:replyToUrl
+schema:replyToUrl
     rdfs:label "reply toUrl" ;
     rdfs:comment "The URL at which a reply may be posted to the specified UserComment." ;
 .
 
-sdo:reportNumber
+schema:reportNumber
     rdfs:label "report number" ;
     rdfs:comment "The number or other unique designator assigned to a Report by the publishing organization." ;
 .
 
-sdo:representativeOfPage
+schema:representativeOfPage
     rdfs:label "representative ofPage" ;
     rdfs:comment "Indicates whether this image is representative of the content of the page." ;
 .
 
-sdo:requiredCollateral
+schema:requiredCollateral
     rdfs:label "required collateral" ;
     rdfs:comment "Assets required to secure loan or credit repayments. It may take form of third party pledge, goods, financial instruments (cash, securities, etc.)" ;
 .
 
-sdo:requiredGender
+schema:requiredGender
     rdfs:label "required gender" ;
     rdfs:comment "Audiences defined by a person's gender." ;
 .
 
-sdo:requiredMaxAge
+schema:requiredMaxAge
     rdfs:label "required maxAge" ;
     rdfs:comment "Audiences defined by a person's maximum age." ;
 .
 
-sdo:requiredMinAge
+schema:requiredMinAge
     rdfs:label "required minAge" ;
     rdfs:comment "Audiences defined by a person's minimum age." ;
 .
 
-sdo:requiredQuantity
+schema:requiredQuantity
     rdfs:label "required quantity" ;
     rdfs:comment "The required quantity of the item(s)." ;
 .
 
-sdo:requirements
+schema:requirements
     rdfs:label "requirements" ;
     rdfs:comment "Component dependency requirements for application. This includes runtime environments and shared libraries that are not included in the application distribution package, but required to run the application (Examples: DirectX, Java or .NET runtime)." ;
 .
 
-sdo:requiresSubscription
+schema:requiresSubscription
     rdfs:label "requires subscription" ;
     rdfs:comment "Indicates if use of the media require a subscription  (either paid or free). Allowed values are ```true``` or ```false``` (note that an earlier version had 'yes', 'no')." ;
 .
 
-sdo:reservationFor
+schema:reservationFor
     rdfs:label "reservation for" ;
     rdfs:comment "The thing -- flight, event, restaurant,etc. being reserved." ;
 .
 
-sdo:reservationId
+schema:reservationId
     rdfs:label "reservation id" ;
     rdfs:comment "A unique identifier for the reservation." ;
 .
 
-sdo:reservationStatus
+schema:reservationStatus
     rdfs:label "reservation status" ;
     rdfs:comment "The current status of the reservation." ;
 .
 
-sdo:reservedTicket
+schema:reservedTicket
     rdfs:label "reserved ticket" ;
     rdfs:comment "A ticket associated with the reservation." ;
 .
 
-sdo:responsibilities
+schema:responsibilities
     rdfs:label "responsibilities" ;
     rdfs:comment "Responsibilities associated with this role or Occupation." ;
 .
 
-sdo:restPeriods
+schema:restPeriods
     rdfs:label "rest periods" ;
     rdfs:comment "How often one should break from the activity." ;
 .
 
-sdo:restockingFee
+schema:restockingFee
     rdfs:label "restocking fee" ;
     rdfs:comment "Use [[MonetaryAmount]] to specify a fixed restocking fee for product returns, or use [[Number]] to specify a percentage of the product price paid by the customer." ;
 .
 
-sdo:result
+schema:result
     rdfs:label "result" ;
     rdfs:comment "The result produced in the action. e.g. John wrote *a book*." ;
 .
 
-sdo:resultComment
+schema:resultComment
     rdfs:label "result comment" ;
     rdfs:comment "A sub property of result. The Comment created or sent as a result of this action." ;
 .
 
-sdo:resultReview
+schema:resultReview
     rdfs:label "result review" ;
     rdfs:comment "A sub property of result. The review that resulted in the performing of the action." ;
 .
 
-sdo:returnFees
+schema:returnFees
     rdfs:label "return fees" ;
     rdfs:comment "The type of return fees for purchased products (for any return reason)" ;
 .
 
-sdo:returnLabelSource
+schema:returnLabelSource
     rdfs:label "return labelSource" ;
     rdfs:comment "The method (from an enumeration) by which the customer obtains a return shipping label for a product returned for any reason." ;
 .
 
-sdo:returnMethod
+schema:returnMethod
     rdfs:label "return method" ;
     rdfs:comment "The type of return method offered, specified from an enumeration." ;
 .
 
-sdo:returnPolicyCategory
+schema:returnPolicyCategory
     rdfs:label "return policyCategory" ;
     rdfs:comment "Specifies an applicable return policy (from an enumeration)." ;
 .
 
-sdo:returnPolicyCountry
+schema:returnPolicyCountry
     rdfs:label "return policyCountry" ;
     rdfs:comment "The country where the product has to be sent to for returns, for example \"Ireland\" using the [[name]] property of [[Country]]. You can also provide the two-letter [ISO 3166-1 alpha-2 country code](http://en.wikipedia.org/wiki/ISO_3166-1). Note that this can be different from the country where the product was originally shipped from or sent too." ;
 .
 
-sdo:returnPolicySeasonalOverride
+schema:returnPolicySeasonalOverride
     rdfs:label "return policy Seasonal Override" ;
     rdfs:comment "Seasonal override of a return policy." ;
 .
 
-sdo:returnShippingFeesAmount
+schema:returnShippingFeesAmount
     rdfs:label "return shipping Fees Amount" ;
     rdfs:comment "Amount of shipping costs for product returns (for any reason). Applicable when property [[returnFees]] equals [[ReturnShippingFees]]." ;
 .
 
-sdo:review
+schema:review
     rdfs:label "review" ;
     rdfs:comment "A review of the item." ;
 .
 
-sdo:reviewAspect
+schema:reviewAspect
     rdfs:label "review aspect" ;
     rdfs:comment "This Review or Rating is relevant to this part or facet of the itemReviewed." ;
 .
 
-sdo:reviewBody
+schema:reviewBody
     rdfs:label "review body" ;
     rdfs:comment "The actual body of the review." ;
 .
 
-sdo:reviewCount
+schema:reviewCount
     rdfs:label "review count" ;
     rdfs:comment "The count of total number of reviews." ;
 .
 
-sdo:reviewRating
+schema:reviewRating
     rdfs:label "review rating" ;
     rdfs:comment "The rating given in this review. Note that reviews can themselves be rated. The ```reviewRating``` applies to rating given by the review. The [[aggregateRating]] property applies to the review itself, as a creative work." ;
 .
 
-sdo:reviewedBy
+schema:reviewedBy
     rdfs:label "reviewed by" ;
     rdfs:comment "People or organizations that have reviewed the content on this web page for accuracy and/or completeness." ;
 .
 
-sdo:reviews
+schema:reviews
     rdfs:label "reviews" ;
     rdfs:comment "Review of the item." ;
 .
 
-sdo:riskFactor
+schema:riskFactor
     rdfs:label "risk factor" ;
     rdfs:comment "A modifiable or non-modifiable factor that increases the risk of a patient contracting this condition, e.g. age,  coexisting condition." ;
 .
 
-sdo:risks
+schema:risks
     rdfs:label "risks" ;
     rdfs:comment "Specific physiologic risks associated to the diet plan." ;
 .
 
-sdo:roleName
+schema:roleName
     rdfs:label "role name" ;
     rdfs:comment "A role played, performed or filled by a person or organization. For example, the team of creators for a comic book might fill the roles named 'inker', 'penciller', and 'letterer'; or an athlete in a SportsTeam might play in the position named 'Quarterback'." ;
 .
 
-sdo:roofLoad
+schema:roofLoad
     rdfs:label "roof load" ;
     rdfs:comment "The permitted total weight of cargo and installations (e.g. a roof rack) on top of the vehicle.\\n\\nTypical unit code(s): KGM for kilogram, LBR for pound\\n\\n* Note 1: You can indicate additional information in the [[name]] of the [[QuantitativeValue]] node.\\n* Note 2: You may also link to a [[QualitativeValue]] node that provides additional information using [[valueReference]]\\n* Note 3: Note that you can use [[minValue]] and [[maxValue]] to indicate ranges." ;
 .
 
-sdo:rsvpResponse
+schema:rsvpResponse
     rdfs:label "rsvp response" ;
     rdfs:comment "The response (yes, no, maybe) to the RSVP." ;
 .
 
-sdo:runsTo
+schema:runsTo
     rdfs:label "runs to" ;
     rdfs:comment "The vasculature the lymphatic structure runs, or efferents, to." ;
 .
 
-sdo:runtime
+schema:runtime
     rdfs:label "runtime" ;
     rdfs:comment "Runtime platform or script interpreter dependencies (Example - Java v1, Python2.3, .Net Framework 3.0)." ;
 .
 
-sdo:runtimePlatform
+schema:runtimePlatform
     rdfs:label "runtime platform" ;
     rdfs:comment "Runtime platform or script interpreter dependencies (Example - Java v1, Python2.3, .Net Framework 3.0)." ;
 .
 
-sdo:rxcui
+schema:rxcui
     rdfs:label "rxcui" ;
     rdfs:comment "The RxCUI drug identifier from RXNORM." ;
 .
 
-sdo:safetyConsideration
+schema:safetyConsideration
     rdfs:label "safety consideration" ;
     rdfs:comment "Any potential safety concern associated with the supplement. May include interactions with other drugs and foods, pregnancy, breastfeeding, known adverse reactions, and documented efficacy of the supplement." ;
 .
 
-sdo:salaryCurrency
+schema:salaryCurrency
     rdfs:label "salary currency" ;
     rdfs:comment "The currency (coded using [ISO 4217](http://en.wikipedia.org/wiki/ISO_4217) ) used for the main salary information in this job posting or for this employee." ;
 .
 
-sdo:salaryUponCompletion
+schema:salaryUponCompletion
     rdfs:label "salary uponCompletion" ;
     rdfs:comment "The expected salary upon completing the training." ;
 .
 
-sdo:sameAs
+schema:sameAs
     rdfs:label "same as" ;
     rdfs:comment "URL of a reference Web page that unambiguously indicates the item's identity. E.g. the URL of the item's Wikipedia page, Wikidata entry, or official website." ;
 .
 
-sdo:sampleType
+schema:sampleType
     rdfs:label "sample type" ;
     rdfs:comment "What type of code sample: full (compile ready) solution, code snippet, inline code, scripts, template." ;
 .
 
-sdo:saturatedFatContent
+schema:saturatedFatContent
     rdfs:label "saturated fatContent" ;
     rdfs:comment "The number of grams of saturated fat." ;
 .
 
-sdo:scheduleTimezone
+schema:scheduleTimezone
     rdfs:label "schedule timezone" ;
     rdfs:comment "Indicates the timezone for which the time(s) indicated in the [[Schedule]] are given. The value provided should be among those listed in the IANA Time Zone Database." ;
 .
 
-sdo:scheduledPaymentDate
+schema:scheduledPaymentDate
     rdfs:label "scheduled paymentDate" ;
     rdfs:comment "The date the invoice is scheduled to be paid." ;
 .
 
-sdo:scheduledTime
+schema:scheduledTime
     rdfs:label "scheduled time" ;
     rdfs:comment "The time the object is scheduled to." ;
 .
 
-sdo:schemaVersion
+schema:schemaVersion
     rdfs:label "schema version" ;
     rdfs:comment """Indicates (by URL or string) a particular version of a schema used in some CreativeWork. This property was created primarily to
     indicate the use of a specific schema.org release, e.g. ```10.0``` as a simple string, or more explicitly via URL, ```https://schema.org/docs/releases.html#v10.0```. There may be situations in which other schemas might usefully be referenced this way, e.g. ```http://dublincore.org/specifications/dublin-core/dces/1999-07-02/``` but this has not been carefully explored in the community.""" ;
 .
 
-sdo:schoolClosuresInfo
+schema:schoolClosuresInfo
     rdfs:label "school closuresInfo" ;
     rdfs:comment "Information about school closures." ;
 .
 
-sdo:screenCount
+schema:screenCount
     rdfs:label "screen count" ;
     rdfs:comment "The number of screens in the movie theater." ;
 .
 
-sdo:screenshot
+schema:screenshot
     rdfs:label "screenshot" ;
     rdfs:comment "A link to a screenshot image of the app." ;
 .
 
-sdo:sdDatePublished
+schema:sdDatePublished
     rdfs:label "sd datePublished" ;
     rdfs:comment "Indicates the date on which the current structured data was generated / published. Typically used alongside [[sdPublisher]]" ;
 .
 
-sdo:sdLicense
+schema:sdLicense
     rdfs:label "sd license" ;
     rdfs:comment "A license document that applies to this structured data, typically indicated by URL." ;
 .
 
-sdo:sdPublisher
+schema:sdPublisher
     rdfs:label "sd publisher" ;
     rdfs:comment """Indicates the party responsible for generating and publishing the current structured data markup, typically in cases where the structured data is derived automatically from existing published content but published on a different site. For example, student projects and open data initiatives often re-publish existing content with more explicitly structured metadata. The
 [[sdPublisher]] property helps make such practices more explicit.""" ;
 .
 
-sdo:season
+schema:season
     rdfs:label "season" ;
     rdfs:comment "A season in a media series." ;
 .
 
-sdo:seasonNumber
+schema:seasonNumber
     rdfs:label "season number" ;
     rdfs:comment "Position of the season within an ordered group of seasons." ;
 .
 
-sdo:seasons
+schema:seasons
     rdfs:label "seasons" ;
     rdfs:comment "A season in a media series." ;
 .
 
-sdo:seatNumber
+schema:seatNumber
     rdfs:label "seat number" ;
     rdfs:comment "The location of the reserved seat (e.g., 27)." ;
 .
 
-sdo:seatRow
+schema:seatRow
     rdfs:label "seat row" ;
     rdfs:comment "The row location of the reserved seat (e.g., B)." ;
 .
 
-sdo:seatSection
+schema:seatSection
     rdfs:label "seat section" ;
     rdfs:comment "The section location of the reserved seat (e.g. Orchestra)." ;
 .
 
-sdo:seatingCapacity
+schema:seatingCapacity
     rdfs:label "seating capacity" ;
     rdfs:comment "The number of persons that can be seated (e.g. in a vehicle), both in terms of the physical space available, and in terms of limitations set by law.\\n\\nTypical unit code(s): C62 for persons " ;
 .
 
-sdo:seatingType
+schema:seatingType
     rdfs:label "seating type" ;
     rdfs:comment "The type/class of the seat." ;
 .
 
-sdo:secondaryPrevention
+schema:secondaryPrevention
     rdfs:label "secondary prevention" ;
     rdfs:comment "A preventative therapy used to prevent reoccurrence of the medical condition after an initial episode of the condition." ;
 .
 
-sdo:securityClearanceRequirement
+schema:securityClearanceRequirement
     rdfs:label "security clearanceRequirement" ;
     rdfs:comment "A description of any security clearance requirements of the job." ;
 .
 
-sdo:securityScreening
+schema:securityScreening
     rdfs:label "security screening" ;
     rdfs:comment "The type of security screening the passenger is subject to." ;
 .
 
-sdo:seeks
+schema:seeks
     rdfs:label "seeks" ;
     rdfs:comment "A pointer to products or services sought by the organization or person (demand)." ;
 .
 
-sdo:seller
+schema:seller
     rdfs:label "seller" ;
     rdfs:comment "An entity which offers (sells / leases / lends / loans) the services / goods.  A seller may also be a provider." ;
 .
 
-sdo:sender
+schema:sender
     rdfs:label "sender" ;
     rdfs:comment "A sub property of participant. The participant who is at the sending end of the action." ;
 .
 
-sdo:sensoryRequirement
+schema:sensoryRequirement
     rdfs:label "sensory requirement" ;
     rdfs:comment "A description of any sensory requirements and levels necessary to function on the job, including hearing and vision. Defined terms such as those in O*net may be used, but note that there is no way to specify the level of ability as well as its nature when using a defined term." ;
 .
 
-sdo:sensoryUnit
+schema:sensoryUnit
     rdfs:label "sensory unit" ;
     rdfs:comment "The neurological pathway extension that inputs and sends information to the brain or spinal cord." ;
 .
 
-sdo:serialNumber
+schema:serialNumber
     rdfs:label "serial number" ;
     rdfs:comment "The serial number or any alphanumeric identifier of a particular product. When attached to an offer, it is a shortcut for the serial number of the product included in the offer." ;
 .
 
-sdo:seriousAdverseOutcome
+schema:seriousAdverseOutcome
     rdfs:label "serious adverseOutcome" ;
     rdfs:comment "A possible serious complication and/or serious side effect of this therapy. Serious adverse outcomes include those that are life-threatening; result in death, disability, or permanent damage; require hospitalization or prolong existing hospitalization; cause congenital anomalies or birth defects; or jeopardize the patient and may require medical or surgical intervention to prevent one of the outcomes in this definition." ;
 .
 
-sdo:serverStatus
+schema:serverStatus
     rdfs:label "server status" ;
     rdfs:comment "Status of a game server." ;
 .
 
-sdo:servesCuisine
+schema:servesCuisine
     rdfs:label "serves cuisine" ;
     rdfs:comment "The cuisine of the restaurant." ;
 .
 
-sdo:serviceArea
+schema:serviceArea
     rdfs:label "service area" ;
     rdfs:comment "The geographic area where the service is provided." ;
 .
 
-sdo:serviceAudience
+schema:serviceAudience
     rdfs:label "service audience" ;
     rdfs:comment "The audience eligible for this service." ;
 .
 
-sdo:serviceLocation
+schema:serviceLocation
     rdfs:label "service location" ;
     rdfs:comment "The location (e.g. civic structure, local business, etc.) where a person can go to access the service." ;
 .
 
-sdo:serviceOperator
+schema:serviceOperator
     rdfs:label "service operator" ;
     rdfs:comment "The operating organization, if different from the provider.  This enables the representation of services that are provided by an organization, but operated by another organization like a subcontractor." ;
 .
 
-sdo:serviceOutput
+schema:serviceOutput
     rdfs:label "service output" ;
     rdfs:comment "The tangible thing generated by the service, e.g. a passport, permit, etc." ;
 .
 
-sdo:servicePhone
+schema:servicePhone
     rdfs:label "service phone" ;
     rdfs:comment "The phone number to use to access the service." ;
 .
 
-sdo:servicePostalAddress
+schema:servicePostalAddress
     rdfs:label "service postalAddress" ;
     rdfs:comment "The address for accessing the service by mail." ;
 .
 
-sdo:serviceSmsNumber
+schema:serviceSmsNumber
     rdfs:label "service smsNumber" ;
     rdfs:comment "The number to access the service by text message." ;
 .
 
-sdo:serviceType
+schema:serviceType
     rdfs:label "service type" ;
     rdfs:comment "The type of service being offered, e.g. veterans' benefits, emergency relief, etc." ;
 .
 
-sdo:serviceUrl
+schema:serviceUrl
     rdfs:label "service url" ;
     rdfs:comment "The website to access the service." ;
 .
 
-sdo:servingSize
+schema:servingSize
     rdfs:label "serving size" ;
     rdfs:comment "The serving size, in terms of the number of volume or mass." ;
 .
 
-sdo:sha256
+schema:sha256
     rdfs:label "sha256" ;
     rdfs:comment "The [SHA-2](https://en.wikipedia.org/wiki/SHA-2) SHA256 hash of the content of the item. For example, a zero-length input has value 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'" ;
 .
 
-sdo:sharedContent
+schema:sharedContent
     rdfs:label "shared content" ;
     rdfs:comment "A CreativeWork such as an image, video, or audio clip shared as part of this posting." ;
 .
 
-sdo:shippingDestination
+schema:shippingDestination
     rdfs:label "shipping destination" ;
     rdfs:comment "indicates (possibly multiple) shipping destinations. These can be defined in several ways e.g. postalCode ranges." ;
 .
 
-sdo:shippingDetails
+schema:shippingDetails
     rdfs:label "shipping details" ;
     rdfs:comment "Indicates information about the shipping policies and options associated with an [[Offer]]." ;
 .
 
-sdo:shippingLabel
+schema:shippingLabel
     rdfs:label "shipping label" ;
     rdfs:comment "Label to match an [[OfferShippingDetails]] with a [[ShippingRateSettings]] (within the context of a [[shippingSettingsLink]] cross-reference)." ;
 .
 
-sdo:shippingRate
+schema:shippingRate
     rdfs:label "shipping rate" ;
     rdfs:comment "The shipping rate is the cost of shipping to the specified destination. Typically, the maxValue and currency values (of the [[MonetaryAmount]]) are most appropriate." ;
 .
 
-sdo:shippingSettingsLink
+schema:shippingSettingsLink
     rdfs:label "shipping settingsLink" ;
     rdfs:comment "Link to a page containing [[ShippingRateSettings]] and [[DeliveryTimeSettings]] details." ;
 .
 
-sdo:sibling
+schema:sibling
     rdfs:label "sibling" ;
     rdfs:comment "A sibling of the person." ;
 .
 
-sdo:siblings
+schema:siblings
     rdfs:label "siblings" ;
     rdfs:comment "A sibling of the person." ;
 .
 
-sdo:signDetected
+schema:signDetected
     rdfs:label "sign detected" ;
     rdfs:comment "A sign detected by the test." ;
 .
 
-sdo:signOrSymptom
+schema:signOrSymptom
     rdfs:label "sign orSymptom" ;
     rdfs:comment "A sign or symptom of this condition. Signs are objective or physically observable manifestations of the medical condition while symptoms are the subjective experience of the medical condition." ;
 .
 
-sdo:significance
+schema:significance
     rdfs:label "significance" ;
     rdfs:comment "The significance associated with the superficial anatomy; as an example, how characteristics of the superficial anatomy can suggest underlying medical conditions or courses of treatment." ;
 .
 
-sdo:significantLink
+schema:significantLink
     rdfs:label "significant link" ;
     rdfs:comment "One of the more significant URLs on the page. Typically, these are the non-navigation links that are clicked on the most." ;
 .
 
-sdo:significantLinks
+schema:significantLinks
     rdfs:label "significant links" ;
     rdfs:comment "The most significant URLs on the page. Typically, these are the non-navigation links that are clicked on the most." ;
 .
 
-sdo:size
+schema:size
     rdfs:label "size" ;
     rdfs:comment "A standardized size of a product or creative work, specified either through a simple textual string (for example 'XL', '32Wx34L'), a  QuantitativeValue with a unitCode, or a comprehensive and structured [[SizeSpecification]]; in other cases, the [[width]], [[height]], [[depth]] and [[weight]] properties may be more applicable. " ;
 .
 
-sdo:sizeGroup
+schema:sizeGroup
     rdfs:label "size group" ;
     rdfs:comment "The size group (also known as \"size type\") for a product's size. Size groups are common in the fashion industry to define size segments and suggested audiences for wearable products. Multiple values can be combined, for example \"men's big and tall\", \"petite maternity\" or \"regular\"" ;
 .
 
-sdo:sizeSystem
+schema:sizeSystem
     rdfs:label "size system" ;
     rdfs:comment "The size system used to identify a product's size. Typically either a standard (for example, \"GS1\" or \"ISO-EN13402\"), country code (for example \"US\" or \"JP\"), or a measuring system (for example \"Metric\" or \"Imperial\")." ;
 .
 
-sdo:skills
+schema:skills
     rdfs:label "skills" ;
     rdfs:comment "A statement of knowledge, skill, ability, task or any other assertion expressing a competency that is desired or required to fulfill this role or to work in this occupation." ;
 .
 
-sdo:sku
+schema:sku
     rdfs:label "sku" ;
     rdfs:comment "The Stock Keeping Unit (SKU), i.e. a merchant-specific identifier for a product or service, or the product to which the offer refers." ;
 .
 
-sdo:slogan
+schema:slogan
     rdfs:label "slogan" ;
     rdfs:comment "A slogan or motto associated with the item." ;
 .
 
-sdo:smiles
+schema:smiles
     rdfs:label "smiles" ;
     rdfs:comment "A specification in form of a line notation for describing the structure of chemical species using short ASCII strings.  Double bond stereochemistry \\ indicators may need to be escaped in the string in formats where the backslash is an escape character." ;
 .
 
-sdo:smokingAllowed
+schema:smokingAllowed
     rdfs:label "smoking allowed" ;
     rdfs:comment "Indicates whether it is allowed to smoke in the place, e.g. in the restaurant, hotel or hotel room." ;
 .
 
-sdo:sodiumContent
+schema:sodiumContent
     rdfs:label "sodium content" ;
     rdfs:comment "The number of milligrams of sodium." ;
 .
 
-sdo:softwareAddOn
+schema:softwareAddOn
     rdfs:label "software addOn" ;
     rdfs:comment "Additional content for a software application." ;
 .
 
-sdo:softwareHelp
+schema:softwareHelp
     rdfs:label "software help" ;
     rdfs:comment "Software application help." ;
 .
 
-sdo:softwareRequirements
+schema:softwareRequirements
     rdfs:label "software requirements" ;
     rdfs:comment "Component dependency requirements for application. This includes runtime environments and shared libraries that are not included in the application distribution package, but required to run the application (Examples: DirectX, Java or .NET runtime)." ;
 .
 
-sdo:softwareVersion
+schema:softwareVersion
     rdfs:label "software version" ;
     rdfs:comment "Version of the software instance." ;
 .
 
-sdo:sourceOrganization
+schema:sourceOrganization
     rdfs:label "source organization" ;
     rdfs:comment "The Organization on whose behalf the creator was working." ;
 .
 
-sdo:sourcedFrom
+schema:sourcedFrom
     rdfs:label "sourced from" ;
     rdfs:comment "The neurological pathway that originates the neurons." ;
 .
 
-sdo:spatial
+schema:spatial
     rdfs:label "spatial" ;
     rdfs:comment """The "spatial" property can be used in cases when more specific properties
 (e.g. [[locationCreated]], [[spatialCoverage]], [[contentLocation]]) are not known to be appropriate.""" ;
 .
 
-sdo:spatialCoverage
+schema:spatialCoverage
     rdfs:label "spatial coverage" ;
     rdfs:comment """The spatialCoverage of a CreativeWork indicates the place(s) which are the focus of the content. It is a subproperty of
       contentLocation intended primarily for more technical and detailed materials. For example with a Dataset, it indicates
       areas that the dataset describes: a dataset of New York weather would have spatialCoverage which was the place: the state of New York.""" ;
 .
 
-sdo:speakable
+schema:speakable
     rdfs:label "speakable" ;
     rdfs:comment """Indicates sections of a Web page that are particularly 'speakable' in the sense of being highlighted as being especially appropriate for text-to-speech conversion. Other sections of a page may also be usefully spoken in particular circumstances; the 'speakable' property serves to indicate the parts most likely to be generally useful for speech.
 
@@ -15846,364 +15846,364 @@ we define a supporting type, [[SpeakableSpecification]]  which is defined to be 
          """ ;
 .
 
-sdo:specialCommitments
+schema:specialCommitments
     rdfs:label "special commitments" ;
     rdfs:comment "Any special commitments associated with this job posting. Valid entries include VeteranCommit, MilitarySpouseCommit, etc." ;
 .
 
-sdo:specialOpeningHoursSpecification
+schema:specialOpeningHoursSpecification
     rdfs:label "special opening Hours Specification" ;
     rdfs:comment """The special opening hours of a certain place.\\n\\nUse this to explicitly override general opening hours brought in scope by [[openingHoursSpecification]] or [[openingHours]].
       """ ;
 .
 
-sdo:specialty
+schema:specialty
     rdfs:label "specialty" ;
     rdfs:comment "One of the domain specialities to which this web page's content applies." ;
 .
 
-sdo:speechToTextMarkup
+schema:speechToTextMarkup
     rdfs:label "speech to Text Markup" ;
     rdfs:comment "Form of markup used. eg. [SSML](https://www.w3.org/TR/speech-synthesis11) or [IPA](https://www.wikidata.org/wiki/Property:P898)." ;
 .
 
-sdo:speed
+schema:speed
     rdfs:label "speed" ;
     rdfs:comment "The speed range of the vehicle. If the vehicle is powered by an engine, the upper limit of the speed range (indicated by [[maxValue]] should be the maximum speed achievable under regular conditions.\\n\\nTypical unit code(s): KMH for km/h, HM for mile per hour (0.447 04 m/s), KNT for knot\\n\\n*Note 1: Use [[minValue]] and [[maxValue]] to indicate the range. Typically, the minimal value is zero.\\n* Note 2: There are many different ways of measuring the speed range. You can link to information about how the given value has been determined using the [[valueReference]] property." ;
 .
 
-sdo:spokenByCharacter
+schema:spokenByCharacter
     rdfs:label "spoken byCharacter" ;
     rdfs:comment "The (e.g. fictional) character, Person or Organization to whom the quotation is attributed within the containing CreativeWork." ;
 .
 
-sdo:sponsor
+schema:sponsor
     rdfs:label "sponsor" ;
     rdfs:comment "A person or organization that supports a thing through a pledge, promise, or financial contribution. e.g. a sponsor of a Medical Study or a corporate sponsor of an event." ;
 .
 
-sdo:sport
+schema:sport
     rdfs:label "sport" ;
     rdfs:comment "A type of sport (e.g. Baseball)." ;
 .
 
-sdo:sportsActivityLocation
+schema:sportsActivityLocation
     rdfs:label "sports activityLocation" ;
     rdfs:comment "A sub property of location. The sports activity location where this action occurred." ;
 .
 
-sdo:sportsEvent
+schema:sportsEvent
     rdfs:label "sports event" ;
     rdfs:comment "A sub property of location. The sports event where this action occurred." ;
 .
 
-sdo:sportsTeam
+schema:sportsTeam
     rdfs:label "sports team" ;
     rdfs:comment "A sub property of participant. The sports team that participated on this action." ;
 .
 
-sdo:spouse
+schema:spouse
     rdfs:label "spouse" ;
     rdfs:comment "The person's spouse." ;
 .
 
-sdo:stage
+schema:stage
     rdfs:label "stage" ;
     rdfs:comment "The stage of the condition, if applicable." ;
 .
 
-sdo:stageAsNumber
+schema:stageAsNumber
     rdfs:label "stage asNumber" ;
     rdfs:comment "The stage represented as a number, e.g. 3." ;
 .
 
-sdo:starRating
+schema:starRating
     rdfs:label "star rating" ;
     rdfs:comment "An official rating for a lodging business or food establishment, e.g. from national associations or standards bodies. Use the author property to indicate the rating organization, e.g. as an Organization with name such as (e.g. HOTREC, DEHOGA, WHR, or Hotelstars)." ;
 .
 
-sdo:startDate
+schema:startDate
     rdfs:label "start date" ;
     rdfs:comment "The start date and time of the item (in [ISO 8601 date format](http://en.wikipedia.org/wiki/ISO_8601))." ;
 .
 
-sdo:startOffset
+schema:startOffset
     rdfs:label "start offset" ;
     rdfs:comment "The start time of the clip expressed as the number of seconds from the beginning of the work." ;
 .
 
-sdo:startTime
+schema:startTime
     rdfs:label "start time" ;
     rdfs:comment "The startTime of something. For a reserved event or service (e.g. FoodEstablishmentReservation), the time that it is expected to start. For actions that span a period of time, when the action was performed. e.g. John wrote a book from *January* to December. For media, including audio and video, it's the time offset of the start of a clip within a larger file.\\n\\nNote that Event uses startDate/endDate instead of startTime/endTime, even when describing dates with times. This situation may be clarified in future revisions." ;
 .
 
-sdo:status
+schema:status
     rdfs:label "status" ;
     rdfs:comment "The status of the study (enumerated)." ;
 .
 
-sdo:steeringPosition
+schema:steeringPosition
     rdfs:label "steering position" ;
     rdfs:comment "The position of the steering wheel or similar device (mostly for cars)." ;
 .
 
-sdo:step
+schema:step
     rdfs:label "step" ;
     rdfs:comment "A single step item (as HowToStep, text, document, video, etc.) or a HowToSection." ;
 .
 
-sdo:stepValue
+schema:stepValue
     rdfs:label "step value" ;
     rdfs:comment "The stepValue attribute indicates the granularity that is expected (and required) of the value in a PropertyValueSpecification." ;
 .
 
-sdo:steps
+schema:steps
     rdfs:label "steps" ;
     rdfs:comment "A single step item (as HowToStep, text, document, video, etc.) or a HowToSection (originally misnamed 'steps'; 'step' is preferred)." ;
 .
 
-sdo:storageRequirements
+schema:storageRequirements
     rdfs:label "storage requirements" ;
     rdfs:comment "Storage requirements (free space required)." ;
 .
 
-sdo:streetAddress
+schema:streetAddress
     rdfs:label "street address" ;
     rdfs:comment "The street address. For example, 1600 Amphitheatre Pkwy." ;
 .
 
-sdo:strengthUnit
+schema:strengthUnit
     rdfs:label "strength unit" ;
     rdfs:comment "The units of an active ingredient's strength, e.g. mg." ;
 .
 
-sdo:strengthValue
+schema:strengthValue
     rdfs:label "strength value" ;
     rdfs:comment "The value of an active ingredient's strength, e.g. 325." ;
 .
 
-sdo:structuralClass
+schema:structuralClass
     rdfs:label "structural class" ;
     rdfs:comment "The name given to how bone physically connects to each other." ;
 .
 
-sdo:study
+schema:study
     rdfs:label "study" ;
     rdfs:comment "A medical study or trial related to this entity." ;
 .
 
-sdo:studyDesign
+schema:studyDesign
     rdfs:label "study design" ;
     rdfs:comment "Specifics about the observational study design (enumerated)." ;
 .
 
-sdo:studyLocation
+schema:studyLocation
     rdfs:label "study location" ;
     rdfs:comment "The location in which the study is taking/took place." ;
 .
 
-sdo:studySubject
+schema:studySubject
     rdfs:label "study subject" ;
     rdfs:comment "A subject of the study, i.e. one of the medical conditions, therapies, devices, drugs, etc. investigated by the study." ;
 .
 
-sdo:subEvent
+schema:subEvent
     rdfs:label "sub event" ;
     rdfs:comment "An Event that is part of this event. For example, a conference event includes many presentations, each of which is a subEvent of the conference." ;
 .
 
-sdo:subEvents
+schema:subEvents
     rdfs:label "sub events" ;
     rdfs:comment "Events that are a part of this event. For example, a conference event includes many presentations, each subEvents of the conference." ;
 .
 
-sdo:subOrganization
+schema:subOrganization
     rdfs:label "sub organization" ;
     rdfs:comment "A relationship between two organizations where the first includes the second, e.g., as a subsidiary. See also: the more specific 'department' property." ;
 .
 
-sdo:subReservation
+schema:subReservation
     rdfs:label "sub reservation" ;
     rdfs:comment "The individual reservations included in the package. Typically a repeated property." ;
 .
 
-sdo:subStageSuffix
+schema:subStageSuffix
     rdfs:label "sub stageSuffix" ;
     rdfs:comment "The substage, e.g. 'a' for Stage IIIa." ;
 .
 
-sdo:subStructure
+schema:subStructure
     rdfs:label "sub structure" ;
     rdfs:comment "Component (sub-)structure(s) that comprise this anatomical structure." ;
 .
 
-sdo:subTest
+schema:subTest
     rdfs:label "sub test" ;
     rdfs:comment "A component test of the panel." ;
 .
 
-sdo:subTrip
+schema:subTrip
     rdfs:label "sub trip" ;
     rdfs:comment "Identifies a [[Trip]] that is a subTrip of this Trip.  For example Day 1, Day 2, etc. of a multi-day trip." ;
 .
 
-sdo:subjectOf
+schema:subjectOf
     rdfs:label "subject of" ;
     rdfs:comment "A CreativeWork or Event about this Thing." ;
 .
 
-sdo:subtitleLanguage
+schema:subtitleLanguage
     rdfs:label "subtitle language" ;
     rdfs:comment "Languages in which subtitles/captions are available, in [IETF BCP 47 standard format](http://tools.ietf.org/html/bcp47)." ;
 .
 
-sdo:successorOf
+schema:successorOf
     rdfs:label "successor of" ;
     rdfs:comment "A pointer from a newer variant of a product  to its previous, often discontinued predecessor." ;
 .
 
-sdo:sugarContent
+schema:sugarContent
     rdfs:label "sugar content" ;
     rdfs:comment "The number of grams of sugar." ;
 .
 
-sdo:suggestedAge
+schema:suggestedAge
     rdfs:label "suggested age" ;
     rdfs:comment "The age or age range for the intended audience or person, for example 3-12 months for infants, 1-5 years for toddlers." ;
 .
 
-sdo:suggestedAnswer
+schema:suggestedAnswer
     rdfs:label "suggested answer" ;
     rdfs:comment "An answer (possibly one of several, possibly incorrect) to a Question, e.g. on a Question/Answer site." ;
 .
 
-sdo:suggestedGender
+schema:suggestedGender
     rdfs:label "suggested gender" ;
     rdfs:comment "The suggested gender of the intended person or audience, for example \"male\", \"female\", or \"unisex\"." ;
 .
 
-sdo:suggestedMaxAge
+schema:suggestedMaxAge
     rdfs:label "suggested maxAge" ;
     rdfs:comment "Maximum recommended age in years for the audience or user." ;
 .
 
-sdo:suggestedMeasurement
+schema:suggestedMeasurement
     rdfs:label "suggested measurement" ;
     rdfs:comment "A suggested range of body measurements for the intended audience or person, for example inseam between 32 and 34 inches or height between 170 and 190 cm. Typically found on a size chart for wearable products." ;
 .
 
-sdo:suggestedMinAge
+schema:suggestedMinAge
     rdfs:label "suggested minAge" ;
     rdfs:comment "Minimum recommended age in years for the audience or user." ;
 .
 
-sdo:suitableForDiet
+schema:suitableForDiet
     rdfs:label "suitable forDiet" ;
     rdfs:comment "Indicates a dietary restriction or guideline for which this recipe or menu item is suitable, e.g. diabetic, halal etc." ;
 .
 
-sdo:superEvent
+schema:superEvent
     rdfs:label "super event" ;
     rdfs:comment "An event that this event is a part of. For example, a collection of individual music performances might each have a music festival as their superEvent." ;
 .
 
-sdo:supersededBy
+schema:supersededBy
     rdfs:label "superseded by" ;
     rdfs:comment "Relates a term (i.e. a property, class or enumeration) to one that supersedes it." ;
 .
 
-sdo:supply
+schema:supply
     rdfs:label "supply" ;
     rdfs:comment "A sub-property of instrument. A supply consumed when performing instructions or a direction." ;
 .
 
-sdo:supplyTo
+schema:supplyTo
     rdfs:label "supply to" ;
     rdfs:comment "The area to which the artery supplies blood." ;
 .
 
-sdo:supportingData
+schema:supportingData
     rdfs:label "supporting data" ;
     rdfs:comment "Supporting data for a SoftwareApplication." ;
 .
 
-sdo:surface
+schema:surface
     rdfs:label "surface" ;
     rdfs:comment "A material used as a surface in some artwork, e.g. Canvas, Paper, Wood, Board, etc." ;
 .
 
-sdo:target
+schema:target
     rdfs:label "target" ;
     rdfs:comment "Indicates a target EntryPoint for an Action." ;
 .
 
-sdo:targetCollection
+schema:targetCollection
     rdfs:label "target collection" ;
     rdfs:comment "A sub property of object. The collection target of the action." ;
 .
 
-sdo:targetDescription
+schema:targetDescription
     rdfs:label "target description" ;
     rdfs:comment "The description of a node in an established educational framework." ;
 .
 
-sdo:targetName
+schema:targetName
     rdfs:label "target name" ;
     rdfs:comment "The name of a node in an established educational framework." ;
 .
 
-sdo:targetPlatform
+schema:targetPlatform
     rdfs:label "target platform" ;
     rdfs:comment "Type of app development: phone, Metro style, desktop, XBox, etc." ;
 .
 
-sdo:targetPopulation
+schema:targetPopulation
     rdfs:label "target population" ;
     rdfs:comment "Characteristics of the population for which this is intended, or which typically uses it, e.g. 'adults'." ;
 .
 
-sdo:targetProduct
+schema:targetProduct
     rdfs:label "target product" ;
     rdfs:comment "Target Operating System / Product to which the code applies.  If applies to several versions, just the product name can be used." ;
 .
 
-sdo:targetUrl
+schema:targetUrl
     rdfs:label "target url" ;
     rdfs:comment "The URL of a node in an established educational framework." ;
 .
 
-sdo:taxID
+schema:taxID
     rdfs:label "tax id" ;
     rdfs:comment "The Tax / Fiscal ID of the organization or person, e.g. the TIN in the US or the CIF/NIF in Spain." ;
 .
 
-sdo:taxonRank
+schema:taxonRank
     rdfs:label "taxon rank" ;
     rdfs:comment "The taxonomic rank of this taxon given preferably as a URI from a controlled vocabulary – (typically the ranks from TDWG TaxonRank ontology or equivalent Wikidata URIs)." ;
 .
 
-sdo:taxonomicRange
+schema:taxonomicRange
     rdfs:label "taxonomic range" ;
     rdfs:comment "The taxonomic grouping of the organism that expresses, encodes, or in someway related to the BioChemEntity." ;
 .
 
-sdo:teaches
+schema:teaches
     rdfs:label "teaches" ;
     rdfs:comment "The item being described is intended to help a person learn the competency or learning outcome defined by the referenced term." ;
 .
 
-sdo:telephone
+schema:telephone
     rdfs:label "telephone" ;
     rdfs:comment "The telephone number." ;
 .
 
-sdo:temporal
+schema:temporal
     rdfs:label "temporal" ;
     rdfs:comment """The "temporal" property can be used in cases where more specific properties
 (e.g. [[temporalCoverage]], [[dateCreated]], [[dateModified]], [[datePublished]]) are not known to be appropriate.""" ;
 .
 
-sdo:temporalCoverage
+schema:temporalCoverage
     rdfs:label "temporal coverage" ;
     rdfs:comment """The temporalCoverage of a CreativeWork indicates the period that the content applies to, i.e. that it describes, either as a DateTime or as a textual string indicating a time period in [ISO 8601 time interval format](https://en.wikipedia.org/wiki/ISO_8601#Time_intervals). In
       the case of a Dataset it will typically indicate the relevant time period in a precise notation (e.g. for a 2011 census dataset, the year 2011 would be written "2011/2012"). Other forms of content e.g. ScholarlyArticle, Book, TVSeries or TVEpisode may indicate their temporalCoverage in broader terms - textually or via well-known URL.
@@ -16212,92 +16212,92 @@ sdo:temporalCoverage
 Open-ended date ranges can be written with ".." in place of the end date. For example, "2015-11/.." indicates a range beginning in November 2015 and with no specified final date. This is tentative and might be updated in future when ISO 8601 is officially updated.""" ;
 .
 
-sdo:termCode
+schema:termCode
     rdfs:label "term code" ;
     rdfs:comment "A code that identifies this [[DefinedTerm]] within a [[DefinedTermSet]]" ;
 .
 
-sdo:termDuration
+schema:termDuration
     rdfs:label "term duration" ;
     rdfs:comment "The amount of time in a term as defined by the institution. A term is a length of time where students take one or more classes. Semesters and quarters are common units for term." ;
 .
 
-sdo:termsOfService
+schema:termsOfService
     rdfs:label "terms ofService" ;
     rdfs:comment "Human-readable terms of service documentation." ;
 .
 
-sdo:termsPerYear
+schema:termsPerYear
     rdfs:label "terms perYear" ;
     rdfs:comment "The number of times terms of study are offered per year. Semesters and quarters are common units for term. For example, if the student can only take 2 semesters for the program in one year, then termsPerYear should be 2." ;
 .
 
-sdo:text
+schema:text
     rdfs:label "text" ;
     rdfs:comment "The textual content of this CreativeWork." ;
 .
 
-sdo:textValue
+schema:textValue
     rdfs:label "text value" ;
     rdfs:comment "Text value being annotated." ;
 .
 
-sdo:thumbnail
+schema:thumbnail
     rdfs:label "thumbnail" ;
     rdfs:comment "Thumbnail image for an image or video." ;
 .
 
-sdo:thumbnailUrl
+schema:thumbnailUrl
     rdfs:label "thumbnail url" ;
     rdfs:comment "A thumbnail image relevant to the Thing." ;
 .
 
-sdo:tickerSymbol
+schema:tickerSymbol
     rdfs:label "ticker symbol" ;
     rdfs:comment "The exchange traded instrument associated with a Corporation object. The tickerSymbol is expressed as an exchange and an instrument name separated by a space character. For the exchange component of the tickerSymbol attribute, we recommend using the controlled vocabulary of Market Identifier Codes (MIC) specified in ISO15022." ;
 .
 
-sdo:ticketNumber
+schema:ticketNumber
     rdfs:label "ticket number" ;
     rdfs:comment "The unique identifier for the ticket." ;
 .
 
-sdo:ticketToken
+schema:ticketToken
     rdfs:label "ticket token" ;
     rdfs:comment "Reference to an asset (e.g., Barcode, QR code image or PDF) usable for entrance." ;
 .
 
-sdo:ticketedSeat
+schema:ticketedSeat
     rdfs:label "ticketed seat" ;
     rdfs:comment "The seat associated with the ticket." ;
 .
 
-sdo:timeOfDay
+schema:timeOfDay
     rdfs:label "time ofDay" ;
     rdfs:comment "The time of day the program normally runs. For example, \"evenings\"." ;
 .
 
-sdo:timeRequired
+schema:timeRequired
     rdfs:label "time required" ;
     rdfs:comment "Approximate or typical time it takes to work with or through this learning resource for the typical intended target audience, e.g. 'PT30M', 'PT1H25M'." ;
 .
 
-sdo:timeToComplete
+schema:timeToComplete
     rdfs:label "time toComplete" ;
     rdfs:comment "The expected length of time to complete the program if attending full-time." ;
 .
 
-sdo:tissueSample
+schema:tissueSample
     rdfs:label "tissue sample" ;
     rdfs:comment "The type of tissue sample required for the test." ;
 .
 
-sdo:title
+schema:title
     rdfs:label "title" ;
     rdfs:comment "The title of the job." ;
 .
 
-sdo:titleEIDR
+schema:titleEIDR
     rdfs:label "title eidr" ;
     rdfs:comment """An [EIDR](https://eidr.org/) (Entertainment Identifier Registry) [[identifier]] representing at the most general/abstract level, a work of film or television.
 
@@ -16307,573 +16307,573 @@ Since schema.org types like [[Movie]] and [[TVEpisode]] can be used for both wor
 """ ;
 .
 
-sdo:toLocation
+schema:toLocation
     rdfs:label "to location" ;
     rdfs:comment "A sub property of location. The final location of the object or the agent after the action." ;
 .
 
-sdo:toRecipient
+schema:toRecipient
     rdfs:label "to recipient" ;
     rdfs:comment "A sub property of recipient. The recipient who was directly sent the message." ;
 .
 
-sdo:tocContinuation
+schema:tocContinuation
     rdfs:label "toc continuation" ;
     rdfs:comment "A [[HyperTocEntry]] can have a [[tocContinuation]] indicated, which is another [[HyperTocEntry]] that would be the default next item to play or render." ;
 .
 
-sdo:tocEntry
+schema:tocEntry
     rdfs:label "toc entry" ;
     rdfs:comment "Indicates a [[HyperTocEntry]] in a [[HyperToc]]." ;
 .
 
-sdo:tongueWeight
+schema:tongueWeight
     rdfs:label "tongue weight" ;
     rdfs:comment "The permitted vertical load (TWR) of a trailer attached to the vehicle. Also referred to as Tongue Load Rating (TLR) or Vertical Load Rating (VLR)\\n\\nTypical unit code(s): KGM for kilogram, LBR for pound\\n\\n* Note 1: You can indicate additional information in the [[name]] of the [[QuantitativeValue]] node.\\n* Note 2: You may also link to a [[QualitativeValue]] node that provides additional information using [[valueReference]].\\n* Note 3: Note that you can use [[minValue]] and [[maxValue]] to indicate ranges." ;
 .
 
-sdo:tool
+schema:tool
     rdfs:label "tool" ;
     rdfs:comment "A sub property of instrument. An object used (but not consumed) when performing instructions or a direction." ;
 .
 
-sdo:torque
+schema:torque
     rdfs:label "torque" ;
     rdfs:comment "The torque (turning force) of the vehicle's engine.\\n\\nTypical unit code(s): NU for newton metre (N m), F17 for pound-force per foot, or F48 for pound-force per inch\\n\\n* Note 1: You can link to information about how the given value has been determined (e.g. reference RPM) using the [[valueReference]] property.\\n* Note 2: You can use [[minValue]] and [[maxValue]] to indicate ranges." ;
 .
 
-sdo:totalJobOpenings
+schema:totalJobOpenings
     rdfs:label "total jobOpenings" ;
     rdfs:comment "The number of positions open for this job posting. Use a positive integer. Do not use if the number of positions is unclear or not known." ;
 .
 
-sdo:totalPaymentDue
+schema:totalPaymentDue
     rdfs:label "total paymentDue" ;
     rdfs:comment "The total amount due." ;
 .
 
-sdo:totalPrice
+schema:totalPrice
     rdfs:label "total price" ;
     rdfs:comment "The total price for the reservation or ticket, including applicable taxes, shipping, etc.\\n\\nUsage guidelines:\\n\\n* Use values from 0123456789 (Unicode 'DIGIT ZERO' (U+0030) to 'DIGIT NINE' (U+0039)) rather than superficially similiar Unicode symbols.\\n* Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a decimal point. Avoid using these symbols as a readability separator." ;
 .
 
-sdo:totalTime
+schema:totalTime
     rdfs:label "total time" ;
     rdfs:comment "The total time required to perform instructions or a direction (including time to prepare the supplies), in [ISO 8601 duration format](http://en.wikipedia.org/wiki/ISO_8601)." ;
 .
 
-sdo:tourBookingPage
+schema:tourBookingPage
     rdfs:label "tour bookingPage" ;
     rdfs:comment "A page providing information on how to book a tour of some [[Place]], such as an [[Accommodation]] or [[ApartmentComplex]] in a real estate setting, as well as other kinds of tours as appropriate." ;
 .
 
-sdo:touristType
+schema:touristType
     rdfs:label "tourist type" ;
     rdfs:comment "Attraction suitable for type(s) of tourist. eg. Children, visitors from a particular country, etc. " ;
 .
 
-sdo:track
+schema:track
     rdfs:label "track" ;
     rdfs:comment "A music recording (track)—usually a single song. If an ItemList is given, the list should contain items of type MusicRecording." ;
 .
 
-sdo:trackingNumber
+schema:trackingNumber
     rdfs:label "tracking number" ;
     rdfs:comment "Shipper tracking number." ;
 .
 
-sdo:trackingUrl
+schema:trackingUrl
     rdfs:label "tracking url" ;
     rdfs:comment "Tracking url for the parcel delivery." ;
 .
 
-sdo:tracks
+schema:tracks
     rdfs:label "tracks" ;
     rdfs:comment "A music recording (track)—usually a single song." ;
 .
 
-sdo:trailer
+schema:trailer
     rdfs:label "trailer" ;
     rdfs:comment "The trailer of a movie or tv/radio series, season, episode, etc." ;
 .
 
-sdo:trailerWeight
+schema:trailerWeight
     rdfs:label "trailer weight" ;
     rdfs:comment "The permitted weight of a trailer attached to the vehicle.\\n\\nTypical unit code(s): KGM for kilogram, LBR for pound\\n* Note 1: You can indicate additional information in the [[name]] of the [[QuantitativeValue]] node.\\n* Note 2: You may also link to a [[QualitativeValue]] node that provides additional information using [[valueReference]].\\n* Note 3: Note that you can use [[minValue]] and [[maxValue]] to indicate ranges." ;
 .
 
-sdo:trainName
+schema:trainName
     rdfs:label "train name" ;
     rdfs:comment "The name of the train (e.g. The Orient Express)." ;
 .
 
-sdo:trainNumber
+schema:trainNumber
     rdfs:label "train number" ;
     rdfs:comment "The unique identifier for the train." ;
 .
 
-sdo:trainingSalary
+schema:trainingSalary
     rdfs:label "training salary" ;
     rdfs:comment "The estimated salary earned while in the program." ;
 .
 
-sdo:transFatContent
+schema:transFatContent
     rdfs:label "trans fatContent" ;
     rdfs:comment "The number of grams of trans fat." ;
 .
 
-sdo:transcript
+schema:transcript
     rdfs:label "transcript" ;
     rdfs:comment "If this MediaObject is an AudioObject or VideoObject, the transcript of that object." ;
 .
 
-sdo:transitTime
+schema:transitTime
     rdfs:label "transit time" ;
     rdfs:comment "The typical delay the order has been sent for delivery and the goods reach the final customer. Typical properties: minValue, maxValue, unitCode (d for DAY)." ;
 .
 
-sdo:transitTimeLabel
+schema:transitTimeLabel
     rdfs:label "transit timeLabel" ;
     rdfs:comment "Label to match an [[OfferShippingDetails]] with a [[DeliveryTimeSettings]] (within the context of a [[shippingSettingsLink]] cross-reference)." ;
 .
 
-sdo:translationOfWork
+schema:translationOfWork
     rdfs:label "translation ofWork" ;
     rdfs:comment "The work that this work has been translated from. e.g. 物种起源 is a translationOf “On the Origin of Species”" ;
 .
 
-sdo:translator
+schema:translator
     rdfs:label "translator" ;
     rdfs:comment "Organization or person who adapts a creative work to different languages, regional differences and technical requirements of a target market, or that translates during some event." ;
 .
 
-sdo:transmissionMethod
+schema:transmissionMethod
     rdfs:label "transmission method" ;
     rdfs:comment "How the disease spreads, either as a route or vector, for example 'direct contact', 'Aedes aegypti', etc." ;
 .
 
-sdo:travelBans
+schema:travelBans
     rdfs:label "travel bans" ;
     rdfs:comment "Information about travel bans, e.g. in the context of a pandemic." ;
 .
 
-sdo:trialDesign
+schema:trialDesign
     rdfs:label "trial design" ;
     rdfs:comment "Specifics about the trial design (enumerated)." ;
 .
 
-sdo:tributary
+schema:tributary
     rdfs:label "tributary" ;
     rdfs:comment "The anatomical or organ system that the vein flows into; a larger structure that the vein connects to." ;
 .
 
-sdo:typeOfBed
+schema:typeOfBed
     rdfs:label "type ofBed" ;
     rdfs:comment "The type of bed to which the BedDetail refers, i.e. the type of bed available in the quantity indicated by quantity." ;
 .
 
-sdo:typeOfGood
+schema:typeOfGood
     rdfs:label "type ofGood" ;
     rdfs:comment "The product that this structured value is referring to." ;
 .
 
-sdo:typicalAgeRange
+schema:typicalAgeRange
     rdfs:label "typical ageRange" ;
     rdfs:comment "The typical expected age range, e.g. '7-9', '11-'." ;
 .
 
-sdo:typicalCreditsPerTerm
+schema:typicalCreditsPerTerm
     rdfs:label "typical credits Per Term" ;
     rdfs:comment "The number of credits or units a full-time student would be expected to take in 1 term however 'term' is defined by the institution." ;
 .
 
-sdo:typicalTest
+schema:typicalTest
     rdfs:label "typical test" ;
     rdfs:comment "A medical test typically performed given this condition." ;
 .
 
-sdo:underName
+schema:underName
     rdfs:label "under name" ;
     rdfs:comment "The person or organization the reservation or ticket is for." ;
 .
 
-sdo:unitCode
+schema:unitCode
     rdfs:label "unit code" ;
     rdfs:comment "The unit of measurement given using the UN/CEFACT Common Code (3 characters) or a URL. Other codes than the UN/CEFACT Common Code may be used with a prefix followed by a colon." ;
 .
 
-sdo:unitText
+schema:unitText
     rdfs:label "unit text" ;
     rdfs:comment """A string or text indicating the unit of measurement. Useful if you cannot provide a standard unit code for
 <a href='unitCode'>unitCode</a>.""" ;
 .
 
-sdo:unnamedSourcesPolicy
+schema:unnamedSourcesPolicy
     rdfs:label "unnamed sourcesPolicy" ;
     rdfs:comment "For an [[Organization]] (typically a [[NewsMediaOrganization]]), a statement about policy on use of unnamed sources and the decision process required." ;
 .
 
-sdo:unsaturatedFatContent
+schema:unsaturatedFatContent
     rdfs:label "unsaturated fatContent" ;
     rdfs:comment "The number of grams of unsaturated fat." ;
 .
 
-sdo:uploadDate
+schema:uploadDate
     rdfs:label "upload date" ;
     rdfs:comment "Date when this media object was uploaded to this site." ;
 .
 
-sdo:upvoteCount
+schema:upvoteCount
     rdfs:label "upvote count" ;
     rdfs:comment "The number of upvotes this question, answer or comment has received from the community." ;
 .
 
-sdo:url
+schema:url
     rdfs:label "url" ;
     rdfs:comment "URL of the item." ;
 .
 
-sdo:urlTemplate
+schema:urlTemplate
     rdfs:label "url template" ;
     rdfs:comment "An url template (RFC6570) that will be used to construct the target of the execution of the action." ;
 .
 
-sdo:usageInfo
+schema:usageInfo
     rdfs:label "usage info" ;
     rdfs:comment """The schema.org [[usageInfo]] property indicates further information about a [[CreativeWork]]. This property is applicable both to works that are freely available and to those that require payment or other transactions. It can reference additional information e.g. community expectations on preferred linking and citation conventions, as well as purchasing details. For something that can be commercially licensed, usageInfo can provide detailed, resource-specific information about licensing options.
 
 This property can be used alongside the license property which indicates license(s) applicable to some piece of content. The usageInfo property can provide information about other licensing options, e.g. acquiring commercial usage rights for an image that is also available under non-commercial creative commons licenses.""" ;
 .
 
-sdo:usedToDiagnose
+schema:usedToDiagnose
     rdfs:label "used toDiagnose" ;
     rdfs:comment "A condition the test is used to diagnose." ;
 .
 
-sdo:userInteractionCount
+schema:userInteractionCount
     rdfs:label "user interactionCount" ;
     rdfs:comment "The number of interactions for the CreativeWork using the WebSite or SoftwareApplication." ;
 .
 
-sdo:usesDevice
+schema:usesDevice
     rdfs:label "uses device" ;
     rdfs:comment "Device used to perform the test." ;
 .
 
-sdo:usesHealthPlanIdStandard
+schema:usesHealthPlanIdStandard
     rdfs:label "uses healthPlan Id Standard" ;
     rdfs:comment "The standard for interpreting thePlan ID. The preferred is \"HIOS\". See the Centers for Medicare & Medicaid Services for more details." ;
 .
 
-sdo:utterances
+schema:utterances
     rdfs:label "utterances" ;
     rdfs:comment "Text of an utterances (spoken words, lyrics etc.) that occurs at a certain section of a media object, represented as a [[HyperTocEntry]]." ;
 .
 
-sdo:validFor
+schema:validFor
     rdfs:label "valid for" ;
     rdfs:comment "The duration of validity of a permit or similar thing." ;
 .
 
-sdo:validFrom
+schema:validFrom
     rdfs:label "valid from" ;
     rdfs:comment "The date when the item becomes valid." ;
 .
 
-sdo:validIn
+schema:validIn
     rdfs:label "valid in" ;
     rdfs:comment "The geographic area where a permit or similar thing is valid." ;
 .
 
-sdo:validThrough
+schema:validThrough
     rdfs:label "valid through" ;
     rdfs:comment "The date after when the item is not valid. For example the end of an offer, salary period, or a period of opening hours." ;
 .
 
-sdo:validUntil
+schema:validUntil
     rdfs:label "valid until" ;
     rdfs:comment "The date when the item is no longer valid." ;
 .
 
-sdo:value
+schema:value
     rdfs:label "value" ;
     rdfs:comment "The value of the quantitative value or property value node.\\n\\n* For [[QuantitativeValue]] and [[MonetaryAmount]], the recommended type for values is 'Number'.\\n* For [[PropertyValue]], it can be 'Text;', 'Number', 'Boolean', or 'StructuredValue'.\\n* Use values from 0123456789 (Unicode 'DIGIT ZERO' (U+0030) to 'DIGIT NINE' (U+0039)) rather than superficially similiar Unicode symbols.\\n* Use '.' (Unicode 'FULL STOP' (U+002E)) rather than ',' to indicate a decimal point. Avoid using these symbols as a readability separator." ;
 .
 
-sdo:valueAddedTaxIncluded
+schema:valueAddedTaxIncluded
     rdfs:label "value added Tax Included" ;
     rdfs:comment "Specifies whether the applicable value-added tax (VAT) is included in the price specification or not." ;
 .
 
-sdo:valueMaxLength
+schema:valueMaxLength
     rdfs:label "value maxLength" ;
     rdfs:comment "Specifies the allowed range for number of characters in a literal value." ;
 .
 
-sdo:valueMinLength
+schema:valueMinLength
     rdfs:label "value minLength" ;
     rdfs:comment "Specifies the minimum allowed range for number of characters in a literal value." ;
 .
 
-sdo:valueName
+schema:valueName
     rdfs:label "value name" ;
     rdfs:comment "Indicates the name of the PropertyValueSpecification to be used in URL templates and form encoding in a manner analogous to HTML's input@name." ;
 .
 
-sdo:valuePattern
+schema:valuePattern
     rdfs:label "value pattern" ;
     rdfs:comment "Specifies a regular expression for testing literal values according to the HTML spec." ;
 .
 
-sdo:valueReference
+schema:valueReference
     rdfs:label "value reference" ;
     rdfs:comment "A secondary value that provides additional information on the original value, e.g. a reference temperature or a type of measurement." ;
 .
 
-sdo:valueRequired
+schema:valueRequired
     rdfs:label "value required" ;
     rdfs:comment "Whether the property must be filled in to complete the action.  Default is false." ;
 .
 
-sdo:variableMeasured
+schema:variableMeasured
     rdfs:label "variable measured" ;
     rdfs:comment "The variableMeasured property can indicate (repeated as necessary) the  variables that are measured in some dataset, either described as text or as pairs of identifier and description using PropertyValue." ;
 .
 
-sdo:variantCover
+schema:variantCover
     rdfs:label "variant cover" ;
     rdfs:comment """A description of the variant cover
     	for the issue, if the issue is a variant printing. For example, "Bryan Hitch
     	Variant Cover" or "2nd Printing Variant".""" ;
 .
 
-sdo:variesBy
+schema:variesBy
     rdfs:label "varies by" ;
     rdfs:comment "Indicates the property or properties by which the variants in a [[ProductGroup]] vary, e.g. their size, color etc. Schema.org properties can be referenced by their short name e.g. \"color\"; terms defined elsewhere can be referenced with their URIs." ;
 .
 
-sdo:vatID
+schema:vatID
     rdfs:label "vat id" ;
     rdfs:comment "The Value-added Tax ID of the organization or person." ;
 .
 
-sdo:vehicleConfiguration
+schema:vehicleConfiguration
     rdfs:label "vehicle configuration" ;
     rdfs:comment "A short text indicating the configuration of the vehicle, e.g. '5dr hatchback ST 2.5 MT 225 hp' or 'limited edition'." ;
 .
 
-sdo:vehicleEngine
+schema:vehicleEngine
     rdfs:label "vehicle engine" ;
     rdfs:comment "Information about the engine or engines of the vehicle." ;
 .
 
-sdo:vehicleIdentificationNumber
+schema:vehicleIdentificationNumber
     rdfs:label "vehicle identificationNumber" ;
     rdfs:comment "The Vehicle Identification Number (VIN) is a unique serial number used by the automotive industry to identify individual motor vehicles." ;
 .
 
-sdo:vehicleInteriorColor
+schema:vehicleInteriorColor
     rdfs:label "vehicle interiorColor" ;
     rdfs:comment "The color or color combination of the interior of the vehicle." ;
 .
 
-sdo:vehicleInteriorType
+schema:vehicleInteriorType
     rdfs:label "vehicle interiorType" ;
     rdfs:comment "The type or material of the interior of the vehicle (e.g. synthetic fabric, leather, wood, etc.). While most interior types are characterized by the material used, an interior type can also be based on vehicle usage or target audience." ;
 .
 
-sdo:vehicleModelDate
+schema:vehicleModelDate
     rdfs:label "vehicle modelDate" ;
     rdfs:comment "The release date of a vehicle model (often used to differentiate versions of the same make and model)." ;
 .
 
-sdo:vehicleSeatingCapacity
+schema:vehicleSeatingCapacity
     rdfs:label "vehicle seatingCapacity" ;
     rdfs:comment "The number of passengers that can be seated in the vehicle, both in terms of the physical space available, and in terms of limitations set by law.\\n\\nTypical unit code(s): C62 for persons." ;
 .
 
-sdo:vehicleSpecialUsage
+schema:vehicleSpecialUsage
     rdfs:label "vehicle specialUsage" ;
     rdfs:comment "Indicates whether the vehicle has been used for special purposes, like commercial rental, driving school, or as a taxi. The legislation in many countries requires this information to be revealed when offering a car for sale." ;
 .
 
-sdo:vehicleTransmission
+schema:vehicleTransmission
     rdfs:label "vehicle transmission" ;
     rdfs:comment "The type of component used for transmitting the power from a rotating power source to the wheels or other relevant component(s) (\"gearbox\" for cars)." ;
 .
 
-sdo:vendor
+schema:vendor
     rdfs:label "vendor" ;
     rdfs:comment "'vendor' is an earlier term for 'seller'." ;
 .
 
-sdo:verificationFactCheckingPolicy
+schema:verificationFactCheckingPolicy
     rdfs:label "verification fact Checking Policy" ;
     rdfs:comment "Disclosure about verification and fact-checking processes for a [[NewsMediaOrganization]] or other fact-checking [[Organization]]." ;
 .
 
-sdo:version
+schema:version
     rdfs:label "version" ;
     rdfs:comment "The version of the CreativeWork embodied by a specified resource." ;
 .
 
-sdo:video
+schema:video
     rdfs:label "video" ;
     rdfs:comment "An embedded video object." ;
 .
 
-sdo:videoFormat
+schema:videoFormat
     rdfs:label "video format" ;
     rdfs:comment "The type of screening or video broadcast used (e.g. IMAX, 3D, SD, HD, etc.)." ;
 .
 
-sdo:videoFrameSize
+schema:videoFrameSize
     rdfs:label "video frameSize" ;
     rdfs:comment "The frame size of the video." ;
 .
 
-sdo:videoQuality
+schema:videoQuality
     rdfs:label "video quality" ;
     rdfs:comment "The quality of the video." ;
 .
 
-sdo:volumeNumber
+schema:volumeNumber
     rdfs:label "volume number" ;
     rdfs:comment "Identifies the volume of publication or multi-part work; for example, \"iii\" or \"2\"." ;
 .
 
-sdo:warning
+schema:warning
     rdfs:label "warning" ;
     rdfs:comment "Any FDA or other warnings about the drug (text or URL)." ;
 .
 
-sdo:warranty
+schema:warranty
     rdfs:label "warranty" ;
     rdfs:comment "The warranty promise(s) included in the offer." ;
 .
 
-sdo:warrantyPromise
+schema:warrantyPromise
     rdfs:label "warranty promise" ;
     rdfs:comment "The warranty promise(s) included in the offer." ;
 .
 
-sdo:warrantyScope
+schema:warrantyScope
     rdfs:label "warranty scope" ;
     rdfs:comment "The scope of the warranty promise." ;
 .
 
-sdo:webCheckinTime
+schema:webCheckinTime
     rdfs:label "web checkinTime" ;
     rdfs:comment "The time when a passenger can check into the flight online." ;
 .
 
-sdo:webFeed
+schema:webFeed
     rdfs:label "web feed" ;
     rdfs:comment "The URL for a feed, e.g. associated with a podcast series, blog, or series of date-stamped updates. This is usually RSS or Atom." ;
 .
 
-sdo:weight
+schema:weight
     rdfs:label "weight" ;
     rdfs:comment "The weight of the product or person." ;
 .
 
-sdo:weightTotal
+schema:weightTotal
     rdfs:label "weight total" ;
     rdfs:comment "The permitted total weight of the loaded vehicle, including passengers and cargo and the weight of the empty vehicle.\\n\\nTypical unit code(s): KGM for kilogram, LBR for pound\\n\\n* Note 1: You can indicate additional information in the [[name]] of the [[QuantitativeValue]] node.\\n* Note 2: You may also link to a [[QualitativeValue]] node that provides additional information using [[valueReference]].\\n* Note 3: Note that you can use [[minValue]] and [[maxValue]] to indicate ranges." ;
 .
 
-sdo:wheelbase
+schema:wheelbase
     rdfs:label "wheelbase" ;
     rdfs:comment "The distance between the centers of the front and rear wheels.\\n\\nTypical unit code(s): CMT for centimeters, MTR for meters, INH for inches, FOT for foot/feet" ;
 .
 
-sdo:width
+schema:width
     rdfs:label "width" ;
     rdfs:comment "The width of the item." ;
 .
 
-sdo:winner
+schema:winner
     rdfs:label "winner" ;
     rdfs:comment "A sub property of participant. The winner of the action." ;
 .
 
-sdo:wordCount
+schema:wordCount
     rdfs:label "word count" ;
     rdfs:comment "The number of words in the text of the Article." ;
 .
 
-sdo:workExample
+schema:workExample
     rdfs:label "work example" ;
     rdfs:comment "Example/instance/realization/derivation of the concept of this creative work. eg. The paperback edition, first edition, or eBook." ;
 .
 
-sdo:workFeatured
+schema:workFeatured
     rdfs:label "work featured" ;
     rdfs:comment """A work featured in some event, e.g. exhibited in an ExhibitionEvent.
        Specific subproperties are available for workPerformed (e.g. a play), or a workPresented (a Movie at a ScreeningEvent).""" ;
 .
 
-sdo:workHours
+schema:workHours
     rdfs:label "work hours" ;
     rdfs:comment "The typical working hours for this job (e.g. 1st shift, night shift, 8am-5pm)." ;
 .
 
-sdo:workLocation
+schema:workLocation
     rdfs:label "work location" ;
     rdfs:comment "A contact location for a person's place of work." ;
 .
 
-sdo:workPerformed
+schema:workPerformed
     rdfs:label "work performed" ;
     rdfs:comment "A work performed in some event, for example a play performed in a TheaterEvent." ;
 .
 
-sdo:workPresented
+schema:workPresented
     rdfs:label "work presented" ;
     rdfs:comment "The movie presented during this event." ;
 .
 
-sdo:workTranslation
+schema:workTranslation
     rdfs:label "work translation" ;
     rdfs:comment "A work that is a translation of the content of this work. e.g. 西遊記 has an English workTranslation “Journey to the West”,a German workTranslation “Monkeys Pilgerfahrt” and a Vietnamese  translation Tây du ký bình khảo." ;
 .
 
-sdo:workload
+schema:workload
     rdfs:label "workload" ;
     rdfs:comment "Quantitative measure of the physiologic output of the exercise; also referred to as energy expenditure." ;
 .
 
-sdo:worksFor
+schema:worksFor
     rdfs:label "works for" ;
     rdfs:comment "Organizations that the person works for." ;
 .
 
-sdo:worstRating
+schema:worstRating
     rdfs:label "worst rating" ;
     rdfs:comment "The lowest value allowed in this rating system. If worstRating is omitted, 1 is assumed." ;
 .
 
-sdo:xpath
+schema:xpath
     rdfs:label "xpath" ;
     rdfs:comment "An XPath, e.g. of a [[SpeakableSpecification]] or [[WebPageElement]]. In the latter case, multiple matches within a page can constitute a single conceptual \"Web page element\"." ;
 .
 
-sdo:yearBuilt
+schema:yearBuilt
     rdfs:label "year built" ;
     rdfs:comment "The year an [[Accommodation]] was constructed. This corresponds to the [YearBuilt field in RESO](https://ddwiki.reso.org/display/DDW17/YearBuilt+Field). " ;
 .
 
-sdo:yearlyRevenue
+schema:yearlyRevenue
     rdfs:label "yearly revenue" ;
     rdfs:comment "The size of the business in annual revenue." ;
 .
 
-sdo:yearsInOperation
+schema:yearsInOperation
     rdfs:label "years inOperation" ;
     rdfs:comment "The age of the business." ;
 .
 
-sdo:yield
+schema:yield
     rdfs:label "yield" ;
     rdfs:comment "The quantity that results by performing instructions. For example, a paper airplane, 10 personalized candles." ;
 .

--- a/vocabularies/background/reg-statuses.ttl
+++ b/vocabularies/background/reg-statuses.ttl
@@ -3,7 +3,7 @@ PREFIX rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX owl:  <http://www.w3.org/2002/07/owl#>
 PREFIX xsd:  <http://www.w3.org/2001/XMLSchema#>
-PREFIX sdo: <https://schema.org/>
+PREFIX schema: <https://schema.org/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX reg:  <http://purl.org/linked-data/registry#>
 PREFIX dcterms:  <http://purl.org/dc/terms/>
@@ -39,29 +39,29 @@ Note that just like the original form of this vocabulary, while it is a SKOS voc
 .
 
 <https://www.epimorphics.com>
-    a sdo:Organization ;
-    sdo:name "Epimorphics" ;
-    sdo:url "https://www.epimorphics.com"^^xsd:anyURI ;
+    a schema:Organization ;
+    schema:name "Epimorphics" ;
+    schema:url "https://www.epimorphics.com"^^xsd:anyURI ;
 .
 
 <https://linked.data.gov.au/org/agldwg>
-    a sdo:Organization ;
-    sdo:name "Australian Government Linked Data Working Group" ;
-    sdo:url "http://www.linked.data.gov.au"^^xsd:anyURI ;
+    a schema:Organization ;
+    schema:name "Australian Government Linked Data Working Group" ;
+    schema:url "http://www.linked.data.gov.au"^^xsd:anyURI ;
 .
 
 <https://orcid.org/0000-0002-8742-7730>
-    a sdo:Person ;
-    sdo:honorificPrefix "Dr" ;
-    sdo:name "Nicholas J. Car" ;
-    sdo:email "nicholas.car@surroundaustralia.com"^^xsd:anyURI ;
-    sdo:affiliation <https://linked.data.gov.au/org/surround> ;
+    a schema:Person ;
+    schema:honorificPrefix "Dr" ;
+    schema:name "Nicholas J. Car" ;
+    schema:email "nicholas.car@surroundaustralia.com"^^xsd:anyURI ;
+    schema:affiliation <https://linked.data.gov.au/org/surround> ;
 .
 
 <https://linked.data.gov.au/org/surround>
-    a sdo:Organization ;
-    sdo:name "SURROUND Australia Pty Ltd" ;
-    sdo:url "https://surroundaustralia.com"^^xsd:anyURI ;
+    a schema:Organization ;
+    schema:name "SURROUND Australia Pty Ltd" ;
+    schema:url "https://surroundaustralia.com"^^xsd:anyURI ;
 .
 
 reg:Status a owl:Class;
@@ -78,7 +78,7 @@ reg:Status a owl:Class;
     skos:inScheme cs: ;
     skos:topConceptOf cs: ;
     rdfs:isDefinedBy cs: ;
-    sdo:color "#1bc13f" ;
+    schema:color "#1bc13f" ;
 .
 
 :addition a skos:Concept, reg:Status ;
@@ -87,7 +87,7 @@ reg:Status a owl:Class;
     skos:inScheme cs: ;
     rdfs:isDefinedBy cs: ;
     skos:broader :stable ;
-    sdo:color "#4ac11b" ;
+    schema:color "#4ac11b" ;
 .
 
 :deprecated a skos:Concept, reg:Status ;
@@ -97,7 +97,7 @@ reg:Status a owl:Class;
     skos:inScheme cs: ;
     rdfs:isDefinedBy cs: ;
     skos:broader :accepted ;
-    sdo:color "#a86a0d" ;
+    schema:color "#a86a0d" ;
 .
 
 :experimental a skos:Concept, reg:Status ;
@@ -108,7 +108,7 @@ reg:Status a owl:Class;
     skos:inScheme cs: ;
     rdfs:isDefinedBy cs: ;
     skos:broader :valid ;
-    sdo:color "#eae72c" ;
+    schema:color "#eae72c" ;
 .
 
 :invalid a skos:Concept, reg:Status ;
@@ -118,7 +118,7 @@ reg:Status a owl:Class;
     skos:inScheme cs: ;
     rdfs:isDefinedBy cs: ;
     skos:broader :notAccepted ;
-    sdo:color "#ea3c2c" ;
+    schema:color "#ea3c2c" ;
 .
 
 :notAccepted a skos:Concept, reg:Status ;
@@ -129,7 +129,7 @@ reg:Status a owl:Class;
     skos:inScheme cs: ;
     skos:topConceptOf cs: ;
     rdfs:isDefinedBy cs: ;
-    sdo:color "#ea9e2c" ;
+    schema:color "#ea9e2c" ;
 .
 
 :original a skos:Concept, reg:Status ;
@@ -138,7 +138,7 @@ reg:Status a owl:Class;
     skos:inScheme cs: ;
     rdfs:isDefinedBy cs: ;
     skos:broader :stable ;
-    sdo:color "#38a30e" ;
+    schema:color "#38a30e" ;
 .
 
 :reserved a skos:Concept, reg:Status ;
@@ -148,7 +148,7 @@ reg:Status a owl:Class;
     skos:inScheme cs: ;
     rdfs:isDefinedBy cs: ;
     skos:broader :notAccepted ;
-    sdo:color "#9b8d79" ;
+    schema:color "#9b8d79" ;
 .
 
 :retired a skos:Concept, reg:Status ;
@@ -159,7 +159,7 @@ reg:Status a owl:Class;
     skos:inScheme cs: ;
     rdfs:isDefinedBy cs: ;
     skos:broader :deprecated ;
-    sdo:color "#ad5b24" ;
+    schema:color "#ad5b24" ;
 .
 
 :stable a skos:Concept, reg:Status ;
@@ -169,7 +169,7 @@ reg:Status a owl:Class;
     skos:inScheme cs: ;
     rdfs:isDefinedBy cs: ;
     skos:broader :valid ;
-    sdo:color "#2e8c09" ;
+    schema:color "#2e8c09" ;
 .
 
 :submitted a skos:Concept, reg:Status ;
@@ -179,7 +179,7 @@ reg:Status a owl:Class;
     skos:inScheme cs: ;
     rdfs:isDefinedBy cs: ;
     skos:broader :notAccepted ;
-    sdo:color "#248bad" ;
+    schema:color "#248bad" ;
 .
 
 :superseded a skos:Concept, reg:Status ;
@@ -190,7 +190,7 @@ reg:Status a owl:Class;
     skos:inScheme cs: ;
     rdfs:isDefinedBy cs: ;
     skos:broader :deprecated ;
-    sdo:color "#ad7624" ;
+    schema:color "#ad7624" ;
 .
 
 :unstable a skos:Concept, reg:Status ;
@@ -200,7 +200,7 @@ reg:Status a owl:Class;
     skos:inScheme cs: ;
     skos:broader :valid ;
     owl:sameAs reg:statusStable ;
-    sdo:color "#678c09" ;
+    schema:color "#678c09" ;
 .
 
 :valid a skos:Concept, reg:Status ;
@@ -210,5 +210,5 @@ reg:Status a owl:Class;
     skos:inScheme cs: ;
     rdfs:isDefinedBy cs: ;
     skos:broader :accepted ;
-    sdo:color "#36a80d" ;
+    schema:color "#36a80d" ;
 .

--- a/vocabularies/borehole-configuration-vertical-depth.ttl
+++ b/vocabularies/borehole-configuration-vertical-depth.ttl
@@ -440,14 +440,14 @@ cs:
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    a prov:Agent ;
+                    schema:Person
                     sdo:name "Erin Gray" ;
                 ]
         ] ,
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    a prov:Agent ;
+                    schema:Person
                     sdo:name "Angela Riganti" ;
                 ]
         ] ;

--- a/vocabularies/borehole-configuration-vertical-depth.ttl
+++ b/vocabularies/borehole-configuration-vertical-depth.ttl
@@ -8,7 +8,7 @@ PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX reg: <http://purl.org/linked-data/registry#>
-PREFIX sdo: <https://schema.org/>
+PREFIX schema: <https://schema.org/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
@@ -406,9 +406,9 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 .
 
 <https://linked.data.gov.au/org/gswa>
-    a sdo:Organization ;
-    sdo:name "Geological Survey of Western Australia" ;
-    sdo:url "https://dmp.wa.gov.au/Geological-Survey/Geological-Survey-262.aspx"^^xsd:anyURI ;
+    a schema:Organization ;
+    schema:name "Geological Survey of Western Australia" ;
+    schema:url "https://dmp.wa.gov.au/Geological-Survey/Geological-Survey-262.aspx"^^xsd:anyURI ;
 .
 
 cs:
@@ -440,15 +440,17 @@ cs:
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    schema:Person
-                    sdo:name "Erin Gray" ;
+                    a schema:Person ;
+                    schema:email ""^^xsd:anyURI ;
+                    schema:name "Erin Gray" ;
                 ]
         ] ,
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    schema:Person
-                    sdo:name "Angela Riganti" ;
+                    a schema:Person ;
+                    schema:email ""^^xsd:anyURI ;
+                    schema:name "Angela Riganti" ;
                 ]
         ] ;
 .

--- a/vocabularies/borehole-configuration.ttl
+++ b/vocabularies/borehole-configuration.ttl
@@ -155,14 +155,14 @@ cs:
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    a prov:Agent ;
+                    schema:Person
                     sdo:name "Erin Gray" ;
                 ]
         ] ,
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    a prov:Agent ;
+                    schema:Person
                     sdo:name "Angela Riganti" ;
                 ]
         ] ;

--- a/vocabularies/borehole-configuration.ttl
+++ b/vocabularies/borehole-configuration.ttl
@@ -8,7 +8,7 @@ PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX reg: <http://purl.org/linked-data/registry#>
-PREFIX sdo: <https://schema.org/>
+PREFIX schema: <https://schema.org/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
@@ -127,9 +127,9 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 .
 
 <https://linked.data.gov.au/org/gswa>
-    a sdo:Organization ;
-    sdo:name "Geological Survey of Western Australia" ;
-    sdo:url "https://dmp.wa.gov.au/Geological-Survey/Geological-Survey-262.aspx"^^xsd:anyURI ;
+    a schema:Organization ;
+    schema:name "Geological Survey of Western Australia" ;
+    schema:url "https://dmp.wa.gov.au/Geological-Survey/Geological-Survey-262.aspx"^^xsd:anyURI ;
 .
 
 cs:
@@ -155,15 +155,17 @@ cs:
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    schema:Person
-                    sdo:name "Erin Gray" ;
+                    a schema:Person ;
+                    schema:email ""^^xsd:anyURI ;
+                    schema:name "Erin Gray" ;
                 ]
         ] ,
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    schema:Person
-                    sdo:name "Angela Riganti" ;
+                    a schema:Person ;
+                    schema:email ""^^xsd:anyURI ;
+                    schema:name "Angela Riganti" ;
                 ]
         ] ;
 .

--- a/vocabularies/borehole-drilling-method.ttl
+++ b/vocabularies/borehole-drilling-method.ttl
@@ -582,6 +582,7 @@ cs:
             prov:agent
                 [
                     a schema:Person ;
+                    schema:email ""^^xsd:anyURI ;
                     schema:name "Erin Gray" ;
                 ] ;
         ] ,
@@ -590,6 +591,7 @@ cs:
             prov:agent
                 [
                     a schema:Person ;
+                    schema:email ""^^xsd:anyURI ;
                     schema:name "Angela Riganti" ;
                 ] ;
         ] ;

--- a/vocabularies/borehole-drilling-method.ttl
+++ b/vocabularies/borehole-drilling-method.ttl
@@ -560,7 +560,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.g​ov.au/org/gswa>
     a schema:Organization ;
-    schema:name "Gswa" ;
+    schema:name "Geological Survey of Western Australia" ;
     schema:url ""^^xsd:anyURI ;
 .
 

--- a/vocabularies/borehole-drilling-method.ttl
+++ b/vocabularies/borehole-drilling-method.ttl
@@ -581,7 +581,7 @@ cs:
             dcat:hadRole isoroles:custodian ;
             prov:agent
                 [
-                    a schema:Organization ;
+                    a schema:Person ;
                     schema:name "Erin Gray" ;
                 ] ;
         ] ,
@@ -589,7 +589,7 @@ cs:
             dcat:hadRole isoroles:custodian ;
             prov:agent
                 [
-                    a schema:Organization ;
+                    a schema:Person ;
                     schema:name "Angela Riganti" ;
                 ] ;
         ] ;

--- a/vocabularies/borehole-drilling-method.ttl
+++ b/vocabularies/borehole-drilling-method.ttl
@@ -561,7 +561,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.g​ov.au/org/gswa>
     a schema:Organization ;
     schema:name "Geological Survey of Western Australia" ;
-    schema:url ""^^xsd:anyURI ;
+    schema:url "https://www.dmp.wa.gov.au/Geological-Survey/Geological-Survey-262.aspx"^^xsd:anyURI ;
 .
 
 cs:
@@ -583,7 +583,6 @@ cs:
                 [
                     a schema:Organization ;
                     schema:name "Erin Gray" ;
-                    schema:url ""^^xsd:anyURI ;
                 ] ;
         ] ,
         [
@@ -592,7 +591,6 @@ cs:
                 [
                     a schema:Organization ;
                     schema:name "Angela Riganti" ;
-                    schema:url ""^^xsd:anyURI ;
                 ] ;
         ] ;
     schema:creator <https://linked.data.g​ov.au/org/gswa> ;

--- a/vocabularies/borehole-geometry.ttl
+++ b/vocabularies/borehole-geometry.ttl
@@ -402,14 +402,14 @@ cs:
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    a prov:Agent ;
+                    schema:Person
                     sdo:name "Erin Gray" ;
                 ]
         ] ,
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    a prov:Agent ;
+                    schema:Person
                     sdo:name "Angela Riganti" ;
                 ]
         ] ;

--- a/vocabularies/borehole-geometry.ttl
+++ b/vocabularies/borehole-geometry.ttl
@@ -8,7 +8,7 @@ PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX reg: <http://purl.org/linked-data/registry#>
-PREFIX sdo: <https://schema.org/>
+PREFIX schema: <https://schema.org/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
@@ -366,9 +366,9 @@ https://help.dugeo.com/m/faq/l/167077-height-datums-and-abbreviations""" ;
 .
 
 <https://linked.data.gov.au/org/gswa>
-    a sdo:Organization ;
-    sdo:name "Geological Survey of Western Australia" ;
-    sdo:url "https://dmp.wa.gov.au/Geological-Survey/Geological-Survey-262.aspx"^^xsd:anyURI ;
+    a schema:Organization ;
+    schema:name "Geological Survey of Western Australia" ;
+    schema:url "https://dmp.wa.gov.au/Geological-Survey/Geological-Survey-262.aspx"^^xsd:anyURI ;
 .
 
 cs:
@@ -402,15 +402,17 @@ cs:
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    schema:Person
-                    sdo:name "Erin Gray" ;
+                    a schema:Person ;
+                    schema:email ""^^xsd:anyURI ;
+                    schema:name "Erin Gray" ;
                 ]
         ] ,
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    schema:Person
-                    sdo:name "Angela Riganti" ;
+                    a schema:Person ;
+                    schema:email ""^^xsd:anyURI ;
+                    schema:name "Angela Riganti" ;
                 ]
         ] ;
 .

--- a/vocabularies/borehole-start-point-setting.ttl
+++ b/vocabularies/borehole-start-point-setting.ttl
@@ -8,7 +8,7 @@ PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX reg: <http://purl.org/linked-data/registry#>
-PREFIX sdo: <https://schema.org/>
+PREFIX schema: <https://schema.org/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
@@ -99,9 +99,9 @@ https://www.legislation.gov.au/Details/C2008C00399""" ;
 .
 
 <https://linked.data.gov.au/org/gswa>
-    a sdo:Organization ;
-    sdo:name "Geological Survey of Western Australia" ;
-    sdo:url "https://dmp.wa.gov.au/Geological-Survey/Geological-Survey-262.aspx"^^xsd:anyURI ;
+    a schema:Organization ;
+    schema:name "Geological Survey of Western Australia" ;
+    schema:url "https://dmp.wa.gov.au/Geological-Survey/Geological-Survey-262.aspx"^^xsd:anyURI ;
 .
 
 cs:
@@ -126,15 +126,17 @@ cs:
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    schema:Person
-                    sdo:name "Erin Gray" ;
+                    a schema:Person ;
+                    schema:email ""^^xsd:anyURI ;
+                    schema:name "Erin Gray" ;
                 ]
         ] ,
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    schema:Person
-                    sdo:name "Angela Riganti" ;
+                    a schema:Person ;
+                    schema:email ""^^xsd:anyURI ;
+                    schema:name "Angela Riganti" ;
                 ]
         ] ;
 .

--- a/vocabularies/borehole-start-point-setting.ttl
+++ b/vocabularies/borehole-start-point-setting.ttl
@@ -126,14 +126,14 @@ cs:
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    a prov:Agent ;
+                    schema:Person
                     sdo:name "Erin Gray" ;
                 ]
         ] ,
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    a prov:Agent ;
+                    schema:Person
                     sdo:name "Angela Riganti" ;
                 ]
         ] ;

--- a/vocabularies/dmirs-offices.ttl
+++ b/vocabularies/dmirs-offices.ttl
@@ -296,7 +296,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/org/gswa>
     a schema:Organization ;
     schema:name "Geological Survey of Western Australia" ;
-    schema:url ""^^xsd:anyURI ;
+    schema:url "https://www.dmp.wa.gov.au/Geological-Survey/Geological-Survey-262.aspx"^^xsd:anyURI ;
 .
 
 :karratha-office
@@ -361,7 +361,6 @@ cs:
                 [
                     a schema:Organization ;
                     schema:name "Erin Gray" ;
-                    schema:url ""^^xsd:anyURI ;
                 ] ;
         ] ,
         [
@@ -370,7 +369,6 @@ cs:
                 [
                     a schema:Organization ;
                     schema:name "Angela Riganti" ;
-                    schema:url ""^^xsd:anyURI ;
                 ] ;
         ] ;
     schema:creator <https://linked.data.gov.au/org/gswa> ;

--- a/vocabularies/dmirs-offices.ttl
+++ b/vocabularies/dmirs-offices.ttl
@@ -359,7 +359,7 @@ cs:
             dcat:hadRole isoroles:custodian ;
             prov:agent
                 [
-                    a schema:Organization ;
+                    a schema:Person ;
                     schema:name "Erin Gray" ;
                 ] ;
         ] ,
@@ -367,7 +367,7 @@ cs:
             dcat:hadRole isoroles:custodian ;
             prov:agent
                 [
-                    a schema:Organization ;
+                    a schema:Person ;
                     schema:name "Angela Riganti" ;
                 ] ;
         ] ;

--- a/vocabularies/dmirs-offices.ttl
+++ b/vocabularies/dmirs-offices.ttl
@@ -360,6 +360,7 @@ cs:
             prov:agent
                 [
                     a schema:Person ;
+                    schema:email ""^^xsd:anyURI ;
                     schema:name "Erin Gray" ;
                 ] ;
         ] ,
@@ -368,6 +369,7 @@ cs:
             prov:agent
                 [
                     a schema:Person ;
+                    schema:email ""^^xsd:anyURI ;
                     schema:name "Angela Riganti" ;
                 ] ;
         ] ;

--- a/vocabularies/dmirs-offices.ttl
+++ b/vocabularies/dmirs-offices.ttl
@@ -295,7 +295,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/org/gswa>
     a schema:Organization ;
-    schema:name "Gswa" ;
+    schema:name "Geological Survey of Western Australia" ;
     schema:url ""^^xsd:anyURI ;
 .
 

--- a/vocabularies/geological-feature-type.ttl
+++ b/vocabularies/geological-feature-type.ttl
@@ -205,21 +205,21 @@ cs:
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    a prov:Agent ;
+                    schema:Person
                     sdo:name "Angela Riganti" ;
                 ]
         ] ,
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    a prov:Agent ;
+                    schema:Person
                     sdo:name "David Martin" ;
                 ]
         ] ,
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    a prov:Agent ;
+                    schema:Person
                     sdo:name "Erin Gray" ;
                 ]
         ] ;

--- a/vocabularies/geological-feature-type.ttl
+++ b/vocabularies/geological-feature-type.ttl
@@ -8,7 +8,7 @@ PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX reg: <http://purl.org/linked-data/registry#>
-PREFIX sdo: <https://schema.org/>
+PREFIX schema: <https://schema.org/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
@@ -170,9 +170,9 @@ Wyborn, LAI, Heinrich, CA and Jaques, AL 1994, Australian Proterozoic mineral sy
 .
 
 <https://linked.data.gov.au/org/gswa>
-    a sdo:Organization ;
-    sdo:name "Geological Survey of Western Australia" ;
-    sdo:url "https://dmp.wa.gov.au/Geological-Survey/Geological-Survey-262.aspx"^^xsd:anyURI ;
+    a schema:Organization ;
+    schema:name "Geological Survey of Western Australia" ;
+    schema:url "https://dmp.wa.gov.au/Geological-Survey/Geological-Survey-262.aspx"^^xsd:anyURI ;
 .
 
 cs:
@@ -205,22 +205,25 @@ cs:
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    schema:Person
-                    sdo:name "Angela Riganti" ;
+                    a schema:Person ;
+                    schema:email ""^^xsd:anyURI ;
+                    schema:name "Angela Riganti" ;
                 ]
         ] ,
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    schema:Person
-                    sdo:name "David Martin" ;
+                    a schema:Person ;
+                    schema:email ""^^xsd:anyURI ;
+                    schema:name "David Martin" ;
                 ]
         ] ,
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    schema:Person
-                    sdo:name "Erin Gray" ;
+                    a schema:Person ;
+                    schema:email ""^^xsd:anyURI ;
+                    schema:name "Erin Gray" ;
                 ]
         ] ;
 .

--- a/vocabularies/gswa-collection-facility.ttl
+++ b/vocabularies/gswa-collection-facility.ttl
@@ -205,7 +205,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.gov.au/org/gswa>
     a schema:Organization ;
     schema:name "Geological Survey of Western Australia" ;
-    schema:url ""^^xsd:anyURI ;
+    schema:url "https://www.dmp.wa.gov.au/Geological-Survey/Geological-Survey-262.aspx"^^xsd:anyURI ;
 .
 
 cs:
@@ -229,7 +229,6 @@ cs:
                 [
                     a schema:Organization ;
                     schema:name "Erin Gray" ;
-                    schema:url ""^^xsd:anyURI ;
                 ] ;
         ] ,
         [
@@ -237,8 +236,7 @@ cs:
             prov:agent
                 [
                     a schema:Organization ;
-                    schema:name "Angela Riganti" ;
-                    schema:url ""^^xsd:anyURI ;
+                  schema:name "Angela Riganti" ;
                 ] ;
         ] ,
         [
@@ -247,7 +245,6 @@ cs:
                 [
                     a schema:Organization ;
                     schema:name "Sarah Martin" ;
-                    schema:url ""^^xsd:anyURI ;
                 ] ;
         ] ;
     schema:creator <https://linked.data.gov.au/org/gswa> ;

--- a/vocabularies/gswa-collection-facility.ttl
+++ b/vocabularies/gswa-collection-facility.ttl
@@ -227,7 +227,7 @@ cs:
             dcat:hadRole isoroles:custodian ;
             prov:agent
                 [
-                    a schema:Organization ;
+                    a schema:Person ;
                     schema:name "Erin Gray" ;
                 ] ;
         ] ,
@@ -235,15 +235,15 @@ cs:
             dcat:hadRole isoroles:custodian ;
             prov:agent
                 [
-                    a schema:Organization ;
-                  schema:name "Angela Riganti" ;
+                    a schema:Person ;
+                    schema:name "Angela Riganti" ;
                 ] ;
         ] ,
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent
                 [
-                    a schema:Organization ;
+                    a schema:Person ;
                     schema:name "Sarah Martin" ;
                 ] ;
         ] ;

--- a/vocabularies/gswa-collection-facility.ttl
+++ b/vocabularies/gswa-collection-facility.ttl
@@ -204,7 +204,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.gov.au/org/gswa>
     a schema:Organization ;
-    schema:name "Gswa" ;
+    schema:name "Geological Survey of Western Australia" ;
     schema:url ""^^xsd:anyURI ;
 .
 

--- a/vocabularies/gswa-collection-facility.ttl
+++ b/vocabularies/gswa-collection-facility.ttl
@@ -228,6 +228,7 @@ cs:
             prov:agent
                 [
                     a schema:Person ;
+                    schema:email ""^^xsd:anyURI ;
                     schema:name "Erin Gray" ;
                 ] ;
         ] ,
@@ -236,6 +237,7 @@ cs:
             prov:agent
                 [
                     a schema:Person ;
+                    schema:email ""^^xsd:anyURI ;
                     schema:name "Angela Riganti" ;
                 ] ;
         ] ,
@@ -244,6 +246,7 @@ cs:
             prov:agent
                 [
                     a schema:Person ;
+                    schema:email ""^^xsd:anyURI ;
                     schema:name "Sarah Martin" ;
                 ] ;
         ] ;

--- a/vocabularies/location-method.ttl
+++ b/vocabularies/location-method.ttl
@@ -558,7 +558,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 <https://linked.data.g​ov.au/org/gswa>
     a schema:Organization ;
-    schema:name "Gswa" ;
+    schema:name "Geological Survey of Western Australia" ;
     schema:url ""^^xsd:anyURI ;
 .
 

--- a/vocabularies/location-method.ttl
+++ b/vocabularies/location-method.ttl
@@ -559,7 +559,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <https://linked.data.g​ov.au/org/gswa>
     a schema:Organization ;
     schema:name "Geological Survey of Western Australia" ;
-    schema:url ""^^xsd:anyURI ;
+    schema:url "https://www.dmp.wa.gov.au/Geological-Survey/Geological-Survey-262.aspx"^^xsd:anyURI ;
 .
 
 cs:
@@ -605,7 +605,6 @@ cs:
                 [
                     a schema:Organization ;
                     schema:name "Angela Riganti" ;
-                    schema:url ""^^xsd:anyURI ;
                 ] ;
         ] ;
     schema:creator <https://linked.data.g​ov.au/org/gswa> ;

--- a/vocabularies/location-method.ttl
+++ b/vocabularies/location-method.ttl
@@ -594,16 +594,15 @@ cs:
             dcat:hadRole isoroles:custodian ;
             prov:agent
                 [
-                    a schema:Organization ;
+                    a schema:Person ;
                     schema:name "Terry Farrell" ;
-                    schema:url ""^^xsd:anyURI ;
                 ] ;
         ] ,
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent
                 [
-                    a schema:Organization ;
+                    a schema:Person ;
                     schema:name "Angela Riganti" ;
                 ] ;
         ] ;

--- a/vocabularies/location-method.ttl
+++ b/vocabularies/location-method.ttl
@@ -595,6 +595,7 @@ cs:
             prov:agent
                 [
                     a schema:Person ;
+                    schema:email ""^^xsd:anyURI ;
                     schema:name "Terry Farrell" ;
                 ] ;
         ] ,
@@ -603,6 +604,7 @@ cs:
             prov:agent
                 [
                     a schema:Person ;
+                    schema:email ""^^xsd:anyURI ;
                     schema:name "Angela Riganti" ;
                 ] ;
         ] ;

--- a/vocabularies/metamorphic-P-T-trajectory.ttl
+++ b/vocabularies/metamorphic-P-T-trajectory.ttl
@@ -8,7 +8,7 @@ PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX reg: <http://purl.org/linked-data/registry#>
-PREFIX sdo: <https://schema.org/>
+PREFIX schema: <https://schema.org/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
@@ -172,9 +172,9 @@ c) Harley, SL 1989, The origins of granulites: a metamorphic perspective: Geolog
 .
 
 <https://linked.data.gov.au/org/gswa>
-    a sdo:Organization ;
-    sdo:name "Geological Survey of Western Australia" ;
-    sdo:url "https://dmp.wa.gov.au/Geological-Survey/Geological-Survey-262.aspx"^^xsd:anyURI ;
+    a schema:Organization ;
+    schema:name "Geological Survey of Western Australia" ;
+    schema:url "https://dmp.wa.gov.au/Geological-Survey/Geological-Survey-262.aspx"^^xsd:anyURI ;
 .
 
 cs:
@@ -210,15 +210,17 @@ d) https://en.wikipedia.org/wiki/Pressure-temperature-time_path."""@en ;
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    schema:Person
-                    sdo:name "Fawna Korhonen" ;
+                    a schema:Person ;
+                    schema:email ""^^xsd:anyURI ;
+                    schema:name "Fawna Korhonen" ;
                 ]
         ] ,
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    schema:Person
-                    sdo:name "Dave Kelsey" ;
+                    a schema:Person ;
+                    schema:email ""^^xsd:anyURI ;
+                    schema:name "Dave Kelsey" ;
                 ]
         ] ;
 .

--- a/vocabularies/metamorphic-P-T-trajectory.ttl
+++ b/vocabularies/metamorphic-P-T-trajectory.ttl
@@ -210,14 +210,14 @@ d) https://en.wikipedia.org/wiki/Pressure-temperature-time_path."""@en ;
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    a prov:Agent ;
+                    schema:Person
                     sdo:name "Fawna Korhonen" ;
                 ]
         ] ,
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    a prov:Agent ;
+                    schema:Person
                     sdo:name "Dave Kelsey" ;
                 ]
         ] ;

--- a/vocabularies/metamorphic-facies.ttl
+++ b/vocabularies/metamorphic-facies.ttl
@@ -273,14 +273,14 @@ cs:
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    a prov:Agent ;
+                    schema:Person
                     sdo:name "Dave Kelsey" ;
                 ]
         ] ,
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    a prov:Agent ;
+                    schema:Person
                     sdo:name "Fawna Korhonen" ;
                 ]
         ] ;

--- a/vocabularies/metamorphic-facies.ttl
+++ b/vocabularies/metamorphic-facies.ttl
@@ -8,7 +8,7 @@ PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX reg: <http://purl.org/linked-data/registry#>
-PREFIX sdo: <https://schema.org/>
+PREFIX schema: <https://schema.org/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
@@ -235,9 +235,9 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 .
 
 <https://linked.data.gov.au/org/gswa>
-    a sdo:Organization ;
-    sdo:name "Geological Survey of Western Australia" ;
-    sdo:url "https://dmp.wa.gov.au/Geological-Survey/Geological-Survey-262.aspx"^^xsd:anyURI ;
+    a schema:Organization ;
+    schema:name "Geological Survey of Western Australia" ;
+    schema:url "https://dmp.wa.gov.au/Geological-Survey/Geological-Survey-262.aspx"^^xsd:anyURI ;
 .
 
 cs:
@@ -273,15 +273,17 @@ cs:
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    schema:Person
-                    sdo:name "Dave Kelsey" ;
+                    a schema:Person ;
+                    schema:email ""^^xsd:anyURI ;
+                    schema:name "Dave Kelsey" ;
                 ]
         ] ,
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    schema:Person
-                    sdo:name "Fawna Korhonen" ;
+                    a schema:Person ;
+                    schema:email ""^^xsd:anyURI ;
+                    schema:name "Fawna Korhonen" ;
                 ]
         ] ;
 .

--- a/vocabularies/metamorphic-stage.ttl
+++ b/vocabularies/metamorphic-stage.ttl
@@ -146,14 +146,14 @@ Fettes, D and Desmons, J (eds.) 2007, Metamorphic Rocks: a classification and gl
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    a prov:Agent ;
+                    schema:Person
                     sdo:name "Fawna Korhonen" ;
                 ]
         ] ,
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    a prov:Agent ;
+                    schema:Person
                     sdo:name "Dave Kelsey" ;
                 ]
         ] ;

--- a/vocabularies/metamorphic-stage.ttl
+++ b/vocabularies/metamorphic-stage.ttl
@@ -8,7 +8,7 @@ PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX reg: <http://purl.org/linked-data/registry#>
-PREFIX sdo: <https://schema.org/>
+PREFIX schema: <https://schema.org/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
@@ -114,9 +114,9 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 .
 
 <https://linked.data.gov.au/org/gswa>
-    a sdo:Organization ;
-    sdo:name "Geological Survey of Western Australia" ;
-    sdo:url "https://dmp.wa.gov.au/Geological-Survey/Geological-Survey-262.aspx"^^xsd:anyURI ;
+    a schema:Organization ;
+    schema:name "Geological Survey of Western Australia" ;
+    schema:url "https://dmp.wa.gov.au/Geological-Survey/Geological-Survey-262.aspx"^^xsd:anyURI ;
 .
 
 cs:
@@ -146,15 +146,17 @@ Fettes, D and Desmons, J (eds.) 2007, Metamorphic Rocks: a classification and gl
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    schema:Person
-                    sdo:name "Fawna Korhonen" ;
+                    a schema:Person ;
+                    schema:email ""^^xsd:anyURI ;
+                    schema:name "Fawna Korhonen" ;
                 ]
         ] ,
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    schema:Person
-                    sdo:name "Dave Kelsey" ;
+                    a schema:Person ;
+                    schema:email ""^^xsd:anyURI ;
+                    schema:name "Dave Kelsey" ;
                 ]
         ] ;
 .

--- a/vocabularies/metamorphic-thermal-regime-style.ttl
+++ b/vocabularies/metamorphic-thermal-regime-style.ttl
@@ -8,7 +8,7 @@ PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX reg: <http://purl.org/linked-data/registry#>
-PREFIX sdo: <https://schema.org/>
+PREFIX schema: <https://schema.org/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
@@ -111,9 +111,9 @@ c) Brown, M and Johnson, T 2018, Secular change in metamorphism and the onset of
 .
 
 <https://linked.data.gov.au/org/gswa>
-    a sdo:Organization ;
-    sdo:name "Geological Survey of Western Australia" ;
-    sdo:url "https://dmp.wa.gov.au/Geological-Survey/Geological-Survey-262.aspx"^^xsd:anyURI ;
+    a schema:Organization ;
+    schema:name "Geological Survey of Western Australia" ;
+    schema:url "https://dmp.wa.gov.au/Geological-Survey/Geological-Survey-262.aspx"^^xsd:anyURI ;
 .
 
 cs:
@@ -144,15 +144,17 @@ c) Stüwe, K 2007, Geodynamics of the lithosphere: An introduction: Springer, Be
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    schema:Person
-                    sdo:name "Dave Kelsey" ;
+                    a schema:Person ;
+                    schema:email ""^^xsd:anyURI ;
+                    schema:name "Dave Kelsey" ;
                 ]
         ] ,
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    schema:Person
-                    sdo:name "Fawna Korhonen" ;
+                    a schema:Person ;
+                    schema:email ""^^xsd:anyURI ;
+                    schema:name "Fawna Korhonen" ;
                 ]
         ] ;
 .

--- a/vocabularies/metamorphic-thermal-regime-style.ttl
+++ b/vocabularies/metamorphic-thermal-regime-style.ttl
@@ -144,14 +144,14 @@ c) Stüwe, K 2007, Geodynamics of the lithosphere: An introduction: Springer, Be
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    a prov:Agent ;
+                    schema:Person
                     sdo:name "Dave Kelsey" ;
                 ]
         ] ,
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    a prov:Agent ;
+                    schema:Person
                     sdo:name "Fawna Korhonen" ;
                 ]
         ] ;

--- a/vocabularies/physiographic-unit-types.ttl
+++ b/vocabularies/physiographic-unit-types.ttl
@@ -8,7 +8,7 @@ PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX reg: <http://purl.org/linked-data/registry#>
-PREFIX sdo: <https://schema.org/>
+PREFIX schema: <https://schema.org/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
@@ -46,9 +46,9 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 .
 
 <https://linked.data.gov.au/org/gswa>
-    a sdo:Organization ;
-    sdo:name "Geological Survey of Western Australia" ;
-    sdo:url "https://dmp.wa.gov.au/Geological-Survey/Geological-Survey-262.aspx"^^xsd:anyURI ;
+    a schema:Organization ;
+    schema:name "Geological Survey of Western Australia" ;
+    schema:url "https://dmp.wa.gov.au/Geological-Survey/Geological-Survey-262.aspx"^^xsd:anyURI ;
 .
 
 cs:
@@ -73,15 +73,17 @@ cs:
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    schema:Person
-                    sdo:name "Erin Gray" ;
+                    a schema:Person ;
+                    schema:email ""^^xsd:anyURI ;
+                    schema:name "Erin Gray" ;
                 ]
         ] ,
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    schema:Person
-                    sdo:name "Angela Riganti" ;
+                    a schema:Person ;
+                    schema:email ""^^xsd:anyURI ;
+                    schema:name "Angela Riganti" ;
                 ]
         ] ;
 .

--- a/vocabularies/physiographic-unit-types.ttl
+++ b/vocabularies/physiographic-unit-types.ttl
@@ -73,14 +73,14 @@ cs:
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    a prov:Agent ;
+                    schema:Person
                     sdo:name "Erin Gray" ;
                 ]
         ] ,
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    a prov:Agent ;
+                    schema:Person
                     sdo:name "Angela Riganti" ;
                 ]
         ] ;

--- a/vocabularies/tectonic-unit-type.ttl
+++ b/vocabularies/tectonic-unit-type.ttl
@@ -8,7 +8,7 @@ PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX reg: <http://purl.org/linked-data/registry#>
-PREFIX sdo: <https://schema.org/>
+PREFIX schema: <https://schema.org/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
@@ -290,9 +290,9 @@ Korsch, RJ and Doublier, MP, 2016, Major crustal boundaries of Australia, and th
 .
 
 <https://linked.data.gov.au/org/gswa>
-    a sdo:Organization ;
-    sdo:name "Geological Survey of Western Australia" ;
-    sdo:url "https://dmp.wa.gov.au/Geological-Survey/Geological-Survey-262.aspx"^^xsd:anyURI ;
+    a schema:Organization ;
+    schema:name "Geological Survey of Western Australia" ;
+    schema:url "https://dmp.wa.gov.au/Geological-Survey/Geological-Survey-262.aspx"^^xsd:anyURI ;
 .
 
 cs:
@@ -335,15 +335,17 @@ The concepts outline the type of tectonic elements that are recognized and/or in
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    schema:Person
-                    sdo:name "Erin Gray" ;
+                    a schema:Person ;
+                    schema:email ""^^xsd:anyURI ;
+                    schema:name "Erin Gray" ;
                 ]
         ] ,
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    schema:Person
-                    sdo:name "Angela Riganti" ;
+                    a schema:Person ;
+                    schema:email ""^^xsd:anyURI ;
+                    schema:name "Angela Riganti" ;
                 ]
         ] ;
 .

--- a/vocabularies/tectonic-unit-type.ttl
+++ b/vocabularies/tectonic-unit-type.ttl
@@ -335,14 +335,14 @@ The concepts outline the type of tectonic elements that are recognized and/or in
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    a prov:Agent ;
+                    schema:Person
                     sdo:name "Erin Gray" ;
                 ]
         ] ,
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    a prov:Agent ;
+                    schema:Person
                     sdo:name "Angela Riganti" ;
                 ]
         ] ;

--- a/vocabularies/wa-coordinate-reference-system.ttl
+++ b/vocabularies/wa-coordinate-reference-system.ttl
@@ -8,7 +8,7 @@ PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX reg: <http://purl.org/linked-data/registry#>
-PREFIX sdo: <https://schema.org/>
+PREFIX schema: <https://schema.org/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
@@ -708,9 +708,9 @@ Note EPGS registry""" ;
 .
 
 <https://linked.data.gov.au/org/gswa>
-    a sdo:Organization ;
-    sdo:name "Geological Survey of Western Australia" ;
-    sdo:url "https://dmp.wa.gov.au/Geological-Survey/Geological-Survey-262.aspx"^^xsd:anyURI ;
+    a schema:Organization ;
+    schema:name "Geological Survey of Western Australia" ;
+    schema:url "https://dmp.wa.gov.au/Geological-Survey/Geological-Survey-262.aspx"^^xsd:anyURI ;
 .
 
 cs:
@@ -744,15 +744,17 @@ cs:
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    schema:Person
-                    sdo:name "Erin Gray" ;
+                    a schema:Person ;
+                    schema:email ""^^xsd:anyURI ;
+                    schema:name "Erin Gray" ;
                 ]
         ] ,
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    schema:Person
-                    sdo:name "Angela Riganti" ;
+                    a schema:Person ;
+                    schema:email ""^^xsd:anyURI ;
+                    schema:name "Angela Riganti" ;
                 ]
         ] ;
 .

--- a/vocabularies/wa-coordinate-reference-system.ttl
+++ b/vocabularies/wa-coordinate-reference-system.ttl
@@ -744,14 +744,14 @@ cs:
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    a prov:Agent ;
+                    schema:Person
                     sdo:name "Erin Gray" ;
                 ]
         ] ,
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    a prov:Agent ;
+                    schema:Person
                     sdo:name "Angela Riganti" ;
                 ]
         ] ;

--- a/vocabularies/wa-mineral-fields-and-districts.ttl
+++ b/vocabularies/wa-mineral-fields-and-districts.ttl
@@ -945,14 +945,14 @@ cs:
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    a prov:Agent ;
+                    schema:Person
                     sdo:name "Erin Gray" ;
                 ]
         ] ,
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    a prov:Agent ;
+                    schema:Person
                     sdo:name "Angela Riganti" ;
                 ]
         ] ;

--- a/vocabularies/wa-mineral-fields-and-districts.ttl
+++ b/vocabularies/wa-mineral-fields-and-districts.ttl
@@ -8,7 +8,7 @@ PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX reg: <http://purl.org/linked-data/registry#>
-PREFIX sdo: <https://schema.org/>
+PREFIX schema: <https://schema.org/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
@@ -898,9 +898,9 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 .
 
 <https://linked.data.gov.au/org/gswa>
-    a sdo:Organization ;
-    sdo:name "Geological Survey of Western Australia" ;
-    sdo:url "https://dmp.wa.gov.au/Geological-Survey/Geological-Survey-262.aspx"^^xsd:anyURI ;
+    a schema:Organization ;
+    schema:name "Geological Survey of Western Australia" ;
+    schema:url "https://dmp.wa.gov.au/Geological-Survey/Geological-Survey-262.aspx"^^xsd:anyURI ;
 .
 
 cs:
@@ -945,15 +945,17 @@ cs:
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    schema:Person
-                    sdo:name "Erin Gray" ;
+                    a schema:Person ;
+                    schema:email ""^^xsd:anyURI ;
+                    schema:name "Erin Gray" ;
                 ]
         ] ,
         [
             dcat:hadRole isoroles:custodian ;
             prov:agent [
-                    schema:Person
-                    sdo:name "Angela Riganti" ;
+                    a schema:Person ;
+                    schema:email ""^^xsd:anyURI ;
+                    schema:name "Angela Riganti" ;
                 ]
         ] ;
 .


### PR DESCRIPTION
In a few placers, GSWA is labelled as `Gswa`, rather than `Geological Survey of Western Australia`. This PR fixes that.

Also tidies up bad URLs for orgs & people