### PR TITLE
Fix odd chars

### DIFF
--- a/vocabularies/GSWA-rock-classification-scheme.ttl
+++ b/vocabularies/GSWA-rock-classification-scheme.ttl
@@ -8157,10 +8157,10 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     skos:topConceptOf cs: ;
 .
 
-<https://linked.data.g​ov.au/org/gswa>
+<https://linked.data.gov.au/org/gswa>
     a schema:Organization ;
-    schema:name "Gswa" ;
-    schema:url ""^^xsd:anyURI ;
+    schema:name "Geological Survey of Western Australia" ;
+    schema:url "https://dmp.wa.gov.au/Geological-Survey/Geological-Survey-262.aspx"^^xsd:anyURI ;
 .
 
 :arkose
@@ -9855,9 +9855,9 @@ MAIN REFERENCES used for compilation:
                     schema:name "David Martin" ;
                 ] ;
         ] ;
-    schema:creator <https://linked.data.g​ov.au/org/gswa> ;
+    schema:creator <https://linked.data.gov.au/org/gswa> ;
     schema:dateCreated "2024-06-28"^^xsd:date ;
     schema:dateModified "2024-07-12"^^xsd:date ;
-    schema:publisher <https://linked.data.g​ov.au/org/gswa> ;
+    schema:publisher <https://linked.data.gov.au/org/gswa> ;
     schema:version "1" ;
 .

--- a/vocabularies/GSWA-rock-classification-scheme.ttl
+++ b/vocabularies/GSWA-rock-classification-scheme.ttl
@@ -21,7 +21,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-felsic-intrusive ;
-    skos:definition "A special term for a variety of granite in which plagioclase is less than 10% of the total feldspar. Now defined modally in QAPF field 2 (Fig. 2.4, p. 22). (Le Maitre et al., 2005, p. 52)"@en ;
+    skos:definition "A special term for a variety of granite in which plagioclase is less than 10% of the total feldspar. Now defined modally in QAPF field 2 (Fig. 2.4, p. 22). (Le Maitre et al., 2005, p. 52)"@en ;
     skos:exactMatch
         <http://inspire.ec.europa.eu/codelist/LithologyValue/alkaliFeldsparGranite> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/alkali_feldspar_granite> ;
@@ -36,7 +36,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-felsic-intrusive ;
-    skos:definition "A special term for a variety of syenite in which plagioclase is less than 10% of the total feldspar. Now defined modally in QAPF field 6 (Fig. 2.4, p. 22). (Le Maitre et al., 2005, p. 52)"@en ;
+    skos:definition "A special term for a variety of syenite in which plagioclase is less than 10% of the total feldspar. Now defined modally in QAPF field 6 (Fig. 2.4, p. 22). (Le Maitre et al., 2005, p. 52)"@en ;
     skos:exactMatch
         <http://inspire.ec.europa.eu/codelist/LithologyValue/alkaliFeldsparSyenite> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/alkali_feldspar_syenite> ;
@@ -51,7 +51,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-mafic ;
-    skos:definition "Gneissose or granofelsic metamorphic rock mainly consisting of green, brown or black amphibole and plagioclase (including albite) and derived from an unspecified intrusive, extrusive or volcaniclastic protolith. Amphibole and plagioclase combined form more than 75% of the rock, with both being present as major constituents; the amphibole constitutes more than 50% of the total mafic constituents and is present in an amount of ≥30%. Other common minerals include quartz, clinopyroxene, garnet, epidote-group minerals, biotite, titanite and scapolite. Amphibolites are mostly present in amphibolite-facies metamorphic complexes, or in the highest subfacies of the greenschist facies. Adapted from Fettes and Desmons (2007, p. 128)."@en ;
+    skos:definition "Gneissose or granofelsic metamorphic rock mainly consisting of green, brown or black amphibole and plagioclase (including albite) and derived from an unspecified intrusive, extrusive or volcaniclastic protolith. Amphibole and plagioclase combined form more than 75% of the rock, with both being present as major constituents; the amphibole constitutes more than 50% of the total mafic constituents and is present in an amount of ≥30%. Other common minerals include quartz, clinopyroxene, garnet, epidote-group minerals, biotite, titanite and scapolite. Amphibolites are mostly present in amphibolite-facies metamorphic complexes, or in the highest subfacies of the greenschist facies. Adapted from Fettes and Desmons (2007, p. 128)."@en ;
     skos:exactMatch
         <http://inspire.ec.europa.eu/codelist/LithologyValue/amphibolite> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/amphibolite> ;
@@ -66,7 +66,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-mafic-intrusive ;
-    skos:definition "Gneissose or granofelsic metamorphic rock mainly consisting of green, brown or black amphibole and plagioclase (including albite) and derived from an intrusive protolith. Amphibole and plagioclase combined form more than 75% of the rock, with both being present as major constituents; the amphibole constitutes more than 50% of the total mafic constituents and is present in an amount greater than or equal to 30%. Other common minerals include quartz, clinopyroxene, garnet, epidote-group minerals, biotite, titanite and scapolite. Amphibolites are mostly present in amphibolite-facies metamorphic complexes, or in the highest subfacies of the greenschist facies. Adapted from Fettes and Desmons (2007, p. 128)."@en ;
+    skos:definition "Gneissose or granofelsic metamorphic rock mainly consisting of green, brown or black amphibole and plagioclase (including albite) and derived from an intrusive protolith. Amphibole and plagioclase combined form more than 75% of the rock, with both being present as major constituents; the amphibole constitutes more than 50% of the total mafic constituents and is present in an amount greater than or equal to 30%. Other common minerals include quartz, clinopyroxene, garnet, epidote-group minerals, biotite, titanite and scapolite. Amphibolites are mostly present in amphibolite-facies metamorphic complexes, or in the highest subfacies of the greenschist facies. Adapted from Fettes and Desmons (2007, p. 128)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:notation "moa"^^:GSWA-rock-code ;
@@ -77,7 +77,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-mafic-volcanic ;
-    skos:definition "Gneissose or granofelsic metamorphic rock mainly consisting of green, brown or black amphibole and plagioclase (including albite) and derived from a volcanic protolith. Amphibole and plagioclase combined form more than 75% of the rock, with both being present as major constituents; the amphibole constitutes more than 50% of the total mafic constituents and is present in an amount of greater or equal to 30%. Other common minerals include quartz, clinopyroxene, garnet, epidote-group minerals, biotite, titanite and scapolite. Amphibolites are mostly present in amphibolite-facies metamorphic complexes, or in the highest subfacies of the greenschist facies. Adapted from Fettes and Desmons (2007, p. 128). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
+    skos:definition "Gneissose or granofelsic metamorphic rock mainly consisting of green, brown or black amphibole and plagioclase (including albite) and derived from a volcanic protolith. Amphibole and plagioclase combined form more than 75% of the rock, with both being present as major constituents; the amphibole constitutes more than 50% of the total mafic constituents and is present in an amount of greater or equal to 30%. Other common minerals include quartz, clinopyroxene, garnet, epidote-group minerals, biotite, titanite and scapolite. Amphibolites are mostly present in amphibolite-facies metamorphic complexes, or in the highest subfacies of the greenschist facies. Adapted from Fettes and Desmons (2007, p. 128). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:notation "mba"^^:GSWA-rock-code ;
@@ -100,7 +100,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metamorphic-protolith-unknown-gneiss ;
-    skos:definition "A gneiss distinguished by the abundance of amphiboles. In GSWA usage, this term is reserved for a gneiss for which a protolith cannot be conclusively established. See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
+    skos:definition "A gneiss distinguished by the abundance of amphiboles. In GSWA usage, this term is reserved for a gneiss for which a protolith cannot be conclusively established. See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007) and GSWA usage." ;
     skos:inScheme cs: ;
     skos:notation "mna"^^:GSWA-rock-code ;
@@ -134,7 +134,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-felsic-volcanic ;
-    skos:definition "An intermediate volcanic rock, usually porphyritic, consisting of plagioclase (frequently zoned from labradorite to oligoclase), pyroxene, hornblende and/or biotite. Now defined modally in QAPF fields 9 and 10 (Fig. 2.11, p. 31) and, if modes are not available, chemically in TAS field O2 (Fig. 2.14, p. 35). Definition from Le Maitre et al. (2005, p. 56). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
+    skos:definition "An intermediate volcanic rock, usually porphyritic, consisting of plagioclase (frequently zoned from labradorite to oligoclase), pyroxene, hornblende and/or biotite. Now defined modally in QAPF fields 9 and 10 (Fig. 2.11, p. 31) and, if modes are not available, chemically in TAS field O2 (Fig. 2.14, p. 35). Definition from Le Maitre et al. (2005, p. 56). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
     skos:exactMatch
         <http://inspire.ec.europa.eu/codelist/LithologyValue/andesite> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/andesite> ;
@@ -163,7 +163,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     rdfs:isDefinedBy cs: ;
     skos:altLabel "plagioclasite"@en ;
     skos:broader :igneous-mafic-intrusive ;
-    skos:definition "A leucocratic intrusive rock consisting essentially of plagioclase commonly with small amounts of pyroxene. Now defined modally in QAPF field 10 (Fig. 2.4, p. 22). The term is synonymous with plagioclasite. (Le Maitre et al., 2005, p. 57)"@en ;
+    skos:definition "A leucocratic intrusive rock consisting essentially of plagioclase commonly with small amounts of pyroxene. Now defined modally in QAPF field 10 (Fig. 2.4, p. 22). The term is synonymous with plagioclasite. (Le Maitre et al., 2005, p. 57)"@en ;
     skos:exactMatch
         <http://inspire.ec.europa.eu/codelist/LithologyValue/anorthosite> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/anorthosite> ;
@@ -186,7 +186,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:exactMatch
         <http://inspire.ec.europa.eu/codelist/LithologyValue/anthraciteCoal> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/anthracite_coal> ;
-    skos:historyNote "Forsman, JP and Hunt, JM 1958, Insoluble organic matter (kerogen) in sedimentary rocks: Geochimica et Cosmochimica Acta, v. 15(3), p. 170–182, doi.org/10.1016/0016-7037(58)90055-3." ;
+    skos:historyNote "Forsman, JP and Hunt, JM 1958, Insoluble organic matter (kerogen) in sedimentary rocks: Geochimica et Cosmochimica Acta, v. 15(3), p. 170–182, doi.org/10.1016/0016-7037(58)90055-3." ;
     skos:inScheme cs: ;
     skos:notation "coh"^^:GSWA-rock-code ;
     skos:prefLabel "anthracite"@en ;
@@ -198,8 +198,8 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     rdfs:isDefinedBy cs: ;
     skos:altLabel "BIF"@en ;
     skos:broader :iron-formation ;
-    skos:definition "Banded iron-formation (BIF) is an iron formation that shows marked banding, generally of iron-rich minerals and chert or fine-grained quartz. Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
-    skos:historyNote "Beukes, NJ and Gutzmer, J 2008, Origin and paleoenvironmental significance of major iron formations at the Archean-Paleoproterozoic boundary: Reviews in Economic Geology, v. 15, p. 5–47, doi:10.5382/Rev.15.01." ;
+    skos:definition "Banded iron-formation (BIF) is an iron formation that shows marked banding, generally of iron-rich minerals and chert or fine-grained quartz. Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
+    skos:historyNote "Beukes, NJ and Gutzmer, J 2008, Origin and paleoenvironmental significance of major iron formations at the Archean-Paleoproterozoic boundary: Reviews in Economic Geology, v. 15, p. 5–47, doi:10.5382/Rev.15.01." ;
     skos:inScheme cs: ;
     skos:notation "cib"^^:GSWA-rock-code ;
     skos:prefLabel "banded iron-formation"@en ;
@@ -233,7 +233,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-mafic-volcanic ;
-    skos:definition "A dark-coloured volcanic rock consisting essentially of calcic plagioclase and pyroxene. Olivine and minor foids or minor interstitial quartz may also be present. Now defined modally in QAPF fields 9 and 10 (Fig. 2.11, p. 31) and, if modes are not available, chemically in TAS field B (Fig. 2.14, p. 35). Definition from Le Maitre et al. (2005, p. 60). The GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
+    skos:definition "A dark-coloured volcanic rock consisting essentially of calcic plagioclase and pyroxene. Olivine and minor foids or minor interstitial quartz may also be present. Now defined modally in QAPF fields 9 and 10 (Fig. 2.11, p. 31) and, if modes are not available, chemically in TAS field B (Fig. 2.14, p. 35). Definition from Le Maitre et al. (2005, p. 60). The GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
     skos:exactMatch
         <http://inspire.ec.europa.eu/codelist/LithologyValue/basalt> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/basalt> ;
@@ -248,7 +248,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-mafic-volcanic ;
-    skos:definition "A volcanic rock with plagioclase of variable composition and the ferromagnesian minerals more commonly found in basalts, e.g. olivine. Now defined chemically in TAS field O1. Definition from Le Maitre et al. (2005, p. 61). The GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
+    skos:definition "A volcanic rock with plagioclase of variable composition and the ferromagnesian minerals more commonly found in basalts, e.g. olivine. Now defined chemically in TAS field O1. Definition from Le Maitre et al. (2005, p. 61). The GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "bd"^^:GSWA-rock-code ;
@@ -263,11 +263,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         "black coal"@en ,
         "soft coal"@en ;
     skos:broader :coal ;
-    skos:definition "Coal that ranks between sub-bituminous coal and anthracite, contains more than 14% volatile matter (on a dry, ash-free basis) and has a calorific value of more than 11,500 BTU/lb (26.75 MJ/kg) (moist, mineral-matter-free) or more than 10 500 BTU/lb (24.42 MJ/kg) if agglomerating. It is dark brown to black in colour and burns with a smoky flame. Bituminous coal is the most abundant rank of coal. Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
+    skos:definition "Coal that ranks between sub-bituminous coal and anthracite, contains more than 14% volatile matter (on a dry, ash-free basis) and has a calorific value of more than 11,500 BTU/lb (26.75 MJ/kg) (moist, mineral-matter-free) or more than 10 500 BTU/lb (24.42 MJ/kg) if agglomerating. It is dark brown to black in colour and burns with a smoky flame. Bituminous coal is the most abundant rank of coal. Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
     skos:exactMatch
         <http://inspire.ec.europa.eu/codelist/LithologyValue/bituminousCoal> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/bituminous_coal> ;
-    skos:historyNote "Forsman, JP and Hunt, JM 1958, Insoluble organic matter (kerogen) in sedimentary rocks: Geochimica et Cosmochimica Acta, v. 15(3), p. 170–182, doi.org/10.1016/0016-7037(58)90055-3." ;
+    skos:historyNote "Forsman, JP and Hunt, JM 1958, Insoluble organic matter (kerogen) in sedimentary rocks: Geochimica et Cosmochimica Acta, v. 15(3), p. 170–182, doi.org/10.1016/0016-7037(58)90055-3." ;
     skos:inScheme cs: ;
     skos:notation "coc"^^:GSWA-rock-code ;
     skos:prefLabel "bituminous coal"@en ;
@@ -278,7 +278,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metamorphic-protolith-unknown-fault-rock ;
-    skos:definition "Fault rock that is cohesive and characterized by a well-developed schistosity resulting from tectonic reduction of grain size for more than 90% of the rock volume, and displays a significant degree of grain growth related to or following deformation. Definition adapted from Fossen (2016) and Fettes and Desmons (2007, p. 134)."@en ;
+    skos:definition "Fault rock that is cohesive and characterized by a well-developed schistosity resulting from tectonic reduction of grain size for more than 90% of the rock volume, and displays a significant degree of grain growth related to or following deformation. Definition adapted from Fossen (2016) and Fettes and Desmons (2007, p. 134)."@en ;
     skos:historyNote "Fossen, H 2016, Structural geology (2nd edition): Cambridge University Press, Cambridge, United Kingdom, 524p." ;
     skos:inScheme cs: ;
     skos:notation "myn"^^:GSWA-rock-code ;
@@ -303,8 +303,8 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     rdfs:isDefinedBy cs: ;
     skos:altLabel "boulderstone"@en ;
     skos:broader :conglomerate ;
-    skos:definition "A consolidated rock consisting mainly of boulders (clasts greater than 256 mm or -8 phi units in size). Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
-    skos:historyNote "Wentworth, CK 1922, A scale of grade and class terms for clastic sediments: The Journal of Geology, v. 30, no. 5, p. 377–392, doi:10.1086/622910." ;
+    skos:definition "A consolidated rock consisting mainly of boulders (clasts greater than 256 mm or -8 phi units in size). Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
+    skos:historyNote "Wentworth, CK 1922, A scale of grade and class terms for clastic sediments: The Journal of Geology, v. 30, no. 5, p. 377–392, doi:10.1086/622910." ;
     skos:inScheme cs: ;
     skos:notation "sb"^^:GSWA-rock-code ;
     skos:prefLabel "boulder conglomerate"@en ;
@@ -315,7 +315,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :calc-silicate-rock ;
-    skos:definition "A gneissose rock mainly composed of calc-silicate minerals (i.e. calcium-rich silicate minerals) and containing less than 5% volume of carbonate minerals (calcite and/or aragonite and/or dolomite). Adapted from Fettes and Desmons (2007, p. 137)."@en ;
+    skos:definition "A gneissose rock mainly composed of calc-silicate minerals (i.e. calcium-rich silicate minerals) and containing less than 5% volume of carbonate minerals (calcite and/or aragonite and/or dolomite). Adapted from Fettes and Desmons (2007, p. 137)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:notation "mkqn"^^:GSWA-rock-code ;
@@ -327,7 +327,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     rdfs:isDefinedBy cs: ;
     skos:altLabel "tactite"@en ;
     skos:broader :calc-silicate-rock ;
-    skos:definition "A granofels/hornfels mainly composed of calc-silicate minerals (i.e. calcium-rich silicate minerals) and containing less than 5% volume of carbonate minerals (calcite and/or aragonite and/or dolomite) (adapted from Fettes and Desmons, 2007, p. 137). A calc-silicate rock formed by contact metasomatism of a carbonate or marly rock (i.e. a calc-silicate hornfels) is also referred to as tactite (Fettes and Desmons, 2007, p. 199)."@en ;
+    skos:definition "A granofels/hornfels mainly composed of calc-silicate minerals (i.e. calcium-rich silicate minerals) and containing less than 5% volume of carbonate minerals (calcite and/or aragonite and/or dolomite) (adapted from Fettes and Desmons, 2007, p. 137). A calc-silicate rock formed by contact metasomatism of a carbonate or marly rock (i.e. a calc-silicate hornfels) is also referred to as tactite (Fettes and Desmons, 2007, p. 199)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:notation "mkqe"^^:GSWA-rock-code ;
@@ -351,7 +351,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:altLabel "calcareous sandstone"@en ;
     skos:broader :limestone ;
     skos:definition "A limestone consisting predominantly (more than 50%) of sand-size, detrital carbonate grains; a consolidated calcareous sand. The term was introduced by Grabau (1903). (Glossary of geology, 5th edition revised; Neuendorf et al., 2011)"@en ;
-    skos:historyNote "Grabau, AW 1903, Paleozoic coral reefs: Geological Society of America Bulletin, v. 14, p. 337–352." ;
+    skos:historyNote "Grabau, AW 1903, Paleozoic coral reefs: Geological Society of America Bulletin, v. 14, p. 337–352." ;
     skos:inScheme cs: ;
     skos:notation "kla"^^:GSWA-rock-code ;
     skos:prefLabel "calcarenite"@en ;
@@ -378,7 +378,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         "micritic limestone"@en ;
     skos:broader :limestone ;
     skos:definition "A limestone consisting predominantly (more than 50%) of detrital calcite particles of silt and/or clay size; a consolidated carbonate mud. The term was introduced by Grabau (1903). Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
-    skos:historyNote "Grabau, AW 1903, Paleozoic coral reefs: Geological Society of America Bulletin, v. 14, p. 337–352." ;
+    skos:historyNote "Grabau, AW 1903, Paleozoic coral reefs: Geological Society of America Bulletin, v. 14, p. 337–352." ;
     skos:inScheme cs: ;
     skos:notation "kll"^^:GSWA-rock-code ;
     skos:prefLabel "calcilutite"@en ;
@@ -390,7 +390,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     rdfs:isDefinedBy cs: ;
     skos:broader :limestone ;
     skos:definition "A limestone consisting predominantly (more than 50%) of detrital calcite particles larger than sand size (larger than 2 mm in diameter), and commonly also cemented with calcareous material; a consolidated calcareous gravel or rubble, or a limestone conglomerate or breccia. The term was introduced by Grabau (1903). Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
-    skos:historyNote "Grabau, AW 1903, Paleozoic coral reefs: Geological Society of America Bulletin, v. 14, p. 337–352." ;
+    skos:historyNote "Grabau, AW 1903, Paleozoic coral reefs: Geological Society of America Bulletin, v. 14, p. 337–352." ;
     skos:inScheme cs: ;
     skos:notation "klr"^^:GSWA-rock-code ;
     skos:prefLabel "calcirudite"@en ;
@@ -404,7 +404,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         "alvikite"@en ,
         "sövite"@en ;
     skos:broader :igneous-carbonatite ;
-    skos:definition "A variety of carbonatite in which the main carbonate is calcite (section 2.3, p. 10). If the rock is coarse-grained it may be called sövite; if medium- to fine-grained, alvikite. Adapted from Le Maitre et al. (2005, p. 10, 66, 53 and 143)."@en ;
+    skos:definition "A variety of carbonatite in which the main carbonate is calcite (section 2.3, p. 10). If the rock is coarse-grained it may be called sövite; if medium- to fine-grained, alvikite. Adapted from Le Maitre et al. (2005, p. 10, 66, 53 and 143)."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "rc"^^:GSWA-rock-code ;
@@ -440,7 +440,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-lamprophyres ;
-    skos:definition "A variety of lamprophyre composed of phenocrysts of combinations of olivine, kaersutite, titanian augite, and Ti-rich biotite in a matrix of the same minerals (minus olivine) with plagioclase and sometimes subordinate alkali feldspar and feldspathoids. A volatile-rich basanite or alkali basalt. Now defined in the lamprophyre classification (Table 2.9, p. 19). (Le Maitre et al., 2005, p. 67)"@en ;
+    skos:definition "A variety of lamprophyre composed of phenocrysts of combinations of olivine, kaersutite, titanian augite, and Ti-rich biotite in a matrix of the same minerals (minus olivine) with plagioclase and sometimes subordinate alkali feldspar and feldspathoids. A volatile-rich basanite or alkali basalt. Now defined in the lamprophyre classification (Table 2.9, p. 19). (Le Maitre et al., 2005, p. 67)"@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "yc"^^:GSWA-rock-code ;
@@ -485,7 +485,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metamorphic-protolith-unknown-gneiss ;
-    skos:definition "A gneiss distinguished by the abundance of carbonate mineral phases. In GSWA usage, this term is reserved for a gneiss for which a protolith cannot be conclusively established. See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
+    skos:definition "A gneiss distinguished by the abundance of carbonate mineral phases. In GSWA usage, this term is reserved for a gneiss for which a protolith cannot be conclusively established. See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007) and GSWA usage." ;
     skos:inScheme cs: ;
     skos:notation "mnk"^^:GSWA-rock-code ;
@@ -519,7 +519,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metasedimentary-carbonate ;
-    skos:definition "A metamorphosed sedimentary carbonate rock displaying a granofelsic structure, i.e. a granofels/hornfels derived from a sedimentary rock consisting mostly of carbonates. See also definition of granofels/granofelsic structure in Fettes and Desmons (2007, p. 156); hornfels are granofels formed by contact metamorphism (Fettes and Desmons, 2007, p. 159)."@en ;
+    skos:definition "A metamorphosed sedimentary carbonate rock displaying a granofelsic structure, i.e. a granofels/hornfels derived from a sedimentary rock consisting mostly of carbonates. See also definition of granofels/granofelsic structure in Fettes and Desmons (2007, p. 156); hornfels are granofels formed by contact metamorphism (Fettes and Desmons, 2007, p. 159)."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "mke"^^:GSWA-rock-code ;
@@ -559,7 +559,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metamorphic-protolith-unknown-schist ;
-    skos:definition "A schist distinguished by the abundance of carbonate mineral phases. In GSWA usage, this term is reserved for a schist for which a protolith cannot be conclusively established. See also definition of schist/schistose structure in Fettes and Desmons, 2007, p. 193)."@en ;
+    skos:definition "A schist distinguished by the abundance of carbonate mineral phases. In GSWA usage, this term is reserved for a schist for which a protolith cannot be conclusively established. See also definition of schist/schistose structure in Fettes and Desmons, 2007, p. 193)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007) and GSWA usage." ;
     skos:inScheme cs: ;
     skos:notation "msk"^^:GSWA-rock-code ;
@@ -592,7 +592,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-carbonatite ;
-    skos:definition "A collective term for an igneous (intrusive, extrusive or volcaniclastic) rock in which the modal amount of primary carbonate minerals is greater than 50%, but otherwise uncategorized (section 2.3, p. 10). Adapted from Le Maitre et al. (2005, p. 68)."@en ;
+    skos:definition "A collective term for an igneous (intrusive, extrusive or volcaniclastic) rock in which the modal amount of primary carbonate minerals is greater than 50%, but otherwise uncategorized (section 2.3, p. 10). Adapted from Le Maitre et al. (2005, p. 68)."@en ;
     skos:exactMatch
         <http://inspire.ec.europa.eu/codelist/LithologyValue/carbonatite> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/carbonatite> ;
@@ -618,7 +618,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-carbonatite ;
-    skos:definition "A volcaniclastic rock composed mostly of angular fragments greater than 2 mm in size consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, with more than 50% modal carbonates. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
+    skos:definition "A volcaniclastic rock composed mostly of angular fragments greater than 2 mm in size consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, with more than 50% modal carbonates. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "rvb"^^:GSWA-rock-code ;
@@ -629,7 +629,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-carbonatite ;
-    skos:definition "A volcaniclastic rock composed mostly of angular fragments ranging in size from sand (0.0625 – 2 mm) and above, consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with more than 50% modal carbonates. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion w, and with an overall mafic composition."@en ;
+    skos:definition "A volcaniclastic rock composed mostly of angular fragments ranging in size from sand (0.0625 – 2 mm) and above, consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with more than 50% modal carbonates. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion w, and with an overall mafic composition."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "rvbs"^^:GSWA-rock-code ;
@@ -651,7 +651,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-carbonatite ;
-    skos:definition "A breccia composed mostly of angular fragments ranging in size from granule (2–4 mm) to pebble (4–32 mm) consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with more than 50% modal carbonates. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
+    skos:definition "A breccia composed mostly of angular fragments ranging in size from granule (2–4 mm) to pebble (4–32 mm) consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with more than 50% modal carbonates. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "rvg"^^:GSWA-rock-code ;
@@ -662,7 +662,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-carbonatite ;
-    skos:definition "A mudstone (grain size ranging from silt to clay (i.e. less than 0.0625 mm) consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with more than 50% modal carbonates. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
+    skos:definition "A mudstone (grain size ranging from silt to clay (i.e. less than 0.0625 mm) consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with more than 50% modal carbonates. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "rvsm"^^:GSWA-rock-code ;
@@ -684,7 +684,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-carbonatite ;
-    skos:definition "A sandstone (grain size 0.0625 – 2 mm) consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with more than 50% modal carbonates. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
+    skos:definition "A sandstone (grain size 0.0625 – 2 mm) consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with more than 50% modal carbonates. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "rvs"^^:GSWA-rock-code ;
@@ -695,7 +695,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-carbonatite ;
-    skos:definition "A volcaniclastic rock composed mostly of fragments ranging in size from sand (0.0625 – 2 mm) to silt (0.0039 – 0.0625 mm) of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with more than 50% modal carbonates. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
+    skos:definition "A volcaniclastic rock composed mostly of fragments ranging in size from sand (0.0625 – 2 mm) to silt (0.0039 – 0.0625 mm) of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with more than 50% modal carbonates. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "rvss"^^:GSWA-rock-code ;
@@ -706,7 +706,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-carbonatite ;
-    skos:definition "A commonly monomictic breccia with more than 50% modal carbonates composed of angular, coarse igneous fragments cemented by a fine-grained matrix that is clastic though not necessarily strictly sedimentary in origin. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
+    skos:definition "A commonly monomictic breccia with more than 50% modal carbonates composed of angular, coarse igneous fragments cemented by a fine-grained matrix that is clastic though not necessarily strictly sedimentary in origin. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "rvsb"^^:GSWA-rock-code ;
@@ -718,7 +718,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     rdfs:isDefinedBy cs: ;
     skos:altLabel "mesocataclasite"@en ;
     skos:broader :metamorphic-protolith-unknown-fault-rock ;
-    skos:definition "A cohesive fault rock with a poorly developed or absent schistosity, characterized by generally angular porphyroclasts and lithic fragments in a finer-grained matrix of similar composition that constitutes between 50 and 90% of the rock volume. Definition adapted from Fossen (2016) and Fettes and Desmons (2007, p. 138)."@en ;
+    skos:definition "A cohesive fault rock with a poorly developed or absent schistosity, characterized by generally angular porphyroclasts and lithic fragments in a finer-grained matrix of similar composition that constitutes between 50 and 90% of the rock volume. Definition adapted from Fossen (2016) and Fettes and Desmons (2007, p. 138)."@en ;
     skos:historyNote "Fossen, H 2016, Structural geology (2nd edition): Cambridge University Press, Cambridge, United Kingdom, 524p." ;
     skos:inScheme cs: ;
     skos:notation "myx"^^:GSWA-rock-code ;
@@ -774,7 +774,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     rdfs:isDefinedBy cs: ;
     skos:altLabel "flint"@en ;
     skos:broader :sedimentary-other-chemical-or-biochemical ;
-    skos:definition "A hard, extremely dense or compact, dull to semivitreous, microcrystalline or cryptocrystalline sedimentary rock, consisting dominantly of interlocking crystals of quartz less than about 30 μm in diameter; it may contain amorphous silica (opal) or cryptocrystalline quartz (chalcedony). It sometimes contains impurities such as calcite, iron oxide, and the remains of siliceous and other organisms. It has a tough, splintery to conchoidal fracture, and may be white or variously coloured grey, green, blue, pink, red, yellow, brown, and black. Chert occurs principally as nodular or concretionary segregations (chert nodules) in limestones and dolomites, and as areally extensive layered deposits (bedded chert ); it may be an original organic or inorganic precipitate or a replacement product. The term flint is essentially synonymous, although it has been used for the dark variety of chert. Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
+    skos:definition "A hard, extremely dense or compact, dull to semivitreous, microcrystalline or cryptocrystalline sedimentary rock, consisting dominantly of interlocking crystals of quartz less than about 30 μm in diameter; it may contain amorphous silica (opal) or cryptocrystalline quartz (chalcedony). It sometimes contains impurities such as calcite, iron oxide, and the remains of siliceous and other organisms. It has a tough, splintery to conchoidal fracture, and may be white or variously coloured grey, green, blue, pink, red, yellow, brown, and black. Chert occurs principally as nodular or concretionary segregations (chert nodules) in limestones and dolomites, and as areally extensive layered deposits (bedded chert ); it may be an original organic or inorganic precipitate or a replacement product. The term flint is essentially synonymous, although it has been used for the dark variety of chert. Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
     skos:historyNote "Based on the Glossary of geology (5th edition, revised; Neuendorf et al. 2011)." ;
     skos:inScheme cs: ;
     skos:notation "cc"^^:GSWA-rock-code ;
@@ -797,7 +797,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metamorphic-protolith-unknown-gneiss ;
-    skos:definition "A gneiss distinguished by the abundance of chlorite minerals. In GSWA usage, this term is reserved for a gneiss for which a protolith cannot be conclusively established. See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
+    skos:definition "A gneiss distinguished by the abundance of chlorite minerals. In GSWA usage, this term is reserved for a gneiss for which a protolith cannot be conclusively established. See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007) and GSWA usage." ;
     skos:inScheme cs: ;
     skos:notation "mnc"^^:GSWA-rock-code ;
@@ -831,7 +831,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-ultramafic-intrusive ;
-    skos:definition "An ultramafic rock consisting essentially of chromite (Le Maitre et al., 2005, p. 69)."@en ;
+    skos:definition "An ultramafic rock consisting essentially of chromite (Le Maitre et al., 2005, p. 69)."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "ac"^^:GSWA-rock-code ;
@@ -858,7 +858,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-mafic-intrusive ;
-    skos:definition "A gabbro sensu strictu, i.e. a mafic intrusive rock (or the coarse-grained part of an extrusive succession) defined modally in QAPF field 10 (Fig. 2.4, p. 22) and consisting of plagioclase more calcic than An50 and clinopyroxene (augite), with less than 5% each of olivine and orthopyroxene in its mode (cf. Le Maitre et al., 2005, p. 24–25)."@en ;
+    skos:definition "A gabbro sensu strictu, i.e. a mafic intrusive rock (or the coarse-grained part of an extrusive succession) defined modally in QAPF field 10 (Fig. 2.4, p. 22) and consisting of plagioclase more calcic than An50 and clinopyroxene (augite), with less than 5% each of olivine and orthopyroxene in its mode (cf. Le Maitre et al., 2005, p. 24–25)."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "oc"^^:GSWA-rock-code ;
@@ -869,7 +869,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-ultramafic-intrusive ;
-    skos:definition "An ultramafic intrusive rock consisting almost entirely of clinopyroxene. Now defined modally in the ultramafic rock classification (Fig. 2.9, p. 28). (cf. Le Maitre et al., 2005, p. 69)"@en ;
+    skos:definition "An ultramafic intrusive rock consisting almost entirely of clinopyroxene. Now defined modally in the ultramafic rock classification (Fig. 2.9, p. 28). (cf. Le Maitre et al., 2005, p. 69)"@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "axc"^^:GSWA-rock-code ;
@@ -882,8 +882,8 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     rdfs:isDefinedBy cs: ;
     skos:altLabel "cobblestone"@en ;
     skos:broader :conglomerate ;
-    skos:definition "A consolidated rock consisting mainly of cobbles (64–256 mm or -4 to -8  phi units) being somewhat rounded or otherwise modified by abrasion in the course of transport. Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
-    skos:historyNote "Wentworth, CK 1922, A scale of grade and class terms for clastic sediments: The Journal of Geology, v. 30, no. 5, p. 377–392, doi:10.1086/622910." ;
+    skos:definition "A consolidated rock consisting mainly of cobbles (64–256 mm or -4 to -8  phi units) being somewhat rounded or otherwise modified by abrasion in the course of transport. Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
+    skos:historyNote "Wentworth, CK 1922, A scale of grade and class terms for clastic sediments: The Journal of Geology, v. 30, no. 5, p. 377–392, doi:10.1086/622910." ;
     skos:inScheme cs: ;
     skos:notation "so"^^:GSWA-rock-code ;
     skos:prefLabel "cobble conglomerate"@en ;
@@ -936,7 +936,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metamorphic-protolith-unknown-fault-rock ;
-    skos:definition "A cohesive fault breccia formed by deformation that caused the fragmentation of the rock in place or nearly in place. In the classification of Fossen (2016) crush breccia specifically refers to occurrences where fragments are larger than 5 mm; GSWA usage of the term is for rocks of unknown protolith, and includes 'fine crush breccia' (fragments between 1 and 5 mm) and 'crush microbreccia' (fragments less than 1 mm). Crush breccias have less than 10% matrix and fragments are usually glued together by cement (typically quartz or calcite) and/or microfragments of minerals that have been crushed during faulting. Adapted from Fossen (2016) and Fettes and Desmons (2007, p. 143)."@en ;
+    skos:definition "A cohesive fault breccia formed by deformation that caused the fragmentation of the rock in place or nearly in place. In the classification of Fossen (2016) crush breccia specifically refers to occurrences where fragments are larger than 5 mm; GSWA usage of the term is for rocks of unknown protolith, and includes 'fine crush breccia' (fragments between 1 and 5 mm) and 'crush microbreccia' (fragments less than 1 mm). Crush breccias have less than 10% matrix and fragments are usually glued together by cement (typically quartz or calcite) and/or microfragments of minerals that have been crushed during faulting. Adapted from Fossen (2016) and Fettes and Desmons (2007, p. 143)."@en ;
     skos:historyNote "Fossen, H 2016, Structural geology (2nd edition): Cambridge University Press, Cambridge, United Kingdom, 524p." ;
     skos:inScheme cs: ;
     skos:notation "myh"^^:GSWA-rock-code ;
@@ -973,7 +973,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-felsic-volcanic ;
-    skos:definition "A volcanic rock composed of quartz and sodic plagioclase with minor amounts of biotite and/or hornblende and/or pyroxene. The volcanic equivalent of granodiorite and tonalite. Now defined modally in QAPF fields 4 and 5 (Fig. 2.11, p. 31) and, if modes are not available, chemically in TAS field O3 (Fig. 2.14, p. 35). Definition from Le Maitre et al. (2005, p. 72). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
+    skos:definition "A volcanic rock composed of quartz and sodic plagioclase with minor amounts of biotite and/or hornblende and/or pyroxene. The volcanic equivalent of granodiorite and tonalite. Now defined modally in QAPF fields 4 and 5 (Fig. 2.11, p. 31) and, if modes are not available, chemically in TAS field O3 (Fig. 2.14, p. 35). Definition from Le Maitre et al. (2005, p. 72). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
     skos:exactMatch
         <http://inspire.ec.europa.eu/codelist/LithologyValue/dacite> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/dacite> ;
@@ -1031,7 +1031,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-lamproites ;
-    skos:definition "A melanocratic diopside–leucite lamproite (Table 2.7, p. 17) essentially composed of leucite and diopside with minor olivine pseudomorphs, amphibole, phlogopite and rutile. The original name cedricite is not recommended for usage. Adapted from Le Maitre et al. (2005, p. 68)."@en ;
+    skos:definition "A melanocratic diopside–leucite lamproite (Table 2.7, p. 17) essentially composed of leucite and diopside with minor olivine pseudomorphs, amphibole, phlogopite and rutile. The original name cedricite is not recommended for usage. Adapted from Le Maitre et al. (2005, p. 68)."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "ic"^^:GSWA-rock-code ;
@@ -1043,7 +1043,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-lamproites ;
-    skos:definition "Originally described as a variety of leucitite composed of clinopyroxene, mica and leucite in a glassy matrix. Diopside madupitic lamproite (term preferred to 'madupite') is a more mafic variety. Now regarded as a diopside-leucite-phlogopite lamproite (Table 2.7, p. 17). The original name wyomingite is not recommended for usage. Adapted from Le Maitre et al. (2005, p. 157)."@en ;
+    skos:definition "Originally described as a variety of leucitite composed of clinopyroxene, mica and leucite in a glassy matrix. Diopside madupitic lamproite (term preferred to 'madupite') is a more mafic variety. Now regarded as a diopside-leucite-phlogopite lamproite (Table 2.7, p. 17). The original name wyomingite is not recommended for usage. Adapted from Le Maitre et al. (2005, p. 157)."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "iy"^^:GSWA-rock-code ;
@@ -1056,7 +1056,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     rdfs:isDefinedBy cs: ;
     skos:altLabel "diopside-leucite-richterite-phlogopite lamproite"@en ;
     skos:broader :igneous-lamproites ;
-    skos:definition "A name for a rock largely composed of leucite, mica and amphibole with subordinate clinopyroxene in a serpentine-rich matrix. Now regarded as a diopside–leucite–richterite madupitic lamproite (Table 2.7, p. 17), with the term 'madupitic' referring to the presence of poikilitic groundmass phlogopite. The original name wolgidite is not recommended for usage. Adapted from Le Maitre et al. (2005, p. 157)."@en ;
+    skos:definition "A name for a rock largely composed of leucite, mica and amphibole with subordinate clinopyroxene in a serpentine-rich matrix. Now regarded as a diopside–leucite–richterite madupitic lamproite (Table 2.7, p. 17), with the term 'madupitic' referring to the presence of poikilitic groundmass phlogopite. The original name wolgidite is not recommended for usage. Adapted from Le Maitre et al. (2005, p. 157)."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "iw"^^:GSWA-rock-code ;
@@ -1069,7 +1069,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     rdfs:isDefinedBy cs: ;
     skos:altLabel "diopside-phlogopite lamproite"@en ;
     skos:broader :igneous-lamproites ;
-    skos:definition "Originally described as a melanocratic variety of leucitite essentially composed of diopside and phlogopite in a glassy matrix, which has the composition of nepheline and leucite. Wyomingite is a more felsic variety. Now regarded as a diopside madupitic lamproite (Table 2.7, p. 17), with the term 'madupitic' referring to the presence of poikilitic groundmass phlogopite. The original name madupite is not recommended for usage. Adapted from Le Maitre et al. (2005, p. 107)."@en ;
+    skos:definition "Originally described as a melanocratic variety of leucitite essentially composed of diopside and phlogopite in a glassy matrix, which has the composition of nepheline and leucite. Wyomingite is a more felsic variety. Now regarded as a diopside madupitic lamproite (Table 2.7, p. 17), with the term 'madupitic' referring to the presence of poikilitic groundmass phlogopite. The original name madupite is not recommended for usage. Adapted from Le Maitre et al. (2005, p. 107)."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "im"^^:GSWA-rock-code ;
@@ -1081,7 +1081,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-lamproites ;
-    skos:definition "Originally described as a variety of leucite phonolite essentially composed of leucite and alkali feldspar with subordinate clinopyroxene, mica and amphibole. Now regarded as a diopside–sanidine–phlogopite lamproite (Table 2.7, p. 17). The original name orendite is not recommended for usage. (Le Maitre et al., 2005, p. 121)"@en ;
+    skos:definition "Originally described as a variety of leucite phonolite essentially composed of leucite and alkali feldspar with subordinate clinopyroxene, mica and amphibole. Now regarded as a diopside–sanidine–phlogopite lamproite (Table 2.7, p. 17). The original name orendite is not recommended for usage. (Le Maitre et al., 2005, p. 121)"@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "io"^^:GSWA-rock-code ;
@@ -1093,7 +1093,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-felsic-intrusive ;
-    skos:definition "An intrusive rock consisting of intermediate plagioclase, commonly with hornblende and often with biotite or augite. Now defined modally in QAPF field 10 (Fig. 2.4, p. 22). (cf. Le Maitre et al., 2005, p. 73)."@en ;
+    skos:definition "An intrusive rock consisting of intermediate plagioclase, commonly with hornblende and often with biotite or augite. Now defined modally in QAPF field 10 (Fig. 2.4, p. 22). (cf. Le Maitre et al., 2005, p. 73)."@en ;
     skos:exactMatch
         <http://inspire.ec.europa.eu/codelist/LithologyValue/diorite> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/diorite> ;
@@ -1109,8 +1109,8 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     rdfs:isDefinedBy cs: ;
     skos:altLabel "dolomitic sandstone"@en ;
     skos:broader :dolomite ;
-    skos:definition "A dolomite rock consisting predominantly of detrital dolomite particles of sand size (Folk, 1959, p. 16); a consolidated dolomitic sand (Glossary of geology, 5th edition revised; Neuendorf et al., 2011)."@en ;
-    skos:historyNote "Folk, RL 1959, Practical petrographic classification of limestones: American Association of Petroleum Geologists Bulletin No. 43(1), p. 1–38, doi:10.1306/0BDA5C36-16BD-11D7-8645000102C1865D." ;
+    skos:definition "A dolomite rock consisting predominantly of detrital dolomite particles of sand size (Folk, 1959, p. 16); a consolidated dolomitic sand (Glossary of geology, 5th edition revised; Neuendorf et al., 2011)."@en ;
+    skos:historyNote "Folk, RL 1959, Practical petrographic classification of limestones: American Association of Petroleum Geologists Bulletin No. 43(1), p. 1–38, doi:10.1306/0BDA5C36-16BD-11D7-8645000102C1865D." ;
     skos:inScheme cs: ;
     skos:notation "kda"^^:GSWA-rock-code ;
     skos:prefLabel "dolarenite"@en ;
@@ -1121,7 +1121,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-mafic-intrusive ;
-    skos:definition "A rock intermediate in grain size between basalt and gabbro and composed essentially of plagioclase, pyroxene and opaque minerals; often with ophitic texture. If olivine is present the rock may be called olivine dolerite; if quartz is present, quartz dolerite. Now regarded as being synonymous with diabase and an approved synonym for microgabbro of QAPF field 10 (Fig. 2.4, p. 22). (Le Maitre et al., 2005, p. 74)."@en ;
+    skos:definition "A rock intermediate in grain size between basalt and gabbro and composed essentially of plagioclase, pyroxene and opaque minerals; often with ophitic texture. If olivine is present the rock may be called olivine dolerite; if quartz is present, quartz dolerite. Now regarded as being synonymous with diabase and an approved synonym for microgabbro of QAPF field 10 (Fig. 2.4, p. 22). (Le Maitre et al., 2005, p. 74)."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "od"^^:GSWA-rock-code ;
@@ -1135,8 +1135,8 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:altLabel "dolomite bafflestone"@en ;
     skos:broader :doloboundstone ;
     skos:definition "A type of reef rock or boundstone composed of upright, branching colonies, closely to widely spaced but not in contact, separated by fine sediment or coarse skeletal debris, and in which dolomite is prevalent over other carbonate minerals. In life, the colonies functioned as a sediment trap or baffle. Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
-    skos:historyNote """Dunham, RJ 1962, Classification of carbonate rocks according to depositional texture, in Classification of carbonate rocks edited by WE Hamm: American Association of Petroleum Geologists, Tulsa, Oklahoma, USA, p. 108–121.,
-Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Island, N.W.T: Bulletin of Canadian Petroleum Geology, v. 19(4), p. 730–781.""" ;
+    skos:historyNote """Dunham, RJ 1962, Classification of carbonate rocks according to depositional texture, in Classification of carbonate rocks edited by WE Hamm: American Association of Petroleum Geologists, Tulsa, Oklahoma, USA, p. 108–121.,
+Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Island, N.W.T: Bulletin of Canadian Petroleum Geology, v. 19(4), p. 730–781.""" ;
     skos:inScheme cs: ;
     skos:notation "kdj"^^:GSWA-rock-code ;
     skos:prefLabel "dolobafflestone"@en ;
@@ -1149,8 +1149,8 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     skos:altLabel "dolomite bindstone"@en ;
     skos:broader :doloboundstone ;
     skos:definition "A type of reef rock or boundstone composed of sheet-like colonies encrusting large fossil fragments or finer sediment, forming a layered mass that is partly in-place skeletal and partly bioclastic, and in which dolomite is prevalent over other carbonate minerals. Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
-    skos:historyNote """Dunham, RJ 1962, Classification of carbonate rocks according to depositional texture, in Classification of carbonate rocks edited by WE Hamm: American Association of Petroleum Geologists, Tulsa, Oklahoma, USA, p. 108–121.,
-Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Island, N.W.T: Bulletin of Canadian Petroleum Geology, v. 19(4), p. 730–781.""" ;
+    skos:historyNote """Dunham, RJ 1962, Classification of carbonate rocks according to depositional texture, in Classification of carbonate rocks edited by WE Hamm: American Association of Petroleum Geologists, Tulsa, Oklahoma, USA, p. 108–121.,
+Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Island, N.W.T: Bulletin of Canadian Petroleum Geology, v. 19(4), p. 730–781.""" ;
     skos:inScheme cs: ;
     skos:notation "kdi"^^:GSWA-rock-code ;
     skos:prefLabel "dolobindstone"@en ;
@@ -1175,8 +1175,8 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     skos:altLabel "dolomite floatstone"@en ;
     skos:broader :dolomite ;
     skos:definition "A carbonate rock with dolomite prevalent over calcite and containing a few bioclasts or other fragments more than 2 mm in diameter, widely spaced, embedded in sand- or mud-size carbonate sediment that forms over 90% of the rock. Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
-    skos:historyNote """Dunham, RJ 1962, Classification of carbonate rocks according to depositional texture, in Classification of carbonate rocks edited by WE Hamm: American Association of Petroleum Geologists, Tulsa, Oklahoma, USA, p. 108–121.,
-Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Island, N.W.T: Bulletin of Canadian Petroleum Geology, v. 19(4), p. 730–781.""" ;
+    skos:historyNote """Dunham, RJ 1962, Classification of carbonate rocks according to depositional texture, in Classification of carbonate rocks edited by WE Hamm: American Association of Petroleum Geologists, Tulsa, Oklahoma, USA, p. 108–121.,
+Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Island, N.W.T: Bulletin of Canadian Petroleum Geology, v. 19(4), p. 730–781.""" ;
     skos:inScheme cs: ;
     skos:notation "kdf"^^:GSWA-rock-code ;
     skos:prefLabel "dolofloatstone"@en ;
@@ -1192,8 +1192,8 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
         <http://resource.geosciml.org/classifier/cgi/lithology/framestone> ;
     skos:broader :doloboundstone ;
     skos:definition "A type of reef rock or boundstone consisting of colonies, shells, or skeletons attached to each other to form a rigid framework or lattice, and consisting mostly of dolomite. Internal cavities are filled with fine sediment, crystalline cement, or coarse skeletal debris. Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
-    skos:historyNote """Dunham, RJ 1962, Classification of carbonate rocks according to depositional texture, in Classification of carbonate rocks edited by WE Hamm: American Association of Petroleum Geologists, Tulsa, Oklahoma, USA, p. 108–121.,
-Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Island, N.W.T: Bulletin of Canadian Petroleum Geology, v. 19(4), p. 730–781.""" ;
+    skos:historyNote """Dunham, RJ 1962, Classification of carbonate rocks according to depositional texture, in Classification of carbonate rocks edited by WE Hamm: American Association of Petroleum Geologists, Tulsa, Oklahoma, USA, p. 108–121.,
+Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Island, N.W.T: Bulletin of Canadian Petroleum Geology, v. 19(4), p. 730–781.""" ;
     skos:inScheme cs: ;
     skos:notation "kde"^^:GSWA-rock-code ;
     skos:prefLabel "doloframestone"@en ;
@@ -1208,9 +1208,9 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
         <http://inspire.ec.europa.eu/codelist/LithologyValue/grainstone> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/grainstone> ;
     skos:broader :dolomite ;
-    skos:definition "A mud-free (less than 1% of material with diameters less than 20 μm), grain-supported, carbonate sedimentary rock, with dolomite prevalent over calcite. It may be current-laid or formed by mud being washed out from previously deposited sediment, or it may result from mud being bypassed while locally produced particles accumulated (Dunham, 1962). Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
-    skos:historyNote """Dunham, RJ 1962, Classification of carbonate rocks according to depositional texture, in Classification of carbonate rocks edited by WE Hamm: American Association of Petroleum Geologists, Tulsa, Oklahoma, USA, p. 108–121.,
-Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Island, N.W.T: Bulletin of Canadian Petroleum Geology, v. 19(4), p. 730–781.""" ;
+    skos:definition "A mud-free (less than 1% of material with diameters less than 20 μm), grain-supported, carbonate sedimentary rock, with dolomite prevalent over calcite. It may be current-laid or formed by mud being washed out from previously deposited sediment, or it may result from mud being bypassed while locally produced particles accumulated (Dunham, 1962). Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
+    skos:historyNote """Dunham, RJ 1962, Classification of carbonate rocks according to depositional texture, in Classification of carbonate rocks edited by WE Hamm: American Association of Petroleum Geologists, Tulsa, Oklahoma, USA, p. 108–121.,
+Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Island, N.W.T: Bulletin of Canadian Petroleum Geology, v. 19(4), p. 730–781.""" ;
     skos:inScheme cs: ;
     skos:notation "kdg"^^:GSWA-rock-code ;
     skos:prefLabel "dolograinstone"@en ;
@@ -1222,9 +1222,9 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     rdfs:isDefinedBy cs: ;
     skos:altLabel "dolosiltite"@en ;
     skos:broader :dolomite ;
-    skos:definition "A dolomitic rock consisting predominantly of detrital dolomite particles of silt and/or clay size (Folk, 1959, p. 16); a consolidated dolomitic mud. It is commonly interlayered with dense primary dolomites in evaporitic sequences. Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
-    skos:historyNote """Grabau, AW 1903, Paleozoic coral reefs: Geological Society of America Bulletin, v. 14, p. 337–352.,
-Folk, RL , 1959, Practical petrographic classification of limestones: American Association of Petroleum Geologists Bulletin No. 43(1), p. 1–38, doi:10.1306/0BDA5C36-16BD-11D7-8645000102C1865D.""" ;
+    skos:definition "A dolomitic rock consisting predominantly of detrital dolomite particles of silt and/or clay size (Folk, 1959, p. 16); a consolidated dolomitic mud. It is commonly interlayered with dense primary dolomites in evaporitic sequences. Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
+    skos:historyNote """Grabau, AW 1903, Paleozoic coral reefs: Geological Society of America Bulletin, v. 14, p. 337–352.,
+Folk, RL , 1959, Practical petrographic classification of limestones: American Association of Petroleum Geologists Bulletin No. 43(1), p. 1–38, doi:10.1306/0BDA5C36-16BD-11D7-8645000102C1865D.""" ;
     skos:inScheme cs: ;
     skos:notation "kdl"^^:GSWA-rock-code ;
     skos:prefLabel "dololutite"@en ;
@@ -1236,7 +1236,7 @@ Folk, RL , 1959, Practical petrographic classification of limestones: American A
     rdfs:isDefinedBy cs: ;
     skos:altLabel "beforsite"@en ;
     skos:broader :igneous-carbonatite ;
-    skos:definition "A variety of carbonatite in which the main carbonate is dolomite (section 2.3, p. 10). A medium- to fine-grained variety of dolomite-carbonatite, often occurring as dykes, may be called beforsite. Adapted from Le Maitre et al. (2005, p. 10, 62 and 74)"@en ;
+    skos:definition "A variety of carbonatite in which the main carbonate is dolomite (section 2.3, p. 10). A medium- to fine-grained variety of dolomite-carbonatite, often occurring as dykes, may be called beforsite. Adapted from Le Maitre et al. (2005, p. 10, 62 and 74)"@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "rd"^^:GSWA-rock-code ;
@@ -1266,9 +1266,9 @@ Folk, RL , 1959, Practical petrographic classification of limestones: American A
         <http://inspire.ec.europa.eu/codelist/LithologyValue/carbonateMudstone> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/carbonate_mudstone> ;
     skos:broader :dolomite ;
-    skos:definition "A sedimentary rock consisting of clay-sized dolomite crystals, interpreted as a lithified dolomite mud (analogous to calcite mud or micrite), and containing less than 1% allochems (Folk, 1959, p. 14). Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
-    skos:historyNote """Dunham, RJ 1962, Classification of carbonate rocks according to depositional texture, in Classification of carbonate rocks edited by WE Hamm: American Association of Petroleum Geologists, Tulsa, Oklahoma, USA, p. 108–121.,
-Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Island, N.W.T: Bulletin of Canadian Petroleum Geology, v. 19(4), p. 730–781.""" ;
+    skos:definition "A sedimentary rock consisting of clay-sized dolomite crystals, interpreted as a lithified dolomite mud (analogous to calcite mud or micrite), and containing less than 1% allochems (Folk, 1959, p. 14). Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
+    skos:historyNote """Dunham, RJ 1962, Classification of carbonate rocks according to depositional texture, in Classification of carbonate rocks edited by WE Hamm: American Association of Petroleum Geologists, Tulsa, Oklahoma, USA, p. 108–121.,
+Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Island, N.W.T: Bulletin of Canadian Petroleum Geology, v. 19(4), p. 730–781.""" ;
     skos:inScheme cs: ;
     skos:notation "kdu"^^:GSWA-rock-code ;
     skos:prefLabel "dolomudstone"@en ;
@@ -1284,8 +1284,8 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
         <http://resource.geosciml.org/classifier/cgi/lithology/packstone> ;
     skos:broader :dolomite ;
     skos:definition "A term used for a detrital carbonate rock consisting predominantly of dolomite and whose granular material is arranged in a self-supporting framework, yet also contains some matrix of calcareous mud (Dunham, 1962). Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
-    skos:historyNote """Dunham, RJ 1962, Classification of carbonate rocks according to depositional texture, in Classification of carbonate rocks edited by WE Hamm: American Association of Petroleum Geologists, Tulsa, Oklahoma, USA, p. 108–121.,
-Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Island, N.W.T: Bulletin of Canadian Petroleum Geology, v. 19(4), p. 730–781.""" ;
+    skos:historyNote """Dunham, RJ 1962, Classification of carbonate rocks according to depositional texture, in Classification of carbonate rocks edited by WE Hamm: American Association of Petroleum Geologists, Tulsa, Oklahoma, USA, p. 108–121.,
+Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Island, N.W.T: Bulletin of Canadian Petroleum Geology, v. 19(4), p. 730–781.""" ;
     skos:inScheme cs: ;
     skos:notation "kdp"^^:GSWA-rock-code ;
     skos:prefLabel "dolopackstone"@en ;
@@ -1297,9 +1297,9 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     rdfs:isDefinedBy cs: ;
     skos:altLabel "dolomite rudite"@en ;
     skos:broader :dolomite ;
-    skos:definition "A carbonate rock consisting predominantly of detrital dolomite particles larger than sand size (Folk, 1959, p. 15); a consolidated dolomitic gravel. Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
-    skos:historyNote """Grabau, AW 1903, Paleozoic coral reefs: Geological Society of America Bulletin, v. 14, p. 337–352.,
-Folk, RL , 1959, Practical petrographic classification of limestones: American Association of Petroleum Geologists Bulletin No. 43(1), p. 1–38, doi:10.1306/0BDA5C36-16BD-11D7-8645000102C1865D.""" ;
+    skos:definition "A carbonate rock consisting predominantly of detrital dolomite particles larger than sand size (Folk, 1959, p. 15); a consolidated dolomitic gravel. Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
+    skos:historyNote """Grabau, AW 1903, Paleozoic coral reefs: Geological Society of America Bulletin, v. 14, p. 337–352.,
+Folk, RL , 1959, Practical petrographic classification of limestones: American Association of Petroleum Geologists Bulletin No. 43(1), p. 1–38, doi:10.1306/0BDA5C36-16BD-11D7-8645000102C1865D.""" ;
     skos:inScheme cs: ;
     skos:notation "kdr"^^:GSWA-rock-code ;
     skos:prefLabel "dolorudite"@en ;
@@ -1311,9 +1311,9 @@ Folk, RL , 1959, Practical petrographic classification of limestones: American A
     rdfs:isDefinedBy cs: ;
     skos:altLabel "dolomite rudstone"@en ;
     skos:broader :dolomite ;
-    skos:definition "A carbonate rock consisting predominantly of dolomite and composed of detrital bioclasts or other fragments, over 2 mm in diameter, closely packed, in physical contact; the interstices may be open, or filled with fine carbonate sediment or crystalline cement. Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
-    skos:historyNote """Dunham, RJ 1962, Classification of carbonate rocks according to depositional texture, in Classification of carbonate rocks edited by WE Hamm: American Association of Petroleum Geologists, Tulsa, Oklahoma, USA, p. 108–121.,
-Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Island, N.W.T: Bulletin of Canadian Petroleum Geology, v. 19(4), p. 730–781.""" ;
+    skos:definition "A carbonate rock consisting predominantly of dolomite and composed of detrital bioclasts or other fragments, over 2 mm in diameter, closely packed, in physical contact; the interstices may be open, or filled with fine carbonate sediment or crystalline cement. Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
+    skos:historyNote """Dunham, RJ 1962, Classification of carbonate rocks according to depositional texture, in Classification of carbonate rocks edited by WE Hamm: American Association of Petroleum Geologists, Tulsa, Oklahoma, USA, p. 108–121.,
+Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Island, N.W.T: Bulletin of Canadian Petroleum Geology, v. 19(4), p. 730–781.""" ;
     skos:inScheme cs: ;
     skos:notation "kdd"^^:GSWA-rock-code ;
     skos:prefLabel "dolorudstone"@en ;
@@ -1328,9 +1328,9 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
         <http://inspire.ec.europa.eu/codelist/LithologyValue/carbonateWackestone> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/carbonate_wackestone> ;
     skos:broader :dolomite ;
-    skos:definition "A term for a mud-supported detrital carbonate sedimentary rock consisting predominantly of dolomite and containing more than 10% grains (particles with diameters greater than 20 μm). Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
-    skos:historyNote """Dunham, RJ 1962, Classification of carbonate rocks according to depositional texture, in Classification of carbonate rocks edited by WE Hamm: American Association of Petroleum Geologists, Tulsa, Oklahoma, USA, p. 108–121.,
-Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Island, N.W.T: Bulletin of Canadian Petroleum Geology, v. 19(4), p. 730–781.""" ;
+    skos:definition "A term for a mud-supported detrital carbonate sedimentary rock consisting predominantly of dolomite and containing more than 10% grains (particles with diameters greater than 20 μm). Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
+    skos:historyNote """Dunham, RJ 1962, Classification of carbonate rocks according to depositional texture, in Classification of carbonate rocks edited by WE Hamm: American Association of Petroleum Geologists, Tulsa, Oklahoma, USA, p. 108–121.,
+Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Island, N.W.T: Bulletin of Canadian Petroleum Geology, v. 19(4), p. 730–781.""" ;
     skos:inScheme cs: ;
     skos:notation "kdw"^^:GSWA-rock-code ;
     skos:prefLabel "dolowackestone"@en ;
@@ -1341,7 +1341,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-ultramafic-intrusive ;
-    skos:definition "An ultramafic intrusive rock consisting essentially of olivine. Now defined modally in the ultramafic rock classification (Fig. 2.9, p. 28). (cf. Le Maitre et al., 2005, p. 74)"@en ;
+    skos:definition "An ultramafic intrusive rock consisting essentially of olivine. Now defined modally in the ultramafic rock classification (Fig. 2.9, p. 28). (cf. Le Maitre et al., 2005, p. 74)"@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "ad"^^:GSWA-rock-code ;
@@ -1353,7 +1353,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-ultramafic-volcanic-and-volcaniclastic ;
-    skos:definition "An ultramafic igneous rock consisting essentially of olivine. Now defined modally in the ultramafic rock classification (Fig. 2.9, p. 28). Definition adapted from Le Maitre et al., (2007, p. 74). In GSWA usage, an 'extrusive' dunite is identified as one formed from fractionation within thick bodies of ultramafic volcanic or subvolcanic magmas. GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
+    skos:definition "An ultramafic igneous rock consisting essentially of olivine. Now defined modally in the ultramafic rock classification (Fig. 2.9, p. 28). Definition adapted from Le Maitre et al., (2007, p. 74). In GSWA usage, an 'extrusive' dunite is identified as one formed from fractionation within thick bodies of ultramafic volcanic or subvolcanic magmas. GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "uu"^^:GSWA-rock-code ;
@@ -1380,8 +1380,8 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :skarn ;
-    skos:definition "The portion of skarn that involves metamorphic, metasomatic, and hybrid mixing effects on the igneous side of the contact between an intrusive body and the country rock. Adapted from Glossary of geology (Neuendorf et al., 5th edition, revised); cf. Fettes and Desmons (2007, p. 148)."@en ;
-    skos:historyNote "Einaudi, MT and Burt, DM 1982, Introduction – terminology, classification, and composition of skarn deposits: Economic Geology, v. 77, p. 745–754." ;
+    skos:definition "The portion of skarn that involves metamorphic, metasomatic, and hybrid mixing effects on the igneous side of the contact between an intrusive body and the country rock. Adapted from Glossary of geology (Neuendorf et al., 5th edition, revised); cf. Fettes and Desmons (2007, p. 148)."@en ;
+    skos:historyNote "Einaudi, MT and Burt, DM 1982, Introduction – terminology, classification, and composition of skarn deposits: Economic Geology, v. 77, p. 745–754." ;
     skos:inScheme cs: ;
     skos:notation "mjkn"^^:GSWA-rock-code ;
     skos:prefLabel "endoskarn"@en ;
@@ -1392,7 +1392,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-lamproites ;
-    skos:definition "A variety of potassic lamproite containing normative olivine but no normative leucite (Table 2.7, p. 17). The original name cancalite is not recommended for usage. Adapted from Le Maitre et al. (2005, p. 67)."@en ;
+    skos:definition "A variety of potassic lamproite containing normative olivine but no normative leucite (Table 2.7, p. 17). The original name cancalite is not recommended for usage. Adapted from Le Maitre et al. (2005, p. 67)."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "ie"^^:GSWA-rock-code ;
@@ -1415,8 +1415,8 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :skarn ;
-    skos:definition "The portion of skarn that involves metamorphic and metasomatic effects on the country-rock (non-intrusive) side of the contact between an intrusive body and the country rock. Adapted from Glossary of geology (Neuendorf et al., 5th edition, revised); cf. Fettes and Desmons (2007, p. 150)."@en ;
-    skos:historyNote "Einaudi, MT and Burt, DM 1982, Introduction – terminology, classification, and composition of skarn deposits: Economic Geology, v. 77, p. 745–754." ;
+    skos:definition "The portion of skarn that involves metamorphic and metasomatic effects on the country-rock (non-intrusive) side of the contact between an intrusive body and the country rock. Adapted from Glossary of geology (Neuendorf et al., 5th edition, revised); cf. Fettes and Desmons (2007, p. 150)."@en ;
+    skos:historyNote "Einaudi, MT and Burt, DM 1982, Introduction – terminology, classification, and composition of skarn deposits: Economic Geology, v. 77, p. 745–754." ;
     skos:inScheme cs: ;
     skos:notation "mjko"^^:GSWA-rock-code ;
     skos:prefLabel "exoskarn"@en ;
@@ -1451,7 +1451,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metamorphic-protolith-unknown-fault-rock ;
-    skos:definition "Rock formed as a result of deformation in a fault zone, i.e. a zone of sheared, crushed or foliated rock, in which numerous small dislocations have occurred, adding up to an appreciable total offset of the undeformed walls. All gradations may occur, from multiple fault planes to single shear zones. (Fettes and Desmons, 2007, p. 151)"@en ;
+    skos:definition "Rock formed as a result of deformation in a fault zone, i.e. a zone of sheared, crushed or foliated rock, in which numerous small dislocations have occurred, adding up to an appreciable total offset of the undeformed walls. All gradations may occur, from multiple fault planes to single shear zones. (Fettes and Desmons, 2007, p. 151)"@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:notation "my"^^:GSWA-rock-code ;
@@ -1463,8 +1463,8 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :granular-iron-formation ;
-    skos:definition "A granular iron-formation with granules between 0.0625 and 2 mm (i.e. equivalent in size to a sandstone/arenite)."@en ;
-    skos:historyNote "Beukes, NJ and Gutzmer, J 2008, Origin and paleoenvironmental significance of major iron formations at the Archean-Paleoproterozoic boundary: Reviews in Economic Geology, v. 15, p. 5–47, doi:10.5382/Rev.15.01." ;
+    skos:definition "A granular iron-formation with granules between 0.0625 and 2 mm (i.e. equivalent in size to a sandstone/arenite)."@en ;
+    skos:historyNote "Beukes, NJ and Gutzmer, J 2008, Origin and paleoenvironmental significance of major iron formations at the Archean-Paleoproterozoic boundary: Reviews in Economic Geology, v. 15, p. 5–47, doi:10.5382/Rev.15.01." ;
     skos:inScheme cs: ;
     skos:notation "ciga"^^:GSWA-rock-code ;
     skos:prefLabel "fearenite"@en ;
@@ -1485,7 +1485,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metamorphic-protolith-unknown-gneiss ;
-    skos:definition "A gneiss distinguished by the abundance of feldspar mineral phases. In GSWA usage, this term is reserved for a gneiss for which a protolith cannot be conclusively established. See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
+    skos:definition "A gneiss distinguished by the abundance of feldspar mineral phases. In GSWA usage, this term is reserved for a gneiss for which a protolith cannot be conclusively established. See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007) and GSWA usage." ;
     skos:inScheme cs: ;
     skos:notation "mnf"^^:GSWA-rock-code ;
@@ -1532,7 +1532,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metamorphic-protolith-unknown-schist ;
-    skos:definition "A schist distinguished by the abundance of feldspar mineral phases. In GSWA usage, this term is reserved for a schist for which a protolith cannot be conclusively established. See also definition of schist/schistose structure in Fettes and Desmons, 2007, p. 193)."@en ;
+    skos:definition "A schist distinguished by the abundance of feldspar mineral phases. In GSWA usage, this term is reserved for a schist for which a protolith cannot be conclusively established. See also definition of schist/schistose structure in Fettes and Desmons, 2007, p. 193)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007) and GSWA usage." ;
     skos:inScheme cs: ;
     skos:notation "msf"^^:GSWA-rock-code ;
@@ -1568,7 +1568,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-felsic ;
-    skos:definition "A metamorphosed felsic igneous rock displaying a gneissose structure, i.e. a gneiss derived from an igneous felsic but otherwise unspecified rock (i.e. the intrusive, extrusive or volcaniclastic nature of the protolith cannot be conclusively established). See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
+    skos:definition "A metamorphosed felsic igneous rock displaying a gneissose structure, i.e. a gneiss derived from an igneous felsic but otherwise unspecified rock (i.e. the intrusive, extrusive or volcaniclastic nature of the protolith cannot be conclusively established). See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:notation "mrn"^^:GSWA-rock-code ;
@@ -1580,7 +1580,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     rdfs:isDefinedBy cs: ;
     skos:altLabel "orthogneiss"@en ;
     skos:broader :meta-igneous-felsic-volcanic ;
-    skos:definition "A metamorphosed felsic volcanic rock displaying a gneissose structure, i.e. a gneiss derived from a volcanic rock with one or more felsic minerals as the main component(s). See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
+    skos:definition "A metamorphosed felsic volcanic rock displaying a gneissose structure, i.e. a gneiss derived from a volcanic rock with one or more felsic minerals as the main component(s). See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:notation "mfn"^^:GSWA-rock-code ;
@@ -1602,7 +1602,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-felsic-volcanic ;
-    skos:definition "A metamorphosed felsic volcanic rock displaying a granofelsic structure, i.e. a granofels/hornfels derived from a volcanic rock with one or more felsic minerals as the main components. See definition of granofels/granofelsic structure in Fettes and Desmons (2007, p. 156); hornfels are granofels formed by contact metamorphism (Fettes and Desmons, 2007, p. 159). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
+    skos:definition "A metamorphosed felsic volcanic rock displaying a granofelsic structure, i.e. a granofels/hornfels derived from a volcanic rock with one or more felsic minerals as the main components. See definition of granofels/granofelsic structure in Fettes and Desmons (2007, p. 156); hornfels are granofels formed by contact metamorphism (Fettes and Desmons, 2007, p. 159). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:notation "mfe"^^:GSWA-rock-code ;
@@ -1616,7 +1616,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
         <http://inspire.ec.europa.eu/codelist/LithologyValue/granulite> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/granulite> ;
     skos:broader :meta-igneous-felsic ;
-    skos:definition "Type of granulite with less than 30% mafic minerals (dominantly pyroxene) (Fettes and Desmons, 2007, p. 151). Mafic minerals is a collective term for modal ferromagnesian and other non-felsic minerals."@en ;
+    skos:definition "Type of granulite with less than 30% mafic minerals (dominantly pyroxene) (Fettes and Desmons, 2007, p. 151). Mafic minerals is a collective term for modal ferromagnesian and other non-felsic minerals."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:notation "mro"^^:GSWA-rock-code ;
@@ -1627,7 +1627,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-felsic ;
-    skos:definition "Composite silicate metamorphic rock derived from a felsic igneous but otherwise uncertain protolith, pervasively heterogeneous on a meso- to megascopic scale. It typically consists of darker (melanosome) and lighter (leucosome) parts. The darker parts usually exhibit features of metamorphic rocks, whereas the lighter parts are of igneous appearance. (Cf. Fettes and Desmond, 2007, p. 176)"@en ;
+    skos:definition "Composite silicate metamorphic rock derived from a felsic igneous but otherwise uncertain protolith, pervasively heterogeneous on a meso- to megascopic scale. It typically consists of darker (melanosome) and lighter (leucosome) parts. The darker parts usually exhibit features of metamorphic rocks, whereas the lighter parts are of igneous appearance. (Cf. Fettes and Desmond, 2007, p. 176)"@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:notation "mri"^^:GSWA-rock-code ;
@@ -1650,7 +1650,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-felsic ;
-    skos:definition "A metamorphosed felsic rock displaying a schistose structure, i.e. a schist derived from an intrusive, extrusive or volcaniclastic rock with one or more felsic minerals as the main component(s). See also definition of schist/schistose structure in Fettes and Desmons, 2007, p. 193)."@en ;
+    skos:definition "A metamorphosed felsic rock displaying a schistose structure, i.e. a schist derived from an intrusive, extrusive or volcaniclastic rock with one or more felsic minerals as the main component(s). See also definition of schist/schistose structure in Fettes and Desmons, 2007, p. 193)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:notation "mrs"^^:GSWA-rock-code ;
@@ -1661,7 +1661,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-felsic-volcanic ;
-    skos:definition "A metamorphosed felsic volcanic rock displaying a schistose structure, i.e. a schist derived from a volcanic rock with one or more felsic minerals as the main component(s). See also definition of schist/schistose structure in Fettes and Desmons, 2007, p. 193). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
+    skos:definition "A metamorphosed felsic volcanic rock displaying a schistose structure, i.e. a schist derived from a volcanic rock with one or more felsic minerals as the main component(s). See also definition of schist/schistose structure in Fettes and Desmons, 2007, p. 193). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:notation "mfs"^^:GSWA-rock-code ;
@@ -1695,7 +1695,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-felsic-volcanic ;
-    skos:definition "A volcaniclastic rock composed mostly of angular fragments greater than 2 mm in size consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with an overall felsic composition. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
+    skos:definition "A volcaniclastic rock composed mostly of angular fragments greater than 2 mm in size consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with an overall felsic composition. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "fvb"^^:GSWA-rock-code ;
@@ -1709,7 +1709,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-felsic-volcanic ;
-    skos:definition "A volcaniclastic rock composed mostly of angular fragments of sand size (0.0625 – 2 mm) and above, consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with an overall felsic composition. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
+    skos:definition "A volcaniclastic rock composed mostly of angular fragments of sand size (0.0625 – 2 mm) and above, consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with an overall felsic composition. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "fvbs"^^:GSWA-rock-code ;
@@ -1735,7 +1735,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-felsic-volcanic ;
-    skos:definition "A breccia composed mostly of angular fragments ranging in size from granule (2–4 mm) to pebble (4–32 mm) consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with an overall felsic composition. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
+    skos:definition "A breccia composed mostly of angular fragments ranging in size from granule (2–4 mm) to pebble (4–32 mm) consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with an overall felsic composition. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "fvg"^^:GSWA-rock-code ;
@@ -1771,8 +1771,8 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-felsic-volcanic ;
-    skos:definition "A sandstone (grain size 0.0625 – 2 mm) consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with an overall felsic composition. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
-    skos:historyNote "Pettijohn, FJ, Potter, PE, Siever, R 1987, Sand and sandstone: Springer-Verlag New York, Inc, 553p. (p. 205)" ;
+    skos:definition "A sandstone (grain size 0.0625 – 2 mm) consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with an overall felsic composition. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
+    skos:historyNote "Pettijohn, FJ, Potter, PE, Siever, R 1987, Sand and sandstone: Springer-Verlag New York, Inc, 553p. (p. 205)" ;
     skos:inScheme cs: ;
     skos:notation "fvs"^^:GSWA-rock-code ;
     skos:prefLabel "felsic volcaniclastic sandstone"@en ;
@@ -1785,7 +1785,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-felsic-volcanic ;
-    skos:definition "A volcaniclastic rock composed mostly of fragments ranging in size from sand (0.0625 – 2 mm) to silt (0.0039 – 0.0625 mm) of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with an overall felsic composition. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion w, and with an overall mafic composition."@en ;
+    skos:definition "A volcaniclastic rock composed mostly of fragments ranging in size from sand (0.0625 – 2 mm) to silt (0.0039 – 0.0625 mm) of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with an overall felsic composition. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion w, and with an overall mafic composition."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "fvss"^^:GSWA-rock-code ;
@@ -1797,7 +1797,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-felsic-volcanic ;
-    skos:definition "A commonly monomictic breccia of overall felsic composition composed of angular, coarse igneous fragments cemented by a fine-grained matrix that is clastic though not necessarily strictly sedimentary in origin. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
+    skos:definition "A commonly monomictic breccia of overall felsic composition composed of angular, coarse igneous fragments cemented by a fine-grained matrix that is clastic though not necessarily strictly sedimentary in origin. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "fvsb"^^:GSWA-rock-code ;
@@ -1810,7 +1810,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     rdfs:isDefinedBy cs: ;
     skos:broader :micritic-iron-formation ;
     skos:definition "A poorly bedded micritic iron-formation with a muddy massive appearance. Adapted from Beukes and Gutzmer (2008)."@en ;
-    skos:historyNote "Beukes, NJ and Gutzmer, J 2008, Origin and paleoenvironmental significance of major iron formations at the Archean-Paleoproterozoic boundary: Reviews in Economic Geology, v. 15, p. 5–47, doi:10.5382/Rev.15.01." ;
+    skos:historyNote "Beukes, NJ and Gutzmer, J 2008, Origin and paleoenvironmental significance of major iron formations at the Archean-Paleoproterozoic boundary: Reviews in Economic Geology, v. 15, p. 5–47, doi:10.5382/Rev.15.01." ;
     skos:inScheme cs: ;
     skos:notation "ciml"^^:GSWA-rock-code ;
     skos:prefLabel "felutite"@en ;
@@ -1820,7 +1820,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metasomatic ;
-    skos:definition "High-temperature metasomatic rock characterized by the presence of alkali feldspar, sodic amphibole and sodic pyroxene; nepheline, calcite and biotite/phlogopite may also be present, and typical accessories are titanite and apatite. Fenites occur as zoned aureoles around alkaline and carbonatite igneous complexes forming in a wide range of host lithologies. They occur on the metre to kilometre scale. (Fettes and Desmons, 2007, p. 152)"@en ;
+    skos:definition "High-temperature metasomatic rock characterized by the presence of alkali feldspar, sodic amphibole and sodic pyroxene; nepheline, calcite and biotite/phlogopite may also be present, and typical accessories are titanite and apatite. Fenites occur as zoned aureoles around alkaline and carbonatite igneous complexes forming in a wide range of host lithologies. They occur on the metre to kilometre scale. (Fettes and Desmons, 2007, p. 152)"@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:notation "mjf"^^:GSWA-rock-code ;
@@ -1838,7 +1838,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
         "banded micritic iron-formation"@en ;
     skos:broader :micritic-iron-formation ;
     skos:definition "A microbanded and well-laminated micritic iron-formation. Adapted from Beukes and Gutzmer (2008)."@en ;
-    skos:historyNote "Beukes, NJ and Gutzmer, J 2008, Origin and paleoenvironmental significance of major iron formations at the Archean-Paleoproterozoic boundary: Reviews in Economic Geology, v. 15, p. 5–47, doi:10.5382/Rev.15.01." ;
+    skos:historyNote "Beukes, NJ and Gutzmer, J 2008, Origin and paleoenvironmental significance of major iron formations at the Archean-Paleoproterozoic boundary: Reviews in Economic Geology, v. 15, p. 5–47, doi:10.5382/Rev.15.01." ;
     skos:inScheme cs: ;
     skos:notation "cimh"^^:GSWA-rock-code ;
     skos:prefLabel "ferhythmite"@en ;
@@ -1848,7 +1848,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-carbonatite ;
-    skos:definition "A variety of carbonatite where the main carbonate is iron-rich. Also used for a chemically derived carbonatite in which weight percent CaO / (CaO+MgO+FeO+Fe₂O₃+MnO) < 0.8 and MgO < (FeO+Fe₂O₃+MnO) (Fig. 2.2, p. 10). Adapted from Le Maitre et al. (2005, p.  10 and 79)."@en ;
+    skos:definition "A variety of carbonatite where the main carbonate is iron-rich. Also used for a chemically derived carbonatite in which weight percent CaO / (CaO+MgO+FeO+Fe₂O₃+MnO) < 0.8 and MgO < (FeO+Fe₂O₃+MnO) (Fig. 2.2, p. 10). Adapted from Le Maitre et al. (2005, p.  10 and 79)."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "rf"^^:GSWA-rock-code ;
@@ -1871,7 +1871,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metamorphic-protolith-unknown-gneiss ;
-    skos:definition "A gneiss distinguished by a red or rusty colour due to the presence of ferric oxide. In GSWA usage, this term is reserved for a gneiss for which a protolith cannot be conclusively established. See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
+    skos:definition "A gneiss distinguished by a red or rusty colour due to the presence of ferric oxide. In GSWA usage, this term is reserved for a gneiss for which a protolith cannot be conclusively established. See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007) and GSWA usage." ;
     skos:inScheme cs: ;
     skos:notation "mnj"^^:GSWA-rock-code ;
@@ -1894,7 +1894,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metamorphic-protolith-unknown-schist ;
-    skos:definition "A schist distinguished by a red or rusty colour due to the presence of ferric oxide. In GSWA usage, this term is reserved for a schist for which a protolith cannot be conclusively established. See also definition of schist/schistose structure in Fettes and Desmons, 2007, p. 193)."@en ;
+    skos:definition "A schist distinguished by a red or rusty colour due to the presence of ferric oxide. In GSWA usage, this term is reserved for a schist for which a protolith cannot be conclusively established. See also definition of schist/schistose structure in Fettes and Desmons, 2007, p. 193)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007) and GSWA usage." ;
     skos:inScheme cs: ;
     skos:notation "msj"^^:GSWA-rock-code ;
@@ -1905,8 +1905,8 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :granular-iron-formation ;
-    skos:definition "A granular iron formation with granules larger than 2 mm (i.e. equivalent in size to a conglomerate)."@en ;
-    skos:historyNote "Beukes, NJ and Gutzmer, J 2008, Origin and paleoenvironmental significance of major iron formations at the Archean-Paleoproterozoic boundary: Reviews in Economic Geology, v. 15, p. 5–47, doi:10.5382/Rev.15.01." ;
+    skos:definition "A granular iron formation with granules larger than 2 mm (i.e. equivalent in size to a conglomerate)."@en ;
+    skos:historyNote "Beukes, NJ and Gutzmer, J 2008, Origin and paleoenvironmental significance of major iron formations at the Archean-Paleoproterozoic boundary: Reviews in Economic Geology, v. 15, p. 5–47, doi:10.5382/Rev.15.01." ;
     skos:inScheme cs: ;
     skos:notation "cigr"^^:GSWA-rock-code ;
     skos:prefLabel "ferudite"@en ;
@@ -1927,7 +1927,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-foid-bearing-intrusive ;
-    skos:definition "A collective term for alkali feldspar syenites containing small amounts of feldspathoids (less than 10% of the felsic minerals). Now defined modally in QAPF field 6' (Fig. 2.4, p. 22). (Le Maitre et al., 2005, p. 81)"@en ;
+    skos:definition "A collective term for alkali feldspar syenites containing small amounts of feldspathoids (less than 10% of the felsic minerals). Now defined modally in QAPF field 6' (Fig. 2.4, p. 22). (Le Maitre et al., 2005, p. 81)"@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "dr"^^:GSWA-rock-code ;
@@ -1939,7 +1939,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-foid-bearing-intrusive ;
-    skos:definition "A collective term for anorthosites containing small amounts of feldspathoids (less than 10% of the felsic minerals). Now defined modally in QAPF field 10' (Fig. 2.4, p. 22). (Le Maitre et al., 2005, p. 81)"@en ;
+    skos:definition "A collective term for anorthosites containing small amounts of feldspathoids (less than 10% of the felsic minerals). Now defined modally in QAPF field 10' (Fig. 2.4, p. 22). (Le Maitre et al., 2005, p. 81)"@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "dw"^^:GSWA-rock-code ;
@@ -1951,7 +1951,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-foid-bearing-intrusive ;
-    skos:definition "A collective term for diorites containing small amounts of feldspathoids (less than 10% of the felsic minerals). Now defined modally in QAPF field 10' (Fig. 2.4, p. 22–23). (Le Maitre et al., 2005, p. 81)"@en ;
+    skos:definition "A collective term for diorites containing small amounts of feldspathoids (less than 10% of the felsic minerals). Now defined modally in QAPF field 10' (Fig. 2.4, p. 22–23). (Le Maitre et al., 2005, p. 81)"@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "dd"^^:GSWA-rock-code ;
@@ -1963,7 +1963,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-foid-bearing-intrusive ;
-    skos:definition "A collective term for gabbros containing small amounts of feldspathoids (less than 10% of the felsic minerals). Now defined modally in QAPF field 10' (Fig. 2.4, p. 22). (Le Maitre et al., 2005, p. 81)"@en ;
+    skos:definition "A collective term for gabbros containing small amounts of feldspathoids (less than 10% of the felsic minerals). Now defined modally in QAPF field 10' (Fig. 2.4, p. 22). (Le Maitre et al., 2005, p. 81)"@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "du"^^:GSWA-rock-code ;
@@ -1998,7 +1998,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-feldspathoid-bearing-volcanic ;
-    skos:definition "A collective term for latites containing small amounts of feldspathoids (less than 10% of the felsic minerals). Now defined modally in QAPF field 8' (Fig. 2.11, p. 31). (Le Maitre et al., 2005, p. 82)"@en ;
+    skos:definition "A collective term for latites containing small amounts of feldspathoids (less than 10% of the felsic minerals). Now defined modally in QAPF field 8' (Fig. 2.11, p. 31). (Le Maitre et al., 2005, p. 82)"@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "ll"^^:GSWA-rock-code ;
@@ -2009,7 +2009,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-foid-bearing-intrusive ;
-    skos:definition "A collective term for monzodiorites containing small amounts of feldspathoids (less than 10% of the felsic minerals). Now defined modally in QAPF field 9' (Fig. 2.4, p. 22). (Le Maitre et al., 2005, p. 82)"@en ;
+    skos:definition "A collective term for monzodiorites containing small amounts of feldspathoids (less than 10% of the felsic minerals). Now defined modally in QAPF field 9' (Fig. 2.4, p. 22). (Le Maitre et al., 2005, p. 82)"@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "dh"^^:GSWA-rock-code ;
@@ -2021,7 +2021,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-foid-bearing-intrusive ;
-    skos:definition "A collective term for monzogabbros containing small amounts of feldspathoids (less than 10% of the felsic minerals). Now defined modally in QAPF field 9' (Fig. 2.4, p. 22). (Le Maitre et al., 2005, p. 82)"@en ;
+    skos:definition "A collective term for monzogabbros containing small amounts of feldspathoids (less than 10% of the felsic minerals). Now defined modally in QAPF field 9' (Fig. 2.4, p. 22). (Le Maitre et al., 2005, p. 82)"@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "dj"^^:GSWA-rock-code ;
@@ -2033,7 +2033,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-foid-bearing-intrusive ;
-    skos:definition "A collective term for monzonites containing small amounts of feldspathoids (less than 10% of the felsic minerals). Now defined modally in QAPF field 8' (Fig. 2.4, p. 22). (Le Maitre et al., 2005, p. 82)"@en ;
+    skos:definition "A collective term for monzonites containing small amounts of feldspathoids (less than 10% of the felsic minerals). Now defined modally in QAPF field 8' (Fig. 2.4, p. 22). (Le Maitre et al., 2005, p. 82)"@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "dz"^^:GSWA-rock-code ;
@@ -2045,7 +2045,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-foid-bearing-intrusive ;
-    skos:definition "A collective term for syenites containing small amounts of feldspathoids (less than 10% of the felsic minerals). Now defined modally in QAPF field 7' (Fig. 2.4, p. 22). (Le Maitre et al., 2005, p. 82)"@en ;
+    skos:definition "A collective term for syenites containing small amounts of feldspathoids (less than 10% of the felsic minerals). Now defined modally in QAPF field 7' (Fig. 2.4, p. 22). (Le Maitre et al., 2005, p. 82)"@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "dy"^^:GSWA-rock-code ;
@@ -2057,7 +2057,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-feldspathoid-bearing-volcanic ;
-    skos:definition "A collective term for trachytes containing small amounts of feldspathoids (less than 10% of the felsic minerals). Now defined modally in QAPF field7' (Fig. 2.11, p. 31). (Le Maitre et al., 2005, p. 82)"@en ;
+    skos:definition "A collective term for trachytes containing small amounts of feldspathoids (less than 10% of the felsic minerals). Now defined modally in QAPF field7' (Fig. 2.11, p. 31). (Le Maitre et al., 2005, p. 82)"@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "lt"^^:GSWA-rock-code ;
@@ -2079,7 +2079,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-feldspathoid-bearing-volcanic ;
-    skos:definition "A volcaniclastic rock composed mostly of angular fragments greater than 2 mm in size consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with foid modal content greater than 0%. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
+    skos:definition "A volcaniclastic rock composed mostly of angular fragments greater than 2 mm in size consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with foid modal content greater than 0%. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "lvb"^^:GSWA-rock-code ;
@@ -2090,7 +2090,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-feldspathoid-bearing-volcanic ;
-    skos:definition "A volcaniclastic rock composed mostly of angular fragments ranging in size from sand (0.0625 – 2 mm) and above, consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with a foid modal content greater than 0%. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion w, and with an overall mafic composition."@en ;
+    skos:definition "A volcaniclastic rock composed mostly of angular fragments ranging in size from sand (0.0625 – 2 mm) and above, consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with a foid modal content greater than 0%. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion w, and with an overall mafic composition."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "lvbs"^^:GSWA-rock-code ;
@@ -2112,7 +2112,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-feldspathoid-bearing-volcanic ;
-    skos:definition "A breccia composed mostly of angular fragments ranging in size from granule (2–4 mm) to pebble (4–32 mm) consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with a foid modal content greater than 0%. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
+    skos:definition "A breccia composed mostly of angular fragments ranging in size from granule (2–4 mm) to pebble (4–32 mm) consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with a foid modal content greater than 0%. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "lvg"^^:GSWA-rock-code ;
@@ -2123,7 +2123,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-feldspathoid-bearing-volcanic ;
-    skos:definition "A mudstone (grain size ranging from silt to clay, i.e. less than 0.0625 mm) consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with a foid modal content greater than 0%. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
+    skos:definition "A mudstone (grain size ranging from silt to clay, i.e. less than 0.0625 mm) consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with a foid modal content greater than 0%. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "lvsm"^^:GSWA-rock-code ;
@@ -2145,7 +2145,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-feldspathoid-bearing-volcanic ;
-    skos:definition "A sandstone (grain size 0.0625 – 2 mm) consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with a foid modal content greater than 0%. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
+    skos:definition "A sandstone (grain size 0.0625 – 2 mm) consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with a foid modal content greater than 0%. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "lvs"^^:GSWA-rock-code ;
@@ -2156,7 +2156,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-feldspathoid-bearing-volcanic ;
-    skos:definition "A volcaniclastic rock composed mostly of fragments ranging in size from sand (0.0625 – 2 mm) to silt (0.0039 – 0.0625 mm) of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with a foid modal content greater than 0%. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion w, and with an overall mafic composition."@en ;
+    skos:definition "A volcaniclastic rock composed mostly of fragments ranging in size from sand (0.0625 – 2 mm) to silt (0.0039 – 0.0625 mm) of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with a foid modal content greater than 0%. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion w, and with an overall mafic composition."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "lvss"^^:GSWA-rock-code ;
@@ -2167,7 +2167,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-feldspathoid-bearing-volcanic ;
-    skos:definition "A commonly monomictic breccia with a foid modal content greater than 0% and composed of angular, coarse igneous fragments cemented by a fine-grained matrix that is clastic though not necessarily strictly sedimentary in origin"@en ;
+    skos:definition "A commonly monomictic breccia with a foid modal content greater than 0% and composed of angular, coarse igneous fragments cemented by a fine-grained matrix that is clastic though not necessarily strictly sedimentary in origin"@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "lvsb"^^:GSWA-rock-code ;
@@ -2178,7 +2178,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-foid-bearing-intrusive ;
-    skos:definition "A collective term for alkaline intrusive rocks consisting of feldspathoids (10–60% of the felsic minerals), intermediate plagioclase and large amounts of mafic minerals. Now defined modally in QAPF field 14 (Fig. 2.4, p. 22). (Le Maitre et al., 2005, p. 80)"@en ;
+    skos:definition "A collective term for alkaline intrusive rocks consisting of feldspathoids (10–60% of the felsic minerals), intermediate plagioclase and large amounts of mafic minerals. Now defined modally in QAPF field 14 (Fig. 2.4, p. 22). (Le Maitre et al., 2005, p. 80)"@en ;
     skos:exactMatch
         <http://inspire.ec.europa.eu/codelist/LithologyValue/foidDiorite> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/foid_diorite> ;
@@ -2193,7 +2193,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-foid-bearing-intrusive ;
-    skos:definition "A collective term for basic alkaline intrusive rocks consisting of feldspathoids (10–60% of the felsic minerals), calcic plagioclase and large amounts of mafic minerals. Now defined modally in QAPF field 14 (Fig. 2.4, p. 22). (Le Maitre et al., 2005, p. 81)"@en ;
+    skos:definition "A collective term for basic alkaline intrusive rocks consisting of feldspathoids (10–60% of the felsic minerals), calcic plagioclase and large amounts of mafic minerals. Now defined modally in QAPF field 14 (Fig. 2.4, p. 22). (Le Maitre et al., 2005, p. 81)"@en ;
     skos:exactMatch
         <http://inspire.ec.europa.eu/codelist/LithologyValue/foidGabbro> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/foid_gabbro> ;
@@ -2208,7 +2208,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-foid-bearing-intrusive ;
-    skos:definition "A collective term for alkaline intrusive rocks consisting of feldspathoids (10–60% of the felsic minerals), intermediate plagioclase with subordinate alkali feldspar and large amounts of mafic minerals. Now defined modally in QAPF field 13 (Fig. 2.4, p. 22). (Le Maitre et al., 2005, p. 81)"@en ;
+    skos:definition "A collective term for alkaline intrusive rocks consisting of feldspathoids (10–60% of the felsic minerals), intermediate plagioclase with subordinate alkali feldspar and large amounts of mafic minerals. Now defined modally in QAPF field 13 (Fig. 2.4, p. 22). (Le Maitre et al., 2005, p. 81)"@en ;
     skos:exactMatch
         <http://inspire.ec.europa.eu/codelist/LithologyValue/foidMonzodiorite> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/foid_monzodiorite> ;
@@ -2223,7 +2223,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-foid-bearing-intrusive ;
-    skos:definition "A collective term for basic alkaline intrusive rocks consisting of feldspathoids (10–60% of the felsic minerals), calcic plagioclase with subordinate alkali feldspar and large amounts of mafic minerals. Now defined modally in QAPF field 13 (Fig. 2.4, p. 22). (Le Maitre et al., 2005, p. 81)"@en ;
+    skos:definition "A collective term for basic alkaline intrusive rocks consisting of feldspathoids (10–60% of the felsic minerals), calcic plagioclase with subordinate alkali feldspar and large amounts of mafic minerals. Now defined modally in QAPF field 13 (Fig. 2.4, p. 22). (Le Maitre et al., 2005, p. 81)"@en ;
     skos:exactMatch
         <http://inspire.ec.europa.eu/codelist/LithologyValue/foidMonzogabbro> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/foid_monzogabbro> ;
@@ -2238,7 +2238,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-foid-bearing-intrusive ;
-    skos:definition "A collective term for rare alkaline intrusive rocks consisting of feldspathoids, alkali feldspar, plagioclase and mafic minerals. Now defined modally in QAPF field 12 (Fig. 2.4, p. 22). (Le Maitre et al., 2005, p. 81)"@en ;
+    skos:definition "A collective term for rare alkaline intrusive rocks consisting of feldspathoids, alkali feldspar, plagioclase and mafic minerals. Now defined modally in QAPF field 12 (Fig. 2.4, p. 22). (Le Maitre et al., 2005, p. 81)"@en ;
     skos:exactMatch
         <http://inspire.ec.europa.eu/codelist/LithologyValue/foidMonzosyenite> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/foid_monzosyenite> ;
@@ -2253,7 +2253,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-foid-bearing-intrusive ;
-    skos:definition "A collective term for leucocratic alkaline intrusive rocks consisting of feldspathoids (10–60% of the felsic minerals), alkali feldspar and mafic minerals. Now defined modally in QAPF field 11 (Fig. 2.4, p. 22). (Le Maitre et al., 2005, p. 81)"@en ;
+    skos:definition "A collective term for leucocratic alkaline intrusive rocks consisting of feldspathoids (10–60% of the felsic minerals), alkali feldspar and mafic minerals. Now defined modally in QAPF field 11 (Fig. 2.4, p. 22). (Le Maitre et al., 2005, p. 81)"@en ;
     skos:exactMatch
         <http://inspire.ec.europa.eu/codelist/LithologyValue/foidSyenite> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/foid_syenite> ;
@@ -2279,7 +2279,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-felsic-intrusive ;
-    skos:definition "A demonstrably felsic intrusive rock, otherwise uncategorized, with a preferred planar orientation of inequant mineral grains or grain aggregates (cf. definition of foliation in Fettes and Desmons, 2007, p. 153)"@en ;
+    skos:definition "A demonstrably felsic intrusive rock, otherwise uncategorized, with a preferred planar orientation of inequant mineral grains or grain aggregates (cf. definition of foliation in Fettes and Desmons, 2007, p. 153)"@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:notation "mgss"^^:GSWA-rock-code ;
@@ -2290,7 +2290,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metamorphosed-quartz-vein ;
-    skos:definition "A metamorphosed quartz vein with a repetitively occurring or penetrative planar feature (cf. Fettes and Desmons, 2007, p. 153)."@en ;
+    skos:definition "A metamorphosed quartz vein with a repetitively occurring or penetrative planar feature (cf. Fettes and Desmons, 2007, p. 153)."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "mzqs"^^:GSWA-rock-code ;
@@ -2301,7 +2301,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-mafic-intrusive ;
-    skos:definition "A coarse-grained intrusive rock (and including coarse-grained parts of extrusive successions) composed essentially of calcic plagioclase, pyroxene and iron oxides. If olivine is an essential constituent it is olivine gabbro; if quartz is an essential constituent it is quartz gabbro. Now defined modally in QAPF field 10 (Fig. 2.4, p. 22). (cf. Le Maitre et al., 2005, p.  83)"@en ;
+    skos:definition "A coarse-grained intrusive rock (and including coarse-grained parts of extrusive successions) composed essentially of calcic plagioclase, pyroxene and iron oxides. If olivine is an essential constituent it is olivine gabbro; if quartz is an essential constituent it is quartz gabbro. Now defined modally in QAPF field 10 (Fig. 2.4, p. 22). (cf. Le Maitre et al., 2005, p.  83)"@en ;
     skos:exactMatch
         <http://inspire.ec.europa.eu/codelist/LithologyValue/gabbro> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/gabbro> ;
@@ -2316,7 +2316,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-mafic-intrusive ;
-    skos:definition "A collective name for an intrusive rock consisting of calcic plagioclase and roughly equal amounts of clinopyroxene and orthopyroxene. Now defined modally in the gabbroic rock classification (Fig. 2.6, p. 25). (Le Maitre et al., 2005, p. 83)"@en ;
+    skos:definition "A collective name for an intrusive rock consisting of calcic plagioclase and roughly equal amounts of clinopyroxene and orthopyroxene. Now defined modally in the gabbroic rock classification (Fig. 2.6, p. 25). (Le Maitre et al., 2005, p. 83)"@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "om"^^:GSWA-rock-code ;
@@ -2328,7 +2328,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metamorphic-protolith-unknown-gneiss ;
-    skos:definition "A metamorphic rock for which a protolith cannot be conclusively identified and displaying a gneissose structure, i.e. a foliated rock formed by regional metamorphism in which bands or lenticles of granular minerals alternate with bands or lenticles in which minerals having flaky or elongate prismatic habits predominate. Generally less than 50% of the minerals show preferred parallel orientation. Definition adapted from Fettes and Desmons (2007, p. 154–155) and Glossary of geology 2011, 5th edition revised)."@en ;
+    skos:definition "A metamorphic rock for which a protolith cannot be conclusively identified and displaying a gneissose structure, i.e. a foliated rock formed by regional metamorphism in which bands or lenticles of granular minerals alternate with bands or lenticles in which minerals having flaky or elongate prismatic habits predominate. Generally less than 50% of the minerals show preferred parallel orientation. Definition adapted from Fettes and Desmons (2007, p. 154–155) and Glossary of geology 2011, 5th edition revised)."@en ;
     skos:exactMatch
         <http://inspire.ec.europa.eu/codelist/LithologyValue/gneiss> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/gneiss> ;
@@ -2343,7 +2343,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metamorphic-protolith-unknown-gneiss ;
-    skos:definition "A high-grade metamorphic rock, with a granoblastic texture and little foliation/lineation and in which Fe–Mg silicates are dominantly hydroxyl-free, feldspar is a critical phase, and primary muscovite is absent. In GSWA usage, this term is reserved for a gneiss for which a protolith cannot be conclusively established. See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
+    skos:definition "A high-grade metamorphic rock, with a granoblastic texture and little foliation/lineation and in which Fe–Mg silicates are dominantly hydroxyl-free, feldspar is a critical phase, and primary muscovite is absent. In GSWA usage, this term is reserved for a gneiss for which a protolith cannot be conclusively established. See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007) and GSWA usage." ;
     skos:inScheme cs: ;
     skos:notation "mno"^^:GSWA-rock-code ;
@@ -2355,7 +2355,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metamorphosed-hydrothermal ;
-    skos:definition "A metamorphosed hydrothermal igneous rock displaying a gneissose structure. See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
+    skos:definition "A metamorphosed hydrothermal igneous rock displaying a gneissose structure. See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007) and GSWA usage." ;
     skos:inScheme cs: ;
     skos:notation "mzn"^^:GSWA-rock-code ;
@@ -2383,7 +2383,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
         "itabirite"@en ,
         "taconite"@en ;
     skos:broader :metasedimentary-other-chemical-meta-iron-formation ;
-    skos:definition "A metamorphosed iron formation displaying a gneissose structure, i.e. a gneiss derived from a chemical or biochemical sedimentary protolith containing at least 15% iron of sedimentary origin. See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
+    skos:definition "A metamorphosed iron formation displaying a gneissose structure, i.e. a gneiss derived from a chemical or biochemical sedimentary protolith containing at least 15% iron of sedimentary origin. See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007) and GSWA usage." ;
     skos:inScheme cs: ;
     skos:notation "min"^^:GSWA-rock-code ;
@@ -2395,7 +2395,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-carbonatite ;
-    skos:definition "A gneiss derived by metamorphism of an igneous protolith containing a modal amount of primary carbonate minerals greater than 50%. See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
+    skos:definition "A gneiss derived by metamorphism of an igneous protolith containing a modal amount of primary carbonate minerals greater than 50%. See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
     skos:inScheme cs: ;
     skos:notation "mqn"^^:GSWA-rock-code ;
     skos:prefLabel "gneissose metacarbonatite"@en ;
@@ -2405,7 +2405,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metasedimentary-other-chemical ;
-    skos:definition "A metamorphosed chert displaying a gneissose structure, i.e. a gneiss from a chemical or biochemical sedimentary rock largely consisting of silica and/or quartz. See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
+    skos:definition "A metamorphosed chert displaying a gneissose structure, i.e. a gneiss from a chemical or biochemical sedimentary rock largely consisting of silica and/or quartz. See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "mcn"^^:GSWA-rock-code ;
@@ -2416,7 +2416,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :para-amphibolite-derived-from-carbonate-rock ;
-    skos:definition "A metamorphosed amphibole-rich rock derived from a sedimentary carbonate protolith and displaying a gneissose structure. See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
+    skos:definition "A metamorphosed amphibole-rich rock derived from a sedimentary carbonate protolith and displaying a gneissose structure. See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "mkan"^^:GSWA-rock-code ;
@@ -2449,7 +2449,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-felsic-intrusive ;
-    skos:definition "A metamorphosed felsic intrusive rock displaying a gneissose structure, i.e. a gneiss derived from an intrusive rock with one or more felsic minerals as the main component(s). See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
+    skos:definition "A metamorphosed felsic intrusive rock displaying a gneissose structure, i.e. a gneiss derived from an intrusive rock with one or more felsic minerals as the main component(s). See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:notation "mgn"^^:GSWA-rock-code ;
@@ -2460,7 +2460,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-felsic-intrusive ;
-    skos:definition "A metamorphosed felsic intrusive rock displaying a granofelsic structure, i.e. a granofels/hornfels derived from an intrusive rock with one or more felsic minerals as the main components. See also definition of granofels/granofelsic structure in Fettes and Desmons (2007, p. 156); hornfels are granofels formed by contact metamorphism (Fettes and Desmons, 2007, p. 159)."@en ;
+    skos:definition "A metamorphosed felsic intrusive rock displaying a granofelsic structure, i.e. a granofels/hornfels derived from an intrusive rock with one or more felsic minerals as the main components. See also definition of granofels/granofelsic structure in Fettes and Desmons (2007, p. 156); hornfels are granofels formed by contact metamorphism (Fettes and Desmons, 2007, p. 159)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:notation "mge"^^:GSWA-rock-code ;
@@ -2494,7 +2494,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-felsic-intrusive ;
-    skos:definition "A metamorphosed felsic intrusive rock displaying a schistose structure, i.e. a schist derived from an intrusive rock with one or more felsic minerals as the main component(s). See also definition of schist/schistose structure in Fettes and Desmons, 2007, p. 193)."@en ;
+    skos:definition "A metamorphosed felsic intrusive rock displaying a schistose structure, i.e. a schist derived from an intrusive rock with one or more felsic minerals as the main component(s). See also definition of schist/schistose structure in Fettes and Desmons, 2007, p. 193)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:notation "mgs"^^:GSWA-rock-code ;
@@ -2505,7 +2505,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-felsic-intrusive ;
-    skos:definition "An intrusive rock consisting essentially of quartz, sodic plagioclase and lesser amounts of alkali feldspar with minor amounts of hornblende and biotite. Now defined modally in QAPF field 4 (Fig. 2.4, p. 22). (cf. Le Maitre et al., 2005, p. 86)"@en ;
+    skos:definition "An intrusive rock consisting essentially of quartz, sodic plagioclase and lesser amounts of alkali feldspar with minor amounts of hornblende and biotite. Now defined modally in QAPF field 4 (Fig. 2.4, p. 22). (cf. Le Maitre et al., 2005, p. 86)"@en ;
     skos:exactMatch
         <http://inspire.ec.europa.eu/codelist/LithologyValue/granodiorite> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/granodiorite> ;
@@ -2520,7 +2520,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metamorphic-protolith-unknown-granofels-hornfels ;
-    skos:definition "A metamorphic rock for which a protolith cannot be conclusively established and displaying a granofelsic structure, i.e. a structure resulting from the absence of schistosity such that the mineral grains and aggregates of mineral grains are equant (for example quartz, feldspar, garnet and pyroxene) or, if inequant, have a random orientation. Mineralogical or lithological layering may be present. Definition adapted from Fettes and Desmons (2007, p. 156). Hornfels are granofels that are typically formed by contact metasomatism and occur mostly (though not exclusively) in the innermost part of contact aureoles. Definition adapted from Fettes and Desmons (2007, p. 159) and Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
+    skos:definition "A metamorphic rock for which a protolith cannot be conclusively established and displaying a granofelsic structure, i.e. a structure resulting from the absence of schistosity such that the mineral grains and aggregates of mineral grains are equant (for example quartz, feldspar, garnet and pyroxene) or, if inequant, have a random orientation. Mineralogical or lithological layering may be present. Definition adapted from Fettes and Desmons (2007, p. 156). Hornfels are granofels that are typically formed by contact metasomatism and occur mostly (though not exclusively) in the innermost part of contact aureoles. Definition adapted from Fettes and Desmons (2007, p. 159) and Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:narrowMatch
@@ -2539,7 +2539,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metamorphic-protolith-unknown-granofels-hornfels ;
-    skos:definition "A high-grade metamorphic rock, with a granoblastic texture and little foliation/lineation and in which Fe–Mg silicates are dominantly hydroxyl-free, feldspar is a critical phase, and primary muscovite is absent (cf. Fettes and Desmons, 2007, p. 156). In GSWA usage, this term is reserved for a granofels/hornfels for which a protolith cannot be conclusively established."@en ;
+    skos:definition "A high-grade metamorphic rock, with a granoblastic texture and little foliation/lineation and in which Fe–Mg silicates are dominantly hydroxyl-free, feldspar is a critical phase, and primary muscovite is absent (cf. Fettes and Desmons, 2007, p. 156). In GSWA usage, this term is reserved for a granofels/hornfels for which a protolith cannot be conclusively established."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:notation "meo"^^:GSWA-rock-code ;
@@ -2550,7 +2550,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metamorphosed-hydrothermal ;
-    skos:definition "A metamorphosed hydrothermal rock displaying a granofelsic structure, i.e. a granofels/hornfels derived from a hydrothermal protolith. See also definition of granofels/granofelsic structure in Fettes and Desmons (2007, p. 156); hornfels are granofels formed by contact metamorphism (Fettes and Desmons, 2007, p. 159)."@en ;
+    skos:definition "A metamorphosed hydrothermal rock displaying a granofelsic structure, i.e. a granofels/hornfels derived from a hydrothermal protolith. See also definition of granofels/granofelsic structure in Fettes and Desmons (2007, p. 156); hornfels are granofels formed by contact metamorphism (Fettes and Desmons, 2007, p. 159)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007) and GSWA usage." ;
     skos:inScheme cs: ;
     skos:notation "mze"^^:GSWA-rock-code ;
@@ -2580,7 +2580,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
         "itabirite"@en ,
         "taconite"@en ;
     skos:broader :metasedimentary-other-chemical-meta-iron-formation ;
-    skos:definition "A metamorphosed iron formation displaying a granofelsic structure, i.e. a granofels/hornfels derived from a chemical or biochemical sedimentary protolith containing at least 15% iron of sedimentary origin. See also definition of granofels/granofelsic structure in Fettes and Desmons (2007, p. 156); hornfels are granofels formed by contact metamorphism (Fettes and Desmons, 2007, p. 159)."@en ;
+    skos:definition "A metamorphosed iron formation displaying a granofelsic structure, i.e. a granofels/hornfels derived from a chemical or biochemical sedimentary protolith containing at least 15% iron of sedimentary origin. See also definition of granofels/granofelsic structure in Fettes and Desmons (2007, p. 156); hornfels are granofels formed by contact metamorphism (Fettes and Desmons, 2007, p. 159)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007) and GSWA usage." ;
     skos:inScheme cs: ;
     skos:notation "mie"^^:GSWA-rock-code ;
@@ -2594,7 +2594,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metasedimentary-other-chemical ;
-    skos:definition "A metamorphosed chert displaying a granofelsic structure, i.e. a granofels/hornfels derived from a chemical or biochemical sedimentary rock largely consisting of silica and/or quartz. See also definition of granofels/granofelsic structure in Fettes and Desmons (2007, p. 156); hornfels are granofels formed by contact metamorphism (Fettes and Desmons, 2007, p. 159)."@en ;
+    skos:definition "A metamorphosed chert displaying a granofelsic structure, i.e. a granofels/hornfels derived from a chemical or biochemical sedimentary rock largely consisting of silica and/or quartz. See also definition of granofels/granofelsic structure in Fettes and Desmons (2007, p. 156); hornfels are granofels formed by contact metamorphism (Fettes and Desmons, 2007, p. 159)."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "mce"^^:GSWA-rock-code ;
@@ -2605,7 +2605,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :para-amphibolite-derived-from-carbonate-rock ;
-    skos:definition "A metamorphosed amphibole-rich rock derived from a sedimentary carbonate protolith and displaying a granofelsic/hornfelsic structure. See also definition of granofels/granofelsic structure in Fettes and Desmons (2007, p. 156); hornfels are granofels formed by contact metamorphism (Fettes and Desmons, 2007, p. 159)."@en ;
+    skos:definition "A metamorphosed amphibole-rich rock derived from a sedimentary carbonate protolith and displaying a granofelsic/hornfelsic structure. See also definition of granofels/granofelsic structure in Fettes and Desmons (2007, p. 156); hornfels are granofels formed by contact metamorphism (Fettes and Desmons, 2007, p. 159)."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "mkae"^^:GSWA-rock-code ;
@@ -2627,7 +2627,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-felsic-intrusive ;
-    skos:definition "A porphyritic rock of granite composition in which the groundmass alkali feldspar and quartz are in micrographic intergrowth (Le Maitre et al., 2005, p. 86). A strict and limited usage of the term is encouraged in the GSWA scheme."@en ;
+    skos:definition "A porphyritic rock of granite composition in which the groundmass alkali feldspar and quartz are in micrographic intergrowth (Le Maitre et al., 2005, p. 86). A strict and limited usage of the term is encouraged in the GSWA scheme."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005) and GSWA usage." ;
     skos:inScheme cs: ;
     skos:notation "gv"^^:GSWA-rock-code ;
@@ -2643,8 +2643,8 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
         "gritstone"@en ,
         "very fine pebble conglomerate"@en ;
     skos:broader :conglomerate ;
-    skos:definition "A consolidated rock consisting mainly of granules that are larger than a very coarse sand grain and smaller than a pebble (2–4 mm or -1 to -2 phi units) being somewhat rounded or otherwise modified by abrasion in the course of transport; a consolidated granule gravel. The term very fine pebble conglomerate has been used as a synonym. Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
-    skos:historyNote "Wentworth, CK 1922, A scale of grade and class terms for clastic sediments: The Journal of Geology, v. 30, no. 5, p. 377–392, doi:10.1086/622910." ;
+    skos:definition "A consolidated rock consisting mainly of granules that are larger than a very coarse sand grain and smaller than a pebble (2–4 mm or -1 to -2 phi units) being somewhat rounded or otherwise modified by abrasion in the course of transport; a consolidated granule gravel. The term very fine pebble conglomerate has been used as a synonym. Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
+    skos:historyNote "Wentworth, CK 1922, A scale of grade and class terms for clastic sediments: The Journal of Geology, v. 30, no. 5, p. 377–392, doi:10.1086/622910." ;
     skos:inScheme cs: ;
     skos:notation "su"^^:GSWA-rock-code ;
     skos:prefLabel "granule conglomerate"@en ;
@@ -2666,7 +2666,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metamorphic-protolith-unknown-gneiss ;
-    skos:definition "A gneiss distinguished by the presence of graphite/carbon. In GSWA usage, this term is reserved for a gneiss for which a protolith cannot be conclusively established. See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p.  154–155)."@en ;
+    skos:definition "A gneiss distinguished by the presence of graphite/carbon. In GSWA usage, this term is reserved for a gneiss for which a protolith cannot be conclusively established. See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p.  154–155)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007) and GSWA usage." ;
     skos:inScheme cs: ;
     skos:notation "mng"^^:GSWA-rock-code ;
@@ -2689,7 +2689,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metamorphic-protolith-unknown-schist ;
-    skos:definition "A schist distinguished by the presence of graphite/carbon. In GSWA usage, this term is reserved for a schist for which a protolith cannot be conclusively established. See also definition of schist/schistose structure in Fettes and Desmons, 2007, p.  193)."@en ;
+    skos:definition "A schist distinguished by the presence of graphite/carbon. In GSWA usage, this term is reserved for a schist for which a protolith cannot be conclusively established. See also definition of schist/schistose structure in Fettes and Desmons, 2007, p.  193)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007) and GSWA usage." ;
     skos:inScheme cs: ;
     skos:notation "msg"^^:GSWA-rock-code ;
@@ -2700,7 +2700,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metasomatic ;
-    skos:definition "Medium-temperature metasomatic rock characterized by the presence of quartz and white mica, commonly with topaz, fluorite, tourmaline and locally with amazonite, orthoclase, andalusite and diaspore. Typically greisens may host B, W, Mo, Sn and Ta mineralization. They are associated with high-level late orogenic leucogranites, and form as replacements either in the granite body and/or in a wide range of country rocks. (Fettes and Desmons, 2007, p. 157). Zoning may be present and is characterized by gradients from coarse, crystalline granite, commonly vuggy with miarolitic cavities, through to quartz- and muscovite-rich rocks, which may be locally rich in accessory minerals (e.g. topaz, tourmaline, cassiterite, fluorite, beryl, wolframite, siderite, molybdenite and other sulfide minerals). They may occur as small to large veins, or large zones in the roof of some granites. Greisen is formed by self-generated alteration of a granite and is a class of moderate- to high-temperature magmatic-hydrothermal alteration related to the late-stage release of volatiles dissolved in a magma during the solidification of that magma (https://en.wikipedia.org/wiki/Greisen)."@en ;
+    skos:definition "Medium-temperature metasomatic rock characterized by the presence of quartz and white mica, commonly with topaz, fluorite, tourmaline and locally with amazonite, orthoclase, andalusite and diaspore. Typically greisens may host B, W, Mo, Sn and Ta mineralization. They are associated with high-level late orogenic leucogranites, and form as replacements either in the granite body and/or in a wide range of country rocks. (Fettes and Desmons, 2007, p. 157). Zoning may be present and is characterized by gradients from coarse, crystalline granite, commonly vuggy with miarolitic cavities, through to quartz- and muscovite-rich rocks, which may be locally rich in accessory minerals (e.g. topaz, tourmaline, cassiterite, fluorite, beryl, wolframite, siderite, molybdenite and other sulfide minerals). They may occur as small to large veins, or large zones in the roof of some granites. Greisen is formed by self-generated alteration of a granite and is a class of moderate- to high-temperature magmatic-hydrothermal alteration related to the late-stage release of volatiles dissolved in a magma during the solidification of that magma (https://en.wikipedia.org/wiki/Greisen)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:notation "mjr"^^:GSWA-rock-code ;
@@ -2743,7 +2743,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-ultramafic-intrusive ;
-    skos:definition "An ultramafic intrusive rock composed essentially of olivine and orthopyroxene. Now defined modally in the ultramafic rock classification (Fig. 2.9, p. 28). (cf. Le Maitre et al., 2005, p. 88)"@en ;
+    skos:definition "An ultramafic intrusive rock composed essentially of olivine and orthopyroxene. Now defined modally in the ultramafic rock classification (Fig. 2.9, p. 28). (cf. Le Maitre et al., 2005, p. 88)"@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "aph"^^:GSWA-rock-code ;
@@ -2755,7 +2755,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-mafic-intrusive ;
-    skos:definition "A variety of gabbro in which primary hornblende occurs. Now defined modally in the gabbroic rock classification (Fig. 2.6, p. 25). (Le Maitre et al., 2005, p. 90)"@en ;
+    skos:definition "A variety of gabbro in which primary hornblende occurs. Now defined modally in the gabbroic rock classification (Fig. 2.6, p. 25). (Le Maitre et al., 2005, p. 90)"@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "oh"^^:GSWA-rock-code ;
@@ -2767,7 +2767,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-ultramafic-intrusive ;
-    skos:definition "An ultramafic intrusive rock consisting essentially of olivine with up to 60% hornblende. Now defined modally in the ultramafic rock classification (Fig. 2.9, p. 28). Adapted from Le Maitre et al. (2005, p. 90)."@en ;
+    skos:definition "An ultramafic intrusive rock consisting essentially of olivine with up to 60% hornblende. Now defined modally in the ultramafic rock classification (Fig. 2.9, p. 28). Adapted from Le Maitre et al. (2005, p. 90)."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "ae"^^:GSWA-rock-code ;
@@ -2779,7 +2779,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-ultramafic-intrusive ;
-    skos:definition "A collective term for pyroxenites containing up to 40% of amphibole. Now defined modally in the ultramafic rock classification (Fig. 2.9, p. 28). (Le Maitre et al., 2005, p. 90)"@en ;
+    skos:definition "A collective term for pyroxenites containing up to 40% of amphibole. Now defined modally in the ultramafic rock classification (Fig. 2.9, p. 28). (Le Maitre et al., 2005, p. 90)"@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "al"^^:GSWA-rock-code ;
@@ -2791,7 +2791,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-ultramafic-intrusive ;
-    skos:definition "An ultramafic intrusive rock composed almost entirely of hornblende. Now defined modally in the ultramafic rock classification (Fig. 2.9, p. 28). (Le Maitre et al., 2005, p. 91)"@en ;
+    skos:definition "An ultramafic intrusive rock composed almost entirely of hornblende. Now defined modally in the ultramafic rock classification (Fig. 2.9, p. 28). (Le Maitre et al., 2005, p. 91)"@en ;
     skos:exactMatch
         <http://inspire.ec.europa.eu/codelist/LithologyValue/hornblendite> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/hornblendite> ;
@@ -2806,7 +2806,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-lamproites ;
-    skos:definition "Originally described as a variety of trachyte characterized by the presence of phlogopite and bronzite (= enstatite). Now regarded as an hyalo–enstatite–phlogopite lamproite (Table 2.7, p. 17), where hyalo refers to the presence of glass. The original name fortunite is not recommended for usage. (Le Maitre et al., 2005, p. 82)"@en ;
+    skos:definition "Originally described as a variety of trachyte characterized by the presence of phlogopite and bronzite (= enstatite). Now regarded as an hyalo–enstatite–phlogopite lamproite (Table 2.7, p. 17), where hyalo refers to the presence of glass. The original name fortunite is not recommended for usage. (Le Maitre et al., 2005, p. 82)"@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "ih"^^:GSWA-rock-code ;
@@ -2818,7 +2818,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-lamproites ;
-    skos:definition "Originally described as a black pitch-like rock, associated with an extrusive mass of fortunite [a variety of trachyte characterized by the presence of phlogopite and bronzite (= enstatite). Now regarded as an hyalo-enstatite–phlogopite lamproite], and consisting of phenocrysts of phlogopite and olivine in a glassy matrix containing microlites of diopside and phlogopite. Now regarded as a hyalo-olivine–diopside–phlogopite lamproite (Table 2.7, p. 17). The original name verite is not recommended for usage. (Le Maitre et al., 2005, p. 154)"@en ;
+    skos:definition "Originally described as a black pitch-like rock, associated with an extrusive mass of fortunite [a variety of trachyte characterized by the presence of phlogopite and bronzite (= enstatite). Now regarded as an hyalo-enstatite–phlogopite lamproite], and consisting of phenocrysts of phlogopite and olivine in a glassy matrix containing microlites of diopside and phlogopite. Now regarded as a hyalo-olivine–diopside–phlogopite lamproite (Table 2.7, p. 17). The original name verite is not recommended for usage. (Le Maitre et al., 2005, p. 154)"@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "iv"^^:GSWA-rock-code ;
@@ -2831,7 +2831,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     rdfs:isDefinedBy cs: ;
     skos:broader :hydrothermal ;
     skos:definition "A rock composed of angular broken rock fragments held together by a mineral cement / fine-grained matrix forming from the interaction of a rock with hydrothermal (typically water-rich) solutions."@en ;
-    skos:historyNote "Jébrak, M 1997, Hydrothermal breccias in vein-type ore deposits: A review of mechanisms, morphology and size distribution: Ore Geology Reviews, v. 12, no. 3, p. 111–134, doi:10.1016/S0169-1368(97)00009-7." ;
+    skos:historyNote "Jébrak, M 1997, Hydrothermal breccias in vein-type ore deposits: A review of mechanisms, morphology and size distribution: Ore Geology Reviews, v. 12, no. 3, p. 111–134, doi:10.1016/S0169-1368(97)00009-7." ;
     skos:inScheme cs: ;
     skos:notation "zx"^^:GSWA-rock-code ;
     skos:prefLabel "hydrothermal breccia"@en ;
@@ -2890,7 +2890,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metamorphic-protolith-unknown-impactite ;
-    skos:definition "Crystalline, semihyaline or hyaline rock solidified from impact melt and containing variable amounts of clastic debris of different degree of shock metamorphism (Fettes and Desmons, 2007, p. 162)."@en ;
+    skos:definition "Crystalline, semihyaline or hyaline rock solidified from impact melt and containing variable amounts of clastic debris of different degree of shock metamorphism (Fettes and Desmons, 2007, p. 162)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:notation "mpe"^^:GSWA-rock-code ;
@@ -2902,7 +2902,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metamorphic-protolith-unknown-impactite ;
-    skos:definition "Rock produced by impact metamorphism, otherwise uncategorized. It includes shocked rocks, impact breccias, impact melt rocks, (micro)tektites, and airfall beds (cf. Fettes and Desmons, 2007, p. 162)."@en ;
+    skos:definition "Rock produced by impact metamorphism, otherwise uncategorized. It includes shocked rocks, impact breccias, impact melt rocks, (micro)tektites, and airfall beds (cf. Fettes and Desmons, 2007, p. 162)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:notation "mp"^^:GSWA-rock-code ;
@@ -2914,7 +2914,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :distal-impactite ;
-    skos:definition "Pelitic sedimentary layer containing a certain fraction of shock-metamorphosed material, e.g. shocked minerals and melt particles, which has been ejected from an impact crater and deposited by interaction with the atmosphere over large regions of a planet or globally. (Fettes and Desmons, 2007, p. 162)"@en ;
+    skos:definition "Pelitic sedimentary layer containing a certain fraction of shock-metamorphosed material, e.g. shocked minerals and melt particles, which has been ejected from an impact crater and deposited by interaction with the atmosphere over large regions of a planet or globally. (Fettes and Desmons, 2007, p. 162)"@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:notation "mpa"^^:GSWA-rock-code ;
@@ -2925,7 +2925,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metamorphic-protolith-unknown-impactite ;
-    skos:definition "Consolidated or unconsolidated sediment resulting from ballistic excavation, transport, and deposition of rocks at impact craters. It may contain glassy or crystallized particles of impact melt. (Fettes and Desmons, 2007, p. 162)"@en ;
+    skos:definition "Consolidated or unconsolidated sediment resulting from ballistic excavation, transport, and deposition of rocks at impact craters. It may contain glassy or crystallized particles of impact melt. (Fettes and Desmons, 2007, p. 162)"@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:notation "mpo"^^:GSWA-rock-code ;
@@ -2960,7 +2960,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     rdfs:isDefinedBy cs: ;
     skos:broader :iron-formation ;
     skos:definition "A banded compact siliceous rock containing at least 25% iron, occurring with iron ores, and resembling jasper, i.e. the variety of chert containing iron-oxide impurities that give it a characteristic red colour."@en ;
-    skos:historyNote "Beukes, NJ and Gutzmer, J 2008, Origin and paleoenvironmental significance of major iron formations at the Archean-Paleoproterozoic boundary: Reviews in Economic Geology, v. 15, p. 5–47, doi:10.5382/Rev.15.01." ;
+    skos:historyNote "Beukes, NJ and Gutzmer, J 2008, Origin and paleoenvironmental significance of major iron formations at the Archean-Paleoproterozoic boundary: Reviews in Economic Geology, v. 15, p. 5–47, doi:10.5382/Rev.15.01." ;
     skos:inScheme cs: ;
     skos:notation "cij"^^:GSWA-rock-code ;
     skos:prefLabel "jaspilite"@en ;
@@ -2971,7 +2971,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-kalsilitic ;
-    skos:definition "A potassic melanocratic variety of olivine melilitite composed essentially of olivine and melilite with subordinate leucite, kalsilite, nepheline and perovskite in a glassy matrix. The historical term katungite is considered obsolete. Cf. Tables 2.5 & 2.6 on p. 12, and p. 96 in Le Maitre et al. (2005)."@en ;
+    skos:definition "A potassic melanocratic variety of olivine melilitite composed essentially of olivine and melilite with subordinate leucite, kalsilite, nepheline and perovskite in a glassy matrix. The historical term katungite is considered obsolete. Cf. Tables 2.5 & 2.6 on p. 12, and p. 96 in Le Maitre et al. (2005)."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005). See also https://academic.oup.com/petrology/article/63/5/egac026/6553206." ;
     skos:inScheme cs: ;
     skos:notation "wk"^^:GSWA-rock-code ;
@@ -2983,7 +2983,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-kalsilitic ;
-    skos:definition "An olivine-free, extrusive melilitite containing small clinopyroxene phenocrysts in a holocrystalline groundmass of melilite, clinopyroxene and phlogopite. The historical term coppaelite is considered obsolete. Cf. Tables 2.5 & 2.6 on p. 12, and p. 70 in Le Maitre et al. (2005)."@en ;
+    skos:definition "An olivine-free, extrusive melilitite containing small clinopyroxene phenocrysts in a holocrystalline groundmass of melilite, clinopyroxene and phlogopite. The historical term coppaelite is considered obsolete. Cf. Tables 2.5 & 2.6 on p. 12, and p. 70 in Le Maitre et al. (2005)."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005). See also https://academic.oup.com/petrology/article/63/5/egac026/6553206." ;
     skos:inScheme cs: ;
     skos:notation "wc"^^:GSWA-rock-code ;
@@ -2995,7 +2995,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-kalsilitic ;
-    skos:definition "A melanocratic variety of leucite olivine melilitite largely composed of melilite, leucite, kalsilite and olivine. The historical term venanzite is considered obsolete. Cf. Tables 2.5 & 2.6 on p. 12, and p. 154 in Le Maitre et al. (2005)."@en ;
+    skos:definition "A melanocratic variety of leucite olivine melilitite largely composed of melilite, leucite, kalsilite and olivine. The historical term venanzite is considered obsolete. Cf. Tables 2.5 & 2.6 on p. 12, and p. 154 in Le Maitre et al. (2005)."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005). See also https://academic.oup.com/petrology/article/63/5/egac026/6553206." ;
     skos:inScheme cs: ;
     skos:notation "wv"^^:GSWA-rock-code ;
@@ -3007,7 +3007,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-kalsilitic ;
-    skos:definition "An ultramafic volcanic rock defined in the kalsilite-bearing rock classification as a rock containing kalsilite, but no leucite or melilite (Le Maitre et al., 2005, p. 94), but otherwise uncategorized. GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks. GSWA usage of this term is restricted to rocks that are partially weathered or are identified using remote sensing imagery, and the use of the related code/notation is limited to GSWA's Explanatory Notes System."@en ;
+    skos:definition "An ultramafic volcanic rock defined in the kalsilite-bearing rock classification as a rock containing kalsilite, but no leucite or melilite (Le Maitre et al., 2005, p. 94), but otherwise uncategorized. GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks. GSWA usage of this term is restricted to rocks that are partially weathered or are identified using remote sensing imagery, and the use of the related code/notation is limited to GSWA's Explanatory Notes System."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005). See also https://academic.oup.com/petrology/article/63/5/egac026/6553206." ;
     skos:inScheme cs: ;
     skos:notation "wn"^^:GSWA-rock-code ;
@@ -3029,7 +3029,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-kimberlite ;
-    skos:definition "An ultramafic rock consisting of major amounts of serpentinized olivine with variable amounts of phlogopite, orthopyroxene, clinopyroxene, carbonate and chromite. Characteristic accessory minerals include pyrope garnet, monticellite, rutile and perovskite. It cannot be defined but is characterized by the mineralogical criteria given in section 2.6, p. 13. (Le Maitre et al., 2005, p. 97)"@en ;
+    skos:definition "An ultramafic rock consisting of major amounts of serpentinized olivine with variable amounts of phlogopite, orthopyroxene, clinopyroxene, carbonate and chromite. Characteristic accessory minerals include pyrope garnet, monticellite, rutile and perovskite. It cannot be defined but is characterized by the mineralogical criteria given in section 2.6, p. 13. (Le Maitre et al., 2005, p. 97)"@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "p"^^:GSWA-rock-code ;
@@ -3052,7 +3052,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-kimberlite ;
-    skos:definition "A volcaniclastic rock of kimberlitic affinity composed mostly of angular fragments greater than 2 mm in size consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
+    skos:definition "A volcaniclastic rock of kimberlitic affinity composed mostly of angular fragments greater than 2 mm in size consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "pvb"^^:GSWA-rock-code ;
@@ -3063,7 +3063,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-kimberlite ;
-    skos:definition "A volcaniclastic rock of kimberlitic affinity composed mostly of angular fragments ranging in size from sand (0.0625 – 2 mm) and above, consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
+    skos:definition "A volcaniclastic rock of kimberlitic affinity composed mostly of angular fragments ranging in size from sand (0.0625 – 2 mm) and above, consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "pvbs"^^:GSWA-rock-code ;
@@ -3085,7 +3085,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-kimberlite ;
-    skos:definition "A breccia of kimberlitic affinity composed mostly of angular fragments ranging in size from granule (2–4 mm) to pebble (4–32 mm) consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
+    skos:definition "A breccia of kimberlitic affinity composed mostly of angular fragments ranging in size from granule (2–4 mm) to pebble (4–32 mm) consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "pvg"^^:GSWA-rock-code ;
@@ -3096,7 +3096,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-kimberlite ;
-    skos:definition "A mudstone (grain size ranging from silt to clay, i.e. less than 0.0625 mm) of kimberlitic affinity consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
+    skos:definition "A mudstone (grain size ranging from silt to clay, i.e. less than 0.0625 mm) of kimberlitic affinity consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "pvsm"^^:GSWA-rock-code ;
@@ -3118,7 +3118,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-kimberlite ;
-    skos:definition "A sandstone (grain size 0.0625 – 2 mm) of kimberlitic affinity consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
+    skos:definition "A sandstone (grain size 0.0625 – 2 mm) of kimberlitic affinity consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "pvs"^^:GSWA-rock-code ;
@@ -3129,7 +3129,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-kimberlite ;
-    skos:definition "A volcaniclastic rock of komatiitic affinity composed mostly of fragments ranging in size from sand (0.0625 – 2 mm) to silt (0.0039 – 0.0625 mm) of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with an overall mafic composition. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion w, and with an overall mafic composition."@en ;
+    skos:definition "A volcaniclastic rock of komatiitic affinity composed mostly of fragments ranging in size from sand (0.0625 – 2 mm) to silt (0.0039 – 0.0625 mm) of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with an overall mafic composition. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion w, and with an overall mafic composition."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "pvss"^^:GSWA-rock-code ;
@@ -3140,7 +3140,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-kimberlite ;
-    skos:definition "A commonly monomictic breccia of kimberlitic affinity composed of angular, coarse igneous fragments cemented by a fine-grained matrix that is clastic though not necessarily strictly sedimentary in origin. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
+    skos:definition "A commonly monomictic breccia of kimberlitic affinity composed of angular, coarse igneous fragments cemented by a fine-grained matrix that is clastic though not necessarily strictly sedimentary in origin. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "pvsb"^^:GSWA-rock-code ;
@@ -3151,7 +3151,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-ultramafic-volcanic-and-volcaniclastic ;
-    skos:definition "A variety of ultramafic lavas that crystallizes from high temperature magmas with 18% to 32% MgO. They commonly form pillows and have chilled flow-tops and usually display well-developed spinifex textures with intergrown skeletal and bladed olivine and pyroxene crystals set in abundant glass. The more highly magnesian varieties are often termed peridotitic komatiite. Now defined chemically in the TAS classification (Fig. 2.13, p. 34). (Le Maitre et al., 2005, p. 98)"@en ;
+    skos:definition "A variety of ultramafic lavas that crystallizes from high temperature magmas with 18% to 32% MgO. They commonly form pillows and have chilled flow-tops and usually display well-developed spinifex textures with intergrown skeletal and bladed olivine and pyroxene crystals set in abundant glass. The more highly magnesian varieties are often termed peridotitic komatiite. Now defined chemically in the TAS classification (Fig. 2.13, p. 34). (Le Maitre et al., 2005, p. 98)"@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "uk"^^:GSWA-rock-code ;
@@ -3164,7 +3164,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     rdfs:isDefinedBy cs: ;
     skos:altLabel "basaltic komatiite"@en ;
     skos:broader :igneous-mafic-volcanic ;
-    skos:definition "A member of the komatiite series with MgO in the range 5 to 15%, typically displaying pyroxene spinifex texture and evidence of rapid quenching of high-temperature magma. Chemically these rocks are intermediate between tholeiitic basalt and boninite and are thought to have been komatiite magmas contaminated by crustal material. Definition adapted from Le Maitre et al. (2005, p. 61). GSWA usage of the term is restricted to basaltic rocks related to komatiites where petrography or geochemistry has also confirmed a high-magnesium composition."@en ;
+    skos:definition "A member of the komatiite series with MgO in the range 5 to 15%, typically displaying pyroxene spinifex texture and evidence of rapid quenching of high-temperature magma. Chemically these rocks are intermediate between tholeiitic basalt and boninite and are thought to have been komatiite magmas contaminated by crustal material. Definition adapted from Le Maitre et al. (2005, p. 61). GSWA usage of the term is restricted to basaltic rocks related to komatiites where petrography or geochemistry has also confirmed a high-magnesium composition."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "bk"^^:GSWA-rock-code ;
@@ -3199,7 +3199,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-lamproites ;
-    skos:definition "A volcaniclastic rock composed mostly of angular fragments greater than 2 mm in size consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with a lamproitic composition. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
+    skos:definition "A volcaniclastic rock composed mostly of angular fragments greater than 2 mm in size consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with a lamproitic composition. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "ivb"^^:GSWA-rock-code ;
@@ -3210,7 +3210,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-lamproites ;
-    skos:definition "A volcaniclastic rock composed mostly of angular fragments ranging in size from sand (0.0625 – 2 mm) and above, consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with a lamproitic composition. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
+    skos:definition "A volcaniclastic rock composed mostly of angular fragments ranging in size from sand (0.0625 – 2 mm) and above, consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with a lamproitic composition. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "ivbs"^^:GSWA-rock-code ;
@@ -3232,7 +3232,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-lamproites ;
-    skos:definition "A breccia composed mostly of angular fragments ranging in size from granule (2–4 mm) to pebble (4–32 mm) consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with a lamproitic composition. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
+    skos:definition "A breccia composed mostly of angular fragments ranging in size from granule (2–4 mm) to pebble (4–32 mm) consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with a lamproitic composition. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "ivg"^^:GSWA-rock-code ;
@@ -3243,7 +3243,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-lamproites ;
-    skos:definition "A mudstone (grain size ranging from silt to clay, i.e. less than 0.0625 mm) consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and a lamproitic composition. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
+    skos:definition "A mudstone (grain size ranging from silt to clay, i.e. less than 0.0625 mm) consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and a lamproitic composition. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "ivsm"^^:GSWA-rock-code ;
@@ -3265,7 +3265,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-lamproites ;
-    skos:definition "A sandstone (grain size 0.0625 – 2 mm) consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with a lamproitic composition. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
+    skos:definition "A sandstone (grain size 0.0625 – 2 mm) consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with a lamproitic composition. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "ivs"^^:GSWA-rock-code ;
@@ -3276,7 +3276,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-lamproites ;
-    skos:definition "A volcaniclastic rock composed mostly of fragments ranging in size from sand (0.0625 – 2 mm) to silt (0.0039 – 0.0625 mm) of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with a lamproitic composition. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
+    skos:definition "A volcaniclastic rock composed mostly of fragments ranging in size from sand (0.0625 – 2 mm) to silt (0.0039 – 0.0625 mm) of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with a lamproitic composition. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "ivss"^^:GSWA-rock-code ;
@@ -3287,7 +3287,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-lamproites ;
-    skos:definition "A commonly monomictic breccia of overall lamproitic composition, composed of angular, coarse igneous fragments cemented by a fine-grained matrix that is clastic though not necessarily strictly sedimentary in origin. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
+    skos:definition "A commonly monomictic breccia of overall lamproitic composition, composed of angular, coarse igneous fragments cemented by a fine-grained matrix that is clastic though not necessarily strictly sedimentary in origin. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "ivsb"^^:GSWA-rock-code ;
@@ -3298,7 +3298,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-lamprophyres ;
-    skos:definition "A porphyritic, meso- to melanocratic igneous rock with mafic minerals as phenocrysts, typically containing essential biotite (or Fe-phlogopite) and/or amphibole and sometimes clinopyroxene, with feldspars and/or feldspathoid (when present) restricted to the groundmass, but otherwise uncategorized. They are commonly altered and normally occur as dykes. Adapted from Le Maitre et al. (2005, p. 19)."@en ;
+    skos:definition "A porphyritic, meso- to melanocratic igneous rock with mafic minerals as phenocrysts, typically containing essential biotite (or Fe-phlogopite) and/or amphibole and sometimes clinopyroxene, with feldspars and/or feldspathoid (when present) restricted to the groundmass, but otherwise uncategorized. They are commonly altered and normally occur as dykes. Adapted from Le Maitre et al. (2005, p. 19)."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "y"^^:GSWA-rock-code ;
@@ -3321,7 +3321,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-felsic-volcanic ;
-    skos:definition "A term originally proposed for a rock which chemically lies between trachyte and andesite, but later used as a volcanic rock composed of approximately equal amounts of alkali feldspar and sodic plagioclase, i.e. the volcanic equivalent of monzonite. Now defined modally in QAPF field 8 (Fig. 2.11, p. 31) and, if modes are not available, chemically as the potassic variety of trachyandesite in TAS field S3 (Fig. 2.14, p. 35). Definition from Le Maitre et al. (2005, p. 101). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
+    skos:definition "A term originally proposed for a rock which chemically lies between trachyte and andesite, but later used as a volcanic rock composed of approximately equal amounts of alkali feldspar and sodic plagioclase, i.e. the volcanic equivalent of monzonite. Now defined modally in QAPF field 8 (Fig. 2.11, p. 31) and, if modes are not available, chemically as the potassic variety of trachyandesite in TAS field S3 (Fig. 2.14, p. 35). Definition from Le Maitre et al. (2005, p. 101). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
     skos:exactMatch
         <http://inspire.ec.europa.eu/codelist/LithologyValue/latite> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/latite> ;
@@ -3336,7 +3336,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-lamproites ;
-    skos:definition "A lamproite (Table 2.7, p. 17) consisting essentially of leucite and phlogopite in a chlorite-rich groundmass. The original name fitzroyite is not recommended for usage. Adapted from Le Maitre et al. (2005, p. 80)."@en ;
+    skos:definition "A lamproite (Table 2.7, p. 17) consisting essentially of leucite and phlogopite in a chlorite-rich groundmass. The original name fitzroyite is not recommended for usage. Adapted from Le Maitre et al. (2005, p. 80)."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "if"^^:GSWA-rock-code ;
@@ -3348,7 +3348,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-lamproites ;
-    skos:definition "Originally described as a rock consisting essentially of leucite and magnophorite (= titanian potassian richterite) with subordinate phlogopite in a glassy matrix. Now regarded as a leucite–richterite lamproite (Table 2.7, p. 17). The original name mamilite is not recommended for usage. Adapted from Le Maitre et al. (2005, p. 108)."@en ;
+    skos:definition "Originally described as a rock consisting essentially of leucite and magnophorite (= titanian potassian richterite) with subordinate phlogopite in a glassy matrix. Now regarded as a leucite–richterite lamproite (Table 2.7, p. 17). The original name mamilite is not recommended for usage. Adapted from Le Maitre et al. (2005, p. 108)."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "ir"^^:GSWA-rock-code ;
@@ -3359,7 +3359,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-ultramafic-intrusive ;
-    skos:definition "An ultramafic intrusive rock composed of olivine with subordinate orthopyroxene and clinopyroxene. Now defined modally in the ultramafic rock classification (Fig. 2.9, p. 28). (cf. Le Maitre et al., 2005, p. 104)"@en ;
+    skos:definition "An ultramafic intrusive rock composed of olivine with subordinate orthopyroxene and clinopyroxene. Now defined modally in the ultramafic rock classification (Fig. 2.9, p. 28). (cf. Le Maitre et al., 2005, p. 104)"@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "apl"^^:GSWA-rock-code ;
@@ -3372,11 +3372,11 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     rdfs:isDefinedBy cs: ;
     skos:altLabel "brown coal"@en ;
     skos:broader :coal ;
-    skos:definition "A brownish-black coal that is intermediate in coalification between peat and sub-bituminous coal; consolidated coal with a calorific value less than 8 300 BTU/lb (19.31 MJ/kg), on a moist, mineral-matter-free basis. Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
+    skos:definition "A brownish-black coal that is intermediate in coalification between peat and sub-bituminous coal; consolidated coal with a calorific value less than 8 300 BTU/lb (19.31 MJ/kg), on a moist, mineral-matter-free basis. Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
     skos:exactMatch
         <http://inspire.ec.europa.eu/codelist/LithologyValue/lignite> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/lignite> ;
-    skos:historyNote "Forsman, JP and Hunt, JM 1958, Insoluble organic matter (kerogen) in sedimentary rocks: Geochimica et Cosmochimica Acta, v. 15(3), p. 170–182, doi.org/10.1016/0016-7037(58)90055-3." ;
+    skos:historyNote "Forsman, JP and Hunt, JM 1958, Insoluble organic matter (kerogen) in sedimentary rocks: Geochimica et Cosmochimica Acta, v. 15(3), p. 170–182, doi.org/10.1016/0016-7037(58)90055-3." ;
     skos:inScheme cs: ;
     skos:notation "con"^^:GSWA-rock-code ;
     skos:prefLabel "lignite"@en ;
@@ -3389,8 +3389,8 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     skos:altLabel "bafflestone"@en ;
     skos:broader :limestone-boundstone ;
     skos:definition "A type of reef rock or boundstone composed of upright, branching colonies, closely to widely spaced but not in contact, separated by fine sediment or coarse skeletal debris, in which calcite is prevalent over other carbonate minerals. In life, the colonies functioned as a sediment trap or baffle. Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011). The limestone prefix is commonly omitted since it is implied by Dunham's (1962) classification."@en ;
-    skos:historyNote """Dunham, RJ 1962, Classification of carbonate rocks according to depositional texture, in Classification of carbonate rocks edited by WE Hamm: American Association of Petroleum Geologists, Tulsa, Oklahoma, USA, p. 108–121.,
-Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Island, N.W.T: Bulletin of Canadian Petroleum Geology, v. 19(4), p. 730–781.""" ;
+    skos:historyNote """Dunham, RJ 1962, Classification of carbonate rocks according to depositional texture, in Classification of carbonate rocks edited by WE Hamm: American Association of Petroleum Geologists, Tulsa, Oklahoma, USA, p. 108–121.,
+Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Island, N.W.T: Bulletin of Canadian Petroleum Geology, v. 19(4), p. 730–781.""" ;
     skos:inScheme cs: ;
     skos:notation "klj"^^:GSWA-rock-code ;
     skos:prefLabel "limestone bafflestone"@en ;
@@ -3403,8 +3403,8 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     skos:altLabel "bindstone"@en ;
     skos:broader :limestone-boundstone ;
     skos:definition "A type of reef rock or boundstone composed of sheet-like colonies encrusting large fossil fragments or finer sediment, forming a layered mass that is partly in-place skeletal and partly bioclastic, and in which calcite is prevalent over other carbonate minerals. Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011). The limestone prefix is commonly omitted since it is implied by Dunham's (1962) classification."@en ;
-    skos:historyNote """Dunham, RJ 1962, Classification of carbonate rocks according to depositional texture, in Classification of carbonate rocks edited by WE Hamm: American Association of Petroleum Geologists, Tulsa, Oklahoma, USA, p. 108–121.,
-Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Island, N.W.T: Bulletin of Canadian Petroleum Geology, v. 19(4), p. 730–781.""" ;
+    skos:historyNote """Dunham, RJ 1962, Classification of carbonate rocks according to depositional texture, in Classification of carbonate rocks edited by WE Hamm: American Association of Petroleum Geologists, Tulsa, Oklahoma, USA, p. 108–121.,
+Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Island, N.W.T: Bulletin of Canadian Petroleum Geology, v. 19(4), p. 730–781.""" ;
     skos:inScheme cs: ;
     skos:notation "kli"^^:GSWA-rock-code ;
     skos:prefLabel "limestone bindstone"@en ;
@@ -3428,8 +3428,8 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     skos:altLabel "floatstone"@en ;
     skos:broader :limestone ;
     skos:definition "A carbonate rock with dominant calcite and containing a few bioclasts or other fragments more than 2 mm in diameter, widely spaced, embedded in sand- or mud-size carbonate sediment that forms over 90% of the rock. Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011). The limestone prefix is commonly omitted since it is implied by Dunham's (1962) classification."@en ;
-    skos:historyNote """Dunham, RJ 1962, Classification of carbonate rocks according to depositional texture, in Classification of carbonate rocks edited by WE Hamm: American Association of Petroleum Geologists, Tulsa, Oklahoma, USA, p. 108–121.,
-Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Island, N.W.T: Bulletin of Canadian Petroleum Geology, v. 19(4), p. 730–781.""" ;
+    skos:historyNote """Dunham, RJ 1962, Classification of carbonate rocks according to depositional texture, in Classification of carbonate rocks edited by WE Hamm: American Association of Petroleum Geologists, Tulsa, Oklahoma, USA, p. 108–121.,
+Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Island, N.W.T: Bulletin of Canadian Petroleum Geology, v. 19(4), p. 730–781.""" ;
     skos:inScheme cs: ;
     skos:notation "klf"^^:GSWA-rock-code ;
     skos:prefLabel "limestone floatstone"@en ;
@@ -3445,8 +3445,8 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
         <http://resource.geosciml.org/classifier/cgi/lithology/framestone> ;
     skos:broader :limestone-boundstone ;
     skos:definition "A type of reef rock or boundstone consisting of colonies, shells, or skeletons attached to each other to form a rigid framework or lattice, and consisting mostly of calcite. Internal cavities are filled with fine sediment, crystalline cement, or coarse skeletal debris. Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011). The limestone prefix is commonly omitted since it is implied by Dunham's (1962) classification."@en ;
-    skos:historyNote """Dunham, RJ 1962, Classification of carbonate rocks according to depositional texture, in Classification of carbonate rocks edited by WE Hamm: American Association of Petroleum Geologists, Tulsa, Oklahoma, USA, p. 108–121.,
-Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Island, N.W.T: Bulletin of Canadian Petroleum Geology, v. 19(4), p. 730–781.""" ;
+    skos:historyNote """Dunham, RJ 1962, Classification of carbonate rocks according to depositional texture, in Classification of carbonate rocks edited by WE Hamm: American Association of Petroleum Geologists, Tulsa, Oklahoma, USA, p. 108–121.,
+Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Island, N.W.T: Bulletin of Canadian Petroleum Geology, v. 19(4), p. 730–781.""" ;
     skos:inScheme cs: ;
     skos:notation "kle"^^:GSWA-rock-code ;
     skos:prefLabel "limestone framestone"@en ;
@@ -3461,9 +3461,9 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
         <http://inspire.ec.europa.eu/codelist/LithologyValue/grainstone> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/grainstone> ;
     skos:broader :limestone ;
-    skos:definition "A mud-free (less than 1% of material with diameters less than 20 μm), grain-supported, carbonate sedimentary rock, and consisting mostly of calcite. It may be current-laid or formed by mud being washed out from previously deposited sediment, or it may result from mud being bypassed while locally produced particles accumulated (Dunham, 1962). Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011). The limestone prefix is commonly omitted since it is implied by Dunham's (1962) classification."@en ;
-    skos:historyNote """Dunham, RJ 1962, Classification of carbonate rocks according to depositional texture, in Classification of carbonate rocks edited by WE Hamm: American Association of Petroleum Geologists, Tulsa, Oklahoma, USA, p. 108–121.,
-Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Island, N.W.T: Bulletin of Canadian Petroleum Geology, v. 19(4), p. 730–781.""" ;
+    skos:definition "A mud-free (less than 1% of material with diameters less than 20 μm), grain-supported, carbonate sedimentary rock, and consisting mostly of calcite. It may be current-laid or formed by mud being washed out from previously deposited sediment, or it may result from mud being bypassed while locally produced particles accumulated (Dunham, 1962). Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011). The limestone prefix is commonly omitted since it is implied by Dunham's (1962) classification."@en ;
+    skos:historyNote """Dunham, RJ 1962, Classification of carbonate rocks according to depositional texture, in Classification of carbonate rocks edited by WE Hamm: American Association of Petroleum Geologists, Tulsa, Oklahoma, USA, p. 108–121.,
+Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Island, N.W.T: Bulletin of Canadian Petroleum Geology, v. 19(4), p. 730–781.""" ;
     skos:inScheme cs: ;
     skos:notation "klg"^^:GSWA-rock-code ;
     skos:prefLabel "limestone grainstone"@en ;
@@ -3481,8 +3481,8 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
         <http://resource.geosciml.org/classifier/cgi/lithology/carbonate_mudstone> ;
     skos:broader :limestone ;
     skos:definition "A fairly pure (93–99% calcium carbonate), mainly non-porous and impermeable, texturally uniform limestone whose main constituent (75–85%) is calcite mud (micrite) (Dunham, 1962). Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011). The limestone prefix is commonly omitted since it is implied by Dunham's (1962) classification."@en ;
-    skos:historyNote """Folk, RL 1959, Practical petrographic classification of limestones: American Association of Petroleum Geologists Bulletin No. 43(1), p. 1–38, doi:10.1306/0BDA5C36-16BD-11D7-8645000102C1865D.,
-Dunham, RJ 1962, Classification of carbonate rocks according to depositional texture, in Classification of carbonate rocks edited by WE Hamm: American Association of Petroleum Geologists, Tulsa, Oklahoma, USA, p. 108–121.""" ;
+    skos:historyNote """Folk, RL 1959, Practical petrographic classification of limestones: American Association of Petroleum Geologists Bulletin No. 43(1), p. 1–38, doi:10.1306/0BDA5C36-16BD-11D7-8645000102C1865D.,
+Dunham, RJ 1962, Classification of carbonate rocks according to depositional texture, in Classification of carbonate rocks edited by WE Hamm: American Association of Petroleum Geologists, Tulsa, Oklahoma, USA, p. 108–121.""" ;
     skos:inScheme cs: ;
     skos:notation "klu"^^:GSWA-rock-code ;
     skos:prefLabel "limestone mudstone"@en ;
@@ -3498,8 +3498,8 @@ Dunham, RJ 1962, Classification of carbonate rocks according to depositional tex
         <http://resource.geosciml.org/classifier/cgi/lithology/packstone> ;
     skos:broader :limestone ;
     skos:definition "A term used for a sedimentary carbonate rock consisting predominantly of calcite and whose granular material is arranged in a self-supporting framework, yet which also contains some matrix of calcareous mud (Dunham, 1962). Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011). The limestone prefix is commonly omitted since it is implied by Dunham's (1962) classification."@en ;
-    skos:historyNote """Dunham, RJ 1962, Classification of carbonate rocks according to depositional texture, in Classification of carbonate rocks edited by WE Hamm: American Association of Petroleum Geologists, Tulsa, Oklahoma, USA, p. 108–121.,
-Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Island, N.W.T: Bulletin of Canadian Petroleum Geology, v. 19(4), p. 730–781.""" ;
+    skos:historyNote """Dunham, RJ 1962, Classification of carbonate rocks according to depositional texture, in Classification of carbonate rocks edited by WE Hamm: American Association of Petroleum Geologists, Tulsa, Oklahoma, USA, p. 108–121.,
+Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Island, N.W.T: Bulletin of Canadian Petroleum Geology, v. 19(4), p. 730–781.""" ;
     skos:inScheme cs: ;
     skos:notation "klp"^^:GSWA-rock-code ;
     skos:prefLabel "limestone packstone"@en ;
@@ -3511,9 +3511,9 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     rdfs:isDefinedBy cs: ;
     skos:altLabel "rudstone"@en ;
     skos:broader :limestone ;
-    skos:definition "A carbonate rock consisting predominantly of calcite and composed of bioclasts or other fragments, over 2 mm in diameter, closely packed, in physical contact; the interstices may be open, or filled with fine carbonate sediment or crystalline cement. Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011). The limestone prefix is commonly omitted since it is implied by Dunham's (1962) classification."@en ;
-    skos:historyNote """Dunham, RJ 1962, Classification of carbonate rocks according to depositional texture, in Classification of carbonate rocks edited by WE Hamm: American Association of Petroleum Geologists, Tulsa, Oklahoma, USA, p. 108–121.,
-Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Island, N.W.T: Bulletin of Canadian Petroleum Geology, v. 19(4), p. 730–781.""" ;
+    skos:definition "A carbonate rock consisting predominantly of calcite and composed of bioclasts or other fragments, over 2 mm in diameter, closely packed, in physical contact; the interstices may be open, or filled with fine carbonate sediment or crystalline cement. Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011). The limestone prefix is commonly omitted since it is implied by Dunham's (1962) classification."@en ;
+    skos:historyNote """Dunham, RJ 1962, Classification of carbonate rocks according to depositional texture, in Classification of carbonate rocks edited by WE Hamm: American Association of Petroleum Geologists, Tulsa, Oklahoma, USA, p. 108–121.,
+Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Island, N.W.T: Bulletin of Canadian Petroleum Geology, v. 19(4), p. 730–781.""" ;
     skos:inScheme cs: ;
     skos:notation "kld"^^:GSWA-rock-code ;
     skos:prefLabel "limestone rudstone"@en ;
@@ -3528,9 +3528,9 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
         <http://inspire.ec.europa.eu/codelist/LithologyValue/carbonateWackestone> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/carbonate_wackestone> ;
     skos:broader :limestone ;
-    skos:definition "A term for a mud-supported carbonate sedimentary rock consisting predominantly of calcite and containing more than 10% grains (particles with diameters greater than 20 μm). Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011). The limestone prefix is commonly omitted since it is implied by Dunham's (1962) classification."@en ;
-    skos:historyNote """Dunham, RJ 1962, Classification of carbonate rocks according to depositional texture, in Classification of carbonate rocks edited by WE Hamm: American Association of Petroleum Geologists, Tulsa, Oklahoma, USA, p. 108–121.,
-Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Island, N.W.T: Bulletin of Canadian Petroleum Geology, v. 19(4), p. 730–781.""" ;
+    skos:definition "A term for a mud-supported carbonate sedimentary rock consisting predominantly of calcite and containing more than 10% grains (particles with diameters greater than 20 μm). Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011). The limestone prefix is commonly omitted since it is implied by Dunham's (1962) classification."@en ;
+    skos:historyNote """Dunham, RJ 1962, Classification of carbonate rocks according to depositional texture, in Classification of carbonate rocks edited by WE Hamm: American Association of Petroleum Geologists, Tulsa, Oklahoma, USA, p. 108–121.,
+Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Island, N.W.T: Bulletin of Canadian Petroleum Geology, v. 19(4), p. 730–781.""" ;
     skos:inScheme cs: ;
     skos:notation "klw"^^:GSWA-rock-code ;
     skos:prefLabel "limestone wackestone"@en ;
@@ -3569,7 +3569,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :impact-breccia ;
-    skos:definition "Polymictic impact breccia with clastic matrix containing shocked and unshocked mineral and lithic clasts, but lacking cogenetic impact melt particles. Synonymous with, and supersedes, fragmental breccia. (Fettes and Desmons, 2007, p. 169)."@en ;
+    skos:definition "Polymictic impact breccia with clastic matrix containing shocked and unshocked mineral and lithic clasts, but lacking cogenetic impact melt particles. Synonymous with, and supersedes, fragmental breccia. (Fettes and Desmons, 2007, p. 169)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:notation "mpl"^^:GSWA-rock-code ;
@@ -3595,7 +3595,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-mafic ;
-    skos:definition "A metamorphosed mafic igneous rock displaying a gneissose structure, i.e. a gneiss derived from an igneous mafic but otherwise unspecified rock (i.e. the intrusive, extrusive or volcaniclastic nature of the protolith cannot be conclusively established). See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
+    skos:definition "A metamorphosed mafic igneous rock displaying a gneissose structure, i.e. a gneiss derived from an igneous mafic but otherwise unspecified rock (i.e. the intrusive, extrusive or volcaniclastic nature of the protolith cannot be conclusively established). See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:notation "mwn"^^:GSWA-rock-code ;
@@ -3609,7 +3609,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-mafic-intrusive ;
-    skos:definition "A metamorphosed mafic intrusive (or coarse-grained parts of extrusive successions) displaying a gneissose structure, i.e. a gneiss derived from an intrusive rock with one or more mafic minerals as the main component(s). See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
+    skos:definition "A metamorphosed mafic intrusive (or coarse-grained parts of extrusive successions) displaying a gneissose structure, i.e. a gneiss derived from an intrusive rock with one or more mafic minerals as the main component(s). See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:notation "mon"^^:GSWA-rock-code ;
@@ -3620,7 +3620,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-mafic-volcanic ;
-    skos:definition "A metamorphosed mafic volcanic rock displaying a gneissose structure, i.e. a gneiss derived from a volcanic rock with one or more mafic minerals as the main component(s). See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
+    skos:definition "A metamorphosed mafic volcanic rock displaying a gneissose structure, i.e. a gneiss derived from a volcanic rock with one or more mafic minerals as the main component(s). See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:notation "mbn"^^:GSWA-rock-code ;
@@ -3631,7 +3631,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-mafic ;
-    skos:definition "General term for granofelsic or hornfelsed mafic igneous rocks for which an intrusive, extrusive or volcaniclastic protolith cannot be conclusively identified. Commonly the main components are plagioclase and one or more mafic minerals; pyroxene(s) and minor olivine are common under the relatively dry conditions existing in the aureoles of many basic intrusions, whereas hornblende ± biotite form preferentially in more hydrated conditions, as in most aureoles of intermediate to acid intrusions. Mafic hornfelses include, among others, rocks known in the literature as beerbachite, granoblast, muscovadite and sudburite, as well as contact rocks called pyroxene-granulites by some British petrologists. Adapted from Fettes and Desmons (2007, p. 170)."@en ;
+    skos:definition "General term for granofelsic or hornfelsed mafic igneous rocks for which an intrusive, extrusive or volcaniclastic protolith cannot be conclusively identified. Commonly the main components are plagioclase and one or more mafic minerals; pyroxene(s) and minor olivine are common under the relatively dry conditions existing in the aureoles of many basic intrusions, whereas hornblende ± biotite form preferentially in more hydrated conditions, as in most aureoles of intermediate to acid intrusions. Mafic hornfelses include, among others, rocks known in the literature as beerbachite, granoblast, muscovadite and sudburite, as well as contact rocks called pyroxene-granulites by some British petrologists. Adapted from Fettes and Desmons (2007, p. 170)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:notation "mwe"^^:GSWA-rock-code ;
@@ -3643,7 +3643,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-mafic-intrusive ;
-    skos:definition "A metamorphosed mafic intrusive rock displaying a granofelsic structure, i.e. a granofels/hornfels derived from an intrusive (or coarse-grained part of an extrusive succession) rock with one or more mafic minerals as the main components (adapted from Fettes and Desmons, 2007, p. 202). See also definition of granofels/granofelsic structure in Fettes and Desmons (2007, p. 156); hornfels are granofels formed by contact metamorphism (Fettes and Desmons, 2007, p. 159)."@en ;
+    skos:definition "A metamorphosed mafic intrusive rock displaying a granofelsic structure, i.e. a granofels/hornfels derived from an intrusive (or coarse-grained part of an extrusive succession) rock with one or more mafic minerals as the main components (adapted from Fettes and Desmons, 2007, p. 202). See also definition of granofels/granofelsic structure in Fettes and Desmons (2007, p. 156); hornfels are granofels formed by contact metamorphism (Fettes and Desmons, 2007, p. 159)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:notation "moe"^^:GSWA-rock-code ;
@@ -3654,7 +3654,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-mafic-volcanic ;
-    skos:definition "A metamorphosed mafic volcanic rock displaying a granofelsic structure, i.e. a granofels/hornfels derived from a volcanic rock with one or more mafic minerals as the main components (adapted from Fettes and Desmons, 2007, p. 202). See also definition of granofels/granofelsic structure in Fettes and Desmons (2007, p. 156); hornfels are granofels formed by contact metamorphism (Fettes and Desmons, 2007, p. 159). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
+    skos:definition "A metamorphosed mafic volcanic rock displaying a granofelsic structure, i.e. a granofels/hornfels derived from a volcanic rock with one or more mafic minerals as the main components (adapted from Fettes and Desmons, 2007, p. 202). See also definition of granofels/granofelsic structure in Fettes and Desmons (2007, p. 156); hornfels are granofels formed by contact metamorphism (Fettes and Desmons, 2007, p. 159). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:notation "mbe"^^:GSWA-rock-code ;
@@ -3705,7 +3705,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-mafic ;
-    skos:definition "A metamorphosed mafic rock displaying a schistose structure, i.e. a schist derived from an intrusive, extrusive or volcaniclastic rock with one or more mafic minerals as the main component(s). See also definition of schist/schistose structure in Fettes and Desmons (2007, p. 193)."@en ;
+    skos:definition "A metamorphosed mafic rock displaying a schistose structure, i.e. a schist derived from an intrusive, extrusive or volcaniclastic rock with one or more mafic minerals as the main component(s). See also definition of schist/schistose structure in Fettes and Desmons (2007, p. 193)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:notation "mws"^^:GSWA-rock-code ;
@@ -3719,7 +3719,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-mafic-intrusive ;
-    skos:definition "A metamorphosed mafic intrusive rock (or coarse-grained parts of extrusive successions) displaying a schistose structure, i.e. a schist derived from an intrusive rock with one or more mafic minerals as the main component(s). See also definition of schist/schistose structure in Fettes and Desmons, 2007, p. 193)."@en ;
+    skos:definition "A metamorphosed mafic intrusive rock (or coarse-grained parts of extrusive successions) displaying a schistose structure, i.e. a schist derived from an intrusive rock with one or more mafic minerals as the main component(s). See also definition of schist/schistose structure in Fettes and Desmons, 2007, p. 193)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:notation "mos"^^:GSWA-rock-code ;
@@ -3730,7 +3730,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-mafic-volcanic ;
-    skos:definition "A metamorphosed mafic volcanic rock displaying a schistose structure, i.e. a schist derived from a volcanic rock with one or more mafic minerals as the main component(s). See also definition of schist/schistose structure in Fettes and Desmons, 2007, p. 193). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
+    skos:definition "A metamorphosed mafic volcanic rock displaying a schistose structure, i.e. a schist derived from a volcanic rock with one or more mafic minerals as the main component(s). See also definition of schist/schistose structure in Fettes and Desmons, 2007, p. 193). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:notation "mbs"^^:GSWA-rock-code ;
@@ -3764,7 +3764,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-mafic-volcanic ;
-    skos:definition "A volcaniclastic rock composed mostly of angular fragments greater than 2 mm in size consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with an overall mafic composition. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
+    skos:definition "A volcaniclastic rock composed mostly of angular fragments greater than 2 mm in size consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with an overall mafic composition. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "bvb"^^:GSWA-rock-code ;
@@ -3778,7 +3778,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-mafic-volcanic ;
-    skos:definition "A volcaniclastic rock composed mostly of angular fragments ranging in size from sand (0.0625 – 2 mm) and above, consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with an overall mafic composition. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
+    skos:definition "A volcaniclastic rock composed mostly of angular fragments ranging in size from sand (0.0625 – 2 mm) and above, consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with an overall mafic composition. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "bvbs"^^:GSWA-rock-code ;
@@ -3804,7 +3804,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-mafic-volcanic ;
-    skos:definition "A breccia composed mostly of angular fragments ranging in size from granule (2–4 mm) to pebble (4–32 mm) consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with an overall mafic composition. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
+    skos:definition "A breccia composed mostly of angular fragments ranging in size from granule (2–4 mm) to pebble (4–32 mm) consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with an overall mafic composition. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "bvg"^^:GSWA-rock-code ;
@@ -3816,7 +3816,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-mafic-volcanic ;
-    skos:definition "A mudstone (grain size ranging from silt to clay, i.e. less than 0.0625 mm) consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with an overall mafic composition. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
+    skos:definition "A mudstone (grain size ranging from silt to clay, i.e. less than 0.0625 mm) consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with an overall mafic composition. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "bvsm"^^:GSWA-rock-code ;
@@ -3840,8 +3840,8 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-mafic-volcanic ;
-    skos:definition "A sandstone (grain size 0.0625 – 2 mm) consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with an overall mafic composition. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
-    skos:historyNote "Pettijohn, FJ, Potter, PE, Siever, R 1987, Sand and sandstone: Springer-Verlag New York, Inc, 553p. (p. 205)" ;
+    skos:definition "A sandstone (grain size 0.0625 – 2 mm) consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with an overall mafic composition. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
+    skos:historyNote "Pettijohn, FJ, Potter, PE, Siever, R 1987, Sand and sandstone: Springer-Verlag New York, Inc, 553p. (p. 205)" ;
     skos:inScheme cs: ;
     skos:notation "bvs"^^:GSWA-rock-code ;
     skos:prefLabel "mafic volcaniclastic sandstone"@en ;
@@ -3854,7 +3854,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-mafic-volcanic ;
-    skos:definition "A volcaniclastic rock composed mostly of fragments ranging in size from sand (0.0625 – 2 mm) to silt (0.0039 – 0.0625 mm) of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with an overall mafic composition. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion w, and with an overall mafic composition."@en ;
+    skos:definition "A volcaniclastic rock composed mostly of fragments ranging in size from sand (0.0625 – 2 mm) to silt (0.0039 – 0.0625 mm) of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with an overall mafic composition. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion w, and with an overall mafic composition."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "bvss"^^:GSWA-rock-code ;
@@ -3866,7 +3866,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-mafic-volcanic ;
-    skos:definition "A commonly monomictic breccia of overall mafic composition composed of angular, coarse igneous fragments cemented by a fine-grained matrix that is clastic though not necessarily strictly sedimentary in origin. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
+    skos:definition "A commonly monomictic breccia of overall mafic composition composed of angular, coarse igneous fragments cemented by a fine-grained matrix that is clastic though not necessarily strictly sedimentary in origin. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "bvsb"^^:GSWA-rock-code ;
@@ -3901,7 +3901,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-ultramafic-intrusive ;
-    skos:definition "An ultramafic rock consisting essentially of magnetite (Le Maitre et al., 2005, p. 107)."@en ;
+    skos:definition "An ultramafic rock consisting essentially of magnetite (Le Maitre et al., 2005, p. 107)."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "am"^^:GSWA-rock-code ;
@@ -3942,7 +3942,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-melilitic ;
-    skos:definition "An ultramafic intrusive rock consisting essentially of melilite, pyroxene and olivine, otherwise uncategorized. Now defined as a general term for intrusive rocks in the melilite-bearing rocks classification. Definition from Le Maitre et al. (2005, p. 110). Specific names apply based on the percentages of different mineral phases (Le Maitre et al., 2005, p. 11)."@en ;
+    skos:definition "An ultramafic intrusive rock consisting essentially of melilite, pyroxene and olivine, otherwise uncategorized. Now defined as a general term for intrusive rocks in the melilite-bearing rocks classification. Definition from Le Maitre et al. (2005, p. 110). Specific names apply based on the percentages of different mineral phases (Le Maitre et al., 2005, p. 11)."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "e"^^:GSWA-rock-code ;
@@ -3964,7 +3964,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-felsic-volcanic ;
-    skos:definition "A metamorphosed intermediate volcanic rock, usually porphyritic, derived from a protolith consisting of plagioclase (frequently zoned from labradorite to oligoclase), pyroxene, hornblende and/or biotite. Igneous protolith defined modally in QAPF fields 9 and 10, and, if modes are not available, chemically in TAS field O2 (Le Maitre et al., 2005, p. 56). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
+    skos:definition "A metamorphosed intermediate volcanic rock, usually porphyritic, derived from a protolith consisting of plagioclase (frequently zoned from labradorite to oligoclase), pyroxene, hornblende and/or biotite. Igneous protolith defined modally in QAPF fields 9 and 10, and, if modes are not available, chemically in TAS field O2 (Le Maitre et al., 2005, p. 56). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic (Fettes and Desmons, 2007) and igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "mfa"^^:GSWA-rock-code ;
@@ -3975,7 +3975,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-mafic-intrusive ;
-    skos:definition "A metamorphosed leucocratic intrusive rock derived from a protolith consisting essentially of plagioclase commonly with small amounts of pyroxene. Igneous protolith defined modally in QAPF field 10 and in the gabbroic rock classification of Le Maitre et al. (2005, p. 22 and 24)."@en ;
+    skos:definition "A metamorphosed leucocratic intrusive rock derived from a protolith consisting essentially of plagioclase commonly with small amounts of pyroxene. Igneous protolith defined modally in QAPF field 10 and in the gabbroic rock classification of Le Maitre et al. (2005, p. 22 and 24)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic (Fettes and Desmons, 2007) and igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "mof"^^:GSWA-rock-code ;
@@ -3986,7 +3986,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metasedimentary-siliciclastic-psammite ;
-    skos:definition "A metamorphosed rock derived from a siliciclastic sedimentary protolith rich in feldspar and with grain size between 0.0625 and 2 mm."@en ;
+    skos:definition "A metamorphosed rock derived from a siliciclastic sedimentary protolith rich in feldspar and with grain size between 0.0625 and 2 mm."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "mtf"^^:GSWA-rock-code ;
@@ -4069,7 +4069,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-felsic-intrusive ;
-    skos:definition "A metamorphosed felsic intrusive rock derived from a protolith having the composition of diorite but with an appreciable amount of quartz, i.e. between 5 and 20% of the felsic minerals (defined modally in QAPF field 10*; Le Maitre et al., 2005, p. 134)."@en ;
+    skos:definition "A metamorphosed felsic intrusive rock derived from a protolith having the composition of diorite but with an appreciable amount of quartz, i.e. between 5 and 20% of the felsic minerals (defined modally in QAPF field 10*; Le Maitre et al., 2005, p. 134)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic (Fettes and Desmons, 2007) and igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "mgiq"^^:GSWA-rock-code ;
@@ -4080,7 +4080,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-felsic-volcanic ;
-    skos:definition "A term originally used for a volcanic rock composed of phenocrysts of quartz, plagioclase, biotite and hornblende in a glassy matrix potentially of quartz and alkali feldspar. Now commonly used for volcanic rocks composed of alkali feldspar and plagioclase in roughly equal amounts, quartz and mafic minerals. Now defined modally in QAPF field 8* (Fig. 2.4, p. 22). Definition from Le Maitre et al. (2005, p. 135) GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
+    skos:definition "A term originally used for a volcanic rock composed of phenocrysts of quartz, plagioclase, biotite and hornblende in a glassy matrix potentially of quartz and alkali feldspar. Now commonly used for volcanic rocks composed of alkali feldspar and plagioclase in roughly equal amounts, quartz and mafic minerals. Now defined modally in QAPF field 8* (Fig. 2.4, p. 22). Definition from Le Maitre et al. (2005, p. 135) GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic (Fettes and Desmons, 2007) and igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "mflq"^^:GSWA-rock-code ;
@@ -4091,7 +4091,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-felsic-volcanic ;
-    skos:definition "A metamorphosed volcanic rock derived from a protolith consisting of phenocrysts of alkali feldspar and quartz in a cryptocrystalline or glassy matrix. Igneous protolith defined modally in QAPF field 7* (Le Maitre et al., 2005, p. 135). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
+    skos:definition "A metamorphosed volcanic rock derived from a protolith consisting of phenocrysts of alkali feldspar and quartz in a cryptocrystalline or glassy matrix. Igneous protolith defined modally in QAPF field 7* (Le Maitre et al., 2005, p. 135). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic (Fettes and Desmons, 2007) and igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "mftq"^^:GSWA-rock-code ;
@@ -4114,7 +4114,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-ultramafic-volcanic ;
-    skos:definition "A metamorphosed igneous volcanic or volcaniclastic rock derived from a protolith composed chiefly of one or more ferromagnesian, dark-coloured minerals in its mode, but otherwise uncategorized (adapted from Glossary of geology, 5th edition revised; Neuendorf et al., 2011). Igneous protolith defined as a rock with M greater than 90%, where M represents the volume modal percentage of mafic and related minerals (Le Maitre et al., 2005, p. 4 and 153). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
+    skos:definition "A metamorphosed igneous volcanic or volcaniclastic rock derived from a protolith composed chiefly of one or more ferromagnesian, dark-coloured minerals in its mode, but otherwise uncategorized (adapted from Glossary of geology, 5th edition revised; Neuendorf et al., 2011). Igneous protolith defined as a rock with M greater than 90%, where M represents the volume modal percentage of mafic and related minerals (Le Maitre et al., 2005, p. 4 and 153). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic (Fettes and Desmons, 2007) and igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "mu"^^:GSWA-rock-code ;
@@ -4136,7 +4136,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-mafic-volcanic ;
-    skos:definition "A fine-grained metamorphosed mafic volcanic rock consisting essentially of calcic plagioclase and pyroxene. Igneous protolith defined modally in QAPF fields 9 and 10 (Le Maitre et al., 2005, p. 31). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
+    skos:definition "A fine-grained metamorphosed mafic volcanic rock consisting essentially of calcic plagioclase and pyroxene. Igneous protolith defined modally in QAPF fields 9 and 10 (Le Maitre et al., 2005, p. 31). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic (Fettes and Desmons, 2007) and igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "mbb"^^:GSWA-rock-code ;
@@ -4147,7 +4147,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-mafic-volcanic ;
-    skos:definition "A fine-grained metamorphosed mafic volcanic rock with plagioclase of variable composition and the ferromagnesian minerals more commonly found in basalts, e.g. olivine. Igneous protolith defined chemically in TAS field O1 (Le Maitre et al., 2005, p. 61). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
+    skos:definition "A fine-grained metamorphosed mafic volcanic rock with plagioclase of variable composition and the ferromagnesian minerals more commonly found in basalts, e.g. olivine. Igneous protolith defined chemically in TAS field O1 (Le Maitre et al., 2005, p. 61). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic (Fettes and Desmons, 2007) and igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "mbd"^^:GSWA-rock-code ;
@@ -4180,7 +4180,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-carbonatite ;
-    skos:definition "A collective term for a metamorphosed igneous (intrusive, extrusive or volcaniclastic) rock in which the protolith had a modal amount of primary carbonate minerals greater than 50%, but otherwise uncategorized (section 2.3, p. 10). (Cf. Le Maitre et al., 2005, p. 68)"@en ;
+    skos:definition "A collective term for a metamorphosed igneous (intrusive, extrusive or volcaniclastic) rock in which the protolith had a modal amount of primary carbonate minerals greater than 50%, but otherwise uncategorized (section 2.3, p. 10). (Cf. Le Maitre et al., 2005, p. 68)"@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "mq"^^:GSWA-rock-code ;
@@ -4191,7 +4191,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-carbonatite ;
-    skos:definition "A granofels/hornfels derived by (contact) metamorphism of a carbonatite, i.e. an igneous protolith containing a modal amount of primary carbonate minerals greater than 50%. See also definition of granofels/granofelsic structure in Fettes and Desmons (2007, p. 156); hornfels are granofels formed by contact metamorphism (Fettes and Desmons, 2007, p. 159)."@en ;
+    skos:definition "A granofels/hornfels derived by (contact) metamorphism of a carbonatite, i.e. an igneous protolith containing a modal amount of primary carbonate minerals greater than 50%. See also definition of granofels/granofelsic structure in Fettes and Desmons (2007, p. 156); hornfels are granofels formed by contact metamorphism (Fettes and Desmons, 2007, p. 159)."@en ;
     skos:inScheme cs: ;
     skos:notation "mqe"^^:GSWA-rock-code ;
     skos:prefLabel "metacarbonatite granofels/hornfels"@en ;
@@ -4212,7 +4212,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metasedimentary-siliciclastic-psephite ;
-    skos:definition "A metamorphosed rock derived from a siliciclastic sedimentary protolith with grain size greater than 2 mm, i.e. coarser than sand."@en ;
+    skos:definition "A metamorphosed rock derived from a siliciclastic sedimentary protolith with grain size greater than 2 mm, i.e. coarser than sand."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "mx"^^:GSWA-rock-code ;
@@ -4224,7 +4224,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-felsic-volcanic ;
-    skos:definition "A metamorphosed volcanic rock derived from a protolith composed of quartz and sodic plagioclase with minor amounts of biotite and/or hornblende and/or pyroxene (volcanic equivalent of granodiorite and tonalite). Igneous protolith defined modally in QAPF fields 4 and 5, and, if modes are not available, chemically in TAS field O3 (Le Maitre et al., 2005, p. 72). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
+    skos:definition "A metamorphosed volcanic rock derived from a protolith composed of quartz and sodic plagioclase with minor amounts of biotite and/or hornblende and/or pyroxene (volcanic equivalent of granodiorite and tonalite). Igneous protolith defined modally in QAPF fields 4 and 5, and, if modes are not available, chemically in TAS field O3 (Le Maitre et al., 2005, p. 72). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic (Fettes and Desmons, 2007) and igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "mfd"^^:GSWA-rock-code ;
@@ -4235,7 +4235,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-felsic-intrusive ;
-    skos:definition "A metamorphosed felsic intrusive rock derived from a protolith consisting of intermediate plagioclase, commonly with hornblende and often with biotite or augite. Igneous protolith defined modally in QAPF field 10 (Le Maitre et al., 2005, p. 73)."@en ;
+    skos:definition "A metamorphosed felsic intrusive rock derived from a protolith consisting of intermediate plagioclase, commonly with hornblende and often with biotite or augite. Igneous protolith defined modally in QAPF field 10 (Le Maitre et al., 2005, p. 73)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic (Fettes and Desmons, 2007) and igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "mgi"^^:GSWA-rock-code ;
@@ -4246,7 +4246,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-mafic-intrusive ;
-    skos:definition "A metamorphosed mafic intrusive rock (or coarse-grained part of extrusive successions) derived from a protolith intermediate in grain size between basalt and gabbro and composed essentially of plagioclase, pyroxene and opaque minerals with varying amounts of quartz and possibly olivine; often with ophitic texture. Igneous protolith defined modally in QAPF (Le Maitre et al., 2005, p. 74)."@en ;
+    skos:definition "A metamorphosed mafic intrusive rock (or coarse-grained part of extrusive successions) derived from a protolith intermediate in grain size between basalt and gabbro and composed essentially of plagioclase, pyroxene and opaque minerals with varying amounts of quartz and possibly olivine; often with ophitic texture. Igneous protolith defined modally in QAPF (Le Maitre et al., 2005, p. 74)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic (Fettes and Desmons, 2007) and igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "mod"^^:GSWA-rock-code ;
@@ -4257,7 +4257,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-ultramafic-intrusive ;
-    skos:definition "A metamorphosed ultramafic igneous (intrusive or coarse-grained extrusive) rock consisting essentially of olivine. Igneous protolith defined modally in the ultramafic rock classification of Le Maitre et al. (2005, p. 28)."@en ;
+    skos:definition "A metamorphosed ultramafic igneous (intrusive or coarse-grained extrusive) rock consisting essentially of olivine. Igneous protolith defined modally in the ultramafic rock classification of Le Maitre et al. (2005, p. 28)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic (Fettes and Desmons, 2007) and igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "mad"^^:GSWA-rock-code ;
@@ -4314,7 +4314,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-mafic-intrusive ;
-    skos:definition "A metamorphosed intrusive rock (or coarse-grained parts of extrusive successions), derived from a protolith composed essentially of calcic plagioclase, pyroxene and iron oxides, with varying amounts of quartz and possibly olivine. Igneous protolith defined modally in QAPF field 10 (cf. Le Maitre et al., 2005, p. 83)."@en ;
+    skos:definition "A metamorphosed intrusive rock (or coarse-grained parts of extrusive successions), derived from a protolith composed essentially of calcic plagioclase, pyroxene and iron oxides, with varying amounts of quartz and possibly olivine. Igneous protolith defined modally in QAPF field 10 (cf. Le Maitre et al., 2005, p. 83)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic (Fettes and Desmons, 2007) and igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "mog"^^:GSWA-rock-code ;
@@ -4325,7 +4325,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-mafic-intrusive ;
-    skos:definition "A metamorphosed mafic intrusive rock (or coarse-grained parts of extrusive successions) derived from a protolith consisting of calcic plagioclase and roughly equal amounts of clinopyroxene and orthopyroxene. Igneous protolith defined modally in the gabbroic rock classification (Le Maitre et al., 2005, p. 83)."@en ;
+    skos:definition "A metamorphosed mafic intrusive rock (or coarse-grained parts of extrusive successions) derived from a protolith consisting of calcic plagioclase and roughly equal amounts of clinopyroxene and orthopyroxene. Igneous protolith defined modally in the gabbroic rock classification (Le Maitre et al., 2005, p. 83)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic (Fettes and Desmons, 2007) and igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "mom"^^:GSWA-rock-code ;
@@ -4347,7 +4347,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-felsic-intrusive ;
-    skos:definition "A metamorphosed felsic intrusive rock derived from a protolith consisting essentially of quartz, sodic plagioclase and lesser amounts of alkali feldspar with minor amounts of hornblende and biotite. Igneous protolith defined modally in QAPF field 4 (Le Maitre et al., 2005, p. 86)."@en ;
+    skos:definition "A metamorphosed felsic intrusive rock derived from a protolith consisting essentially of quartz, sodic plagioclase and lesser amounts of alkali feldspar with minor amounts of hornblende and biotite. Igneous protolith defined modally in QAPF field 4 (Le Maitre et al., 2005, p. 86)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic (Fettes and Desmons, 2007) and igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "mgg"^^:GSWA-rock-code ;
@@ -4381,7 +4381,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-ultramafic-volcanic ;
-    skos:definition "A metamorphosed ultramafic extrusive rock derived from lavas that crystallize from high temperature magmas with 18% to 32% MgO. Pillows, chilled flow-tops and spinifex textures are commonly preserved. Igneous protolith defined chemically in the TAS classification (cf. Le Maitre et al., 2005, p. 98)."@en ;
+    skos:definition "A metamorphosed ultramafic extrusive rock derived from lavas that crystallize from high temperature magmas with 18% to 32% MgO. Pillows, chilled flow-tops and spinifex textures are commonly preserved. Igneous protolith defined chemically in the TAS classification (cf. Le Maitre et al., 2005, p. 98)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic (Fettes and Desmons, 2007) and igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "muk"^^:GSWA-rock-code ;
@@ -4392,7 +4392,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-mafic-volcanic ;
-    skos:definition "A metamorphosed member of the komatiite series derived from a volcanic rock characterized by MgO in the range 5–15%, typically displaying spinifex texture and evidence of rapid quenching of high-temperature magma (cf. Le Maitre et al., 2005, p. 61) and this vocabulary for a definition of the igneous protolith. GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
+    skos:definition "A metamorphosed member of the komatiite series derived from a volcanic rock characterized by MgO in the range 5–15%, typically displaying spinifex texture and evidence of rapid quenching of high-temperature magma (cf. Le Maitre et al., 2005, p. 61) and this vocabulary for a definition of the igneous protolith. GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic (Fettes and Desmons, 2007) and igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "mbm"^^:GSWA-rock-code ;
@@ -4403,7 +4403,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-felsic-volcanic ;
-    skos:definition "A metamorphosed rock derived from a protolith chemically lying between trachyte and andesite, i.e. derived from a volcanic rock composed of approximately equal amounts of alkali feldspar and sodic plagioclase. Igneous protolith defined modally in QAPF field 8 and, if modes are not available, chemically as the potassic variety of trachyandesite in TAS field S3 (Le Maitre et al., 2005, p. 101). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
+    skos:definition "A metamorphosed rock derived from a protolith chemically lying between trachyte and andesite, i.e. derived from a volcanic rock composed of approximately equal amounts of alkali feldspar and sodic plagioclase. Igneous protolith defined modally in QAPF field 8 and, if modes are not available, chemically as the potassic variety of trachyandesite in TAS field S3 (Le Maitre et al., 2005, p. 101). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic (Fettes and Desmons, 2007) and igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "mfl"^^:GSWA-rock-code ;
@@ -4460,7 +4460,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-felsic-intrusive ;
-    skos:definition "A metamorphosed felsic intrusive rock derived from a protolith intermediate between monzonite and diorite. Igneous protolith defined modally in QAPF field 9 (Le Maitre et al., 2005, p. 113)."@en ;
+    skos:definition "A metamorphosed felsic intrusive rock derived from a protolith intermediate between monzonite and diorite. Igneous protolith defined modally in QAPF field 9 (Le Maitre et al., 2005, p. 113)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic (Fettes and Desmons, 2007) and igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "mgh"^^:GSWA-rock-code ;
@@ -4472,7 +4472,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-felsic-intrusive ;
-    skos:definition "A metamorphosed felsic intrusive rock derived from a monzogranite, i.e. from a variety of granite in QAPF field 3b having roughly equal amounts of alkali feldspar and plagioclase (cf. Le Maitre et al., 2005, p. 113)."@en ;
+    skos:definition "A metamorphosed felsic intrusive rock derived from a monzogranite, i.e. from a variety of granite in QAPF field 3b having roughly equal amounts of alkali feldspar and plagioclase (cf. Le Maitre et al., 2005, p. 113)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic (Fettes and Desmons, 2007) and igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "mgm"^^:GSWA-rock-code ;
@@ -4483,7 +4483,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-felsic-intrusive ;
-    skos:definition "A metamorphosed felsic intrusive rock derived from a monzonite, i.e. an intrusive rock containing almost equal amounts of plagioclase and alkali feldspar with minor amphibole and/or pyroxene. Igneous protolith defined modally in QAPF field 8 (Le Maitre et al., 2005, p. 113)."@en ;
+    skos:definition "A metamorphosed felsic intrusive rock derived from a monzonite, i.e. an intrusive rock containing almost equal amounts of plagioclase and alkali feldspar with minor amphibole and/or pyroxene. Igneous protolith defined modally in QAPF field 8 (Le Maitre et al., 2005, p. 113)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic (Fettes and Desmons, 2007) and igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "mgz"^^:GSWA-rock-code ;
@@ -4530,7 +4530,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-felsic-intrusive ;
-    skos:definition "The metamorphosed equivalent of a pegmatite, i.e. an exceptionally coarse-grained igneous rock with interlocking crystals, usually found as irregular dykes, lenses, or veins, especially at the margins of batholiths and of granitic composition (cf. Le Maitre et al., 2005, p. 125)."@en ;
+    skos:definition "The metamorphosed equivalent of a pegmatite, i.e. an exceptionally coarse-grained igneous rock with interlocking crystals, usually found as irregular dykes, lenses, or veins, especially at the margins of batholiths and of granitic composition (cf. Le Maitre et al., 2005, p. 125)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic (Fettes and Desmons, 2007) and igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "mgp"^^:GSWA-rock-code ;
@@ -4541,7 +4541,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-ultramafic-intrusive ;
-    skos:definition "A metamorphosed ultramafic igneous (intrusive or coarse-grained extrusive) rock consisting essentially of olivine, pyroxene and/or amphibole. Igneous protolith defined modally in the ultramafic rock classification of Le Maitre et al. (2005, p. 28)."@en ;
+    skos:definition "A metamorphosed ultramafic igneous (intrusive or coarse-grained extrusive) rock consisting essentially of olivine, pyroxene and/or amphibole. Igneous protolith defined modally in the ultramafic rock classification of Le Maitre et al. (2005, p. 28)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic (Fettes and Desmons, 2007) and igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "map"^^:GSWA-rock-code ;
@@ -4552,7 +4552,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-ultramafic-volcanic ;
-    skos:definition "A collective term for metamorphosed ultramafic volcanic rocks derived from a protolith consisting essentially of olivine, pyroxene and/or amphibole. Igneous protolith defined modally in the ultramafic rock classification of Le Maitre et al. (2005, p. 28 and 126). In GSWA usage this term refers to a metamorphosed peridotite identified as formed from fractionation within thick bodies of ultramafic volcanic or subvolcanic magmas."@en ;
+    skos:definition "A collective term for metamorphosed ultramafic volcanic rocks derived from a protolith consisting essentially of olivine, pyroxene and/or amphibole. Igneous protolith defined modally in the ultramafic rock classification of Le Maitre et al. (2005, p. 28 and 126). In GSWA usage this term refers to a metamorphosed peridotite identified as formed from fractionation within thick bodies of ultramafic volcanic or subvolcanic magmas."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic (Fettes and Desmons, 2007) and igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "mup"^^:GSWA-rock-code ;
@@ -4563,7 +4563,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-ultramafic-intrusive ;
-    skos:definition "Metamorphic rock consisting of more than 90% modal pyroxene (Fettes and Desmons, 2007, p. 190), i.e. a metamorphosed ultramafic igneous (intrusive or coarse-grained extrusive) rock composed almost entirely of one or more pyroxenes and occasionally biotite, hornblende and olivine. Igneous protolith defined modally in the ultramafic rock classification of Le Maitre et al. (2005, p. 28)."@en ;
+    skos:definition "Metamorphic rock consisting of more than 90% modal pyroxene (Fettes and Desmons, 2007, p. 190), i.e. a metamorphosed ultramafic igneous (intrusive or coarse-grained extrusive) rock composed almost entirely of one or more pyroxenes and occasionally biotite, hornblende and olivine. Igneous protolith defined modally in the ultramafic rock classification of Le Maitre et al. (2005, p. 28)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic (Fettes and Desmons, 2007) and igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "max"^^:GSWA-rock-code ;
@@ -4574,7 +4574,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-ultramafic-volcanic ;
-    skos:definition "A metamorphosed ultramafic volcanic or volcaniclastic rock derived from a protolith composed almost entirely of one or more pyroxenes (greater than 90% modal pyroxenes) and occasionally biotite, hornblende and olivine; igneous protolith defined modally in the ultramafic rock classification (cf. Le Maitre et al., 2005, p. 28 and 134; Fettes and Desmons, 2007, p. 190). In GSWA usage this term refers to a metamorphosed pyroxenite identified as formed from fractionation within thick bodies of ultramafic volcanic or subvolcanic magmas."@en ;
+    skos:definition "A metamorphosed ultramafic volcanic or volcaniclastic rock derived from a protolith composed almost entirely of one or more pyroxenes (greater than 90% modal pyroxenes) and occasionally biotite, hornblende and olivine; igneous protolith defined modally in the ultramafic rock classification (cf. Le Maitre et al., 2005, p. 28 and 134; Fettes and Desmons, 2007, p. 190). In GSWA usage this term refers to a metamorphosed pyroxenite identified as formed from fractionation within thick bodies of ultramafic volcanic or subvolcanic magmas."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic (Fettes and Desmons, 2007) and igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "mux"^^:GSWA-rock-code ;
@@ -4585,7 +4585,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-felsic-volcanic ;
-    skos:definition "A metamorphosed volcanic rock derived from a protolith intermediate between rhyolite and dacite. Igneous protolith defined as consisting of phenocrysts of quartz, plagioclase and a few ferromagnesian minerals in a microcrystalline groundmass (Le Maitre et al., 2005, p. 137). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
+    skos:definition "A metamorphosed volcanic rock derived from a protolith intermediate between rhyolite and dacite. Igneous protolith defined as consisting of phenocrysts of quartz, plagioclase and a few ferromagnesian minerals in a microcrystalline groundmass (Le Maitre et al., 2005, p. 137). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic (Fettes and Desmons, 2007) and igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "mfc"^^:GSWA-rock-code ;
@@ -4596,7 +4596,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-felsic-volcanic ;
-    skos:definition "A metamorphosed silicic volcanic rocks derived from a rhyolitic protolith, i.e. a rock consisting of phenocrysts of quartz and alkali feldspar, often with minor plagioclase and biotite, in a microcrystalline or glassy groundmass and having the chemical composition of granite. Igneous protolith defined modally in QAPF field 3 and, if modes are not available, chemically in TAS field R (Le Maitre et al., 2005, p. 137). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
+    skos:definition "A metamorphosed silicic volcanic rocks derived from a rhyolitic protolith, i.e. a rock consisting of phenocrysts of quartz and alkali feldspar, often with minor plagioclase and biotite, in a microcrystalline or glassy groundmass and having the chemical composition of granite. Igneous protolith defined modally in QAPF field 3 and, if modes are not available, chemically in TAS field R (Le Maitre et al., 2005, p. 137). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic (Fettes and Desmons, 2007) and igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "mfr"^^:GSWA-rock-code ;
@@ -4607,7 +4607,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metasedimentary-siliciclastic-psammite ;
-    skos:definition "A metamorphosed rock derived from a siliciclastic sedimentary protolith with grain size between 0.0625 and 2 mm."@en ;
+    skos:definition "A metamorphosed rock derived from a siliciclastic sedimentary protolith with grain size between 0.0625 and 2 mm."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "mt"^^:GSWA-rock-code ;
@@ -4644,7 +4644,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metasedimentary-siliciclastic-pelite ;
-    skos:definition "A metamorphosed rock derived from a siliciclastic sedimentary protolith with grains less than 0.0625 mm in size."@en ;
+    skos:definition "A metamorphosed rock derived from a siliciclastic sedimentary protolith with grains less than 0.0625 mm in size."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "ml"^^:GSWA-rock-code ;
@@ -4655,7 +4655,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metasomatic ;
-    skos:definition "A metasomatic gneissose rock for which the protolith cannot be established. The timing of metasomatism is not implied and may precede or follow the development of gneissosity during regional metamorphism. A gneiss is a layered rock formed by regional metamorphism, in which bands or lenticles of granular minerals alternate with bands or lenticles in which minerals having flaky or elongate prismatic habits predominate (Fettes and Desmon, 2007, p. 154)."@en ;
+    skos:definition "A metasomatic gneissose rock for which the protolith cannot be established. The timing of metasomatism is not implied and may precede or follow the development of gneissosity during regional metamorphism. A gneiss is a layered rock formed by regional metamorphism, in which bands or lenticles of granular minerals alternate with bands or lenticles in which minerals having flaky or elongate prismatic habits predominate (Fettes and Desmon, 2007, p. 154)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:notation "mjn"^^:GSWA-rock-code ;
@@ -4669,7 +4669,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metasomatic ;
-    skos:definition "A metasomatic rock composed of a mosaic of equidimensional grains without preferred orientation and for which the original protolith cannot be identified. Granofels are metamorphic rocks defined by their granofelsic structure, i.e. the absence of schistosity, such that the mineral grains and aggregates of mineral grains are equant or, if inequant, have random orientation. Mineralogical or lithological layering may be present. (Fettes and Desmons, 2007, p. 156); hornfels are granofels that formed as a result of contact metamorphism (Fettes and Desmons, 2007, p. 159)."@en ;
+    skos:definition "A metasomatic rock composed of a mosaic of equidimensional grains without preferred orientation and for which the original protolith cannot be identified. Granofels are metamorphic rocks defined by their granofelsic structure, i.e. the absence of schistosity, such that the mineral grains and aggregates of mineral grains are equant or, if inequant, have random orientation. Mineralogical or lithological layering may be present. (Fettes and Desmons, 2007, p. 156); hornfels are granofels that formed as a result of contact metamorphism (Fettes and Desmons, 2007, p. 159)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:notation "mje"^^:GSWA-rock-code ;
@@ -4686,7 +4686,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     rdfs:isDefinedBy cs: ;
     skos:altLabel "metasomatite"@en ;
     skos:broader :metasomatic ;
-    skos:definition "Metamorphic rock whose mineral and chemical bulk compositions have been substantially changed by metasomatism, i.e. the metamorphic process by which the chemical composition of a rock or rock portion is altered in a pervasive manner by the introduction and/or removal of chemical components as a result of interaction with aqueous fluids/solutions ((usually hydrothermal or static fluids); during metasomatism the rock remains in a solid state (Fettes and Desmons, 2007, p. 174)."@en ;
+    skos:definition "Metamorphic rock whose mineral and chemical bulk compositions have been substantially changed by metasomatism, i.e. the metamorphic process by which the chemical composition of a rock or rock portion is altered in a pervasive manner by the introduction and/or removal of chemical components as a result of interaction with aqueous fluids/solutions ((usually hydrothermal or static fluids); during metasomatism the rock remains in a solid state (Fettes and Desmons, 2007, p. 174)."@en ;
     skos:exactMatch
         <http://inspire.ec.europa.eu/codelist/LithologyValue/metasomaticRock> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/metasomatic_rock> ;
@@ -4715,7 +4715,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-felsic-intrusive ;
-    skos:definition "A metamorphosed felsic intrusive rock derived from a syenite, i.e. an intrusive rock consisting mainly of alkali feldspar with subordinate sodic plagioclase, biotite, pyroxene, amphibole and occasional fayalite. Minor quartz or nepheline may also be present. Igneous protolith defined modally in QAPF field 7 (Le Maitre et al., 2005, p. 145)."@en ;
+    skos:definition "A metamorphosed felsic intrusive rock derived from a syenite, i.e. an intrusive rock consisting mainly of alkali feldspar with subordinate sodic plagioclase, biotite, pyroxene, amphibole and occasional fayalite. Minor quartz or nepheline may also be present. Igneous protolith defined modally in QAPF field 7 (Le Maitre et al., 2005, p. 145)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic (Fettes and Desmons, 2007) and igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "mgw"^^:GSWA-rock-code ;
@@ -4726,7 +4726,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-felsic-intrusive ;
-    skos:definition "A metamorphosed felsic intrusive rock derived from a syenogranite, i.e. from a variety of granite in QAPF field 3a consisting of alkali feldspar with subordinate plagioclase (Le Maitre et al., 2005, p. 146)."@en ;
+    skos:definition "A metamorphosed felsic intrusive rock derived from a syenogranite, i.e. from a variety of granite in QAPF field 3a consisting of alkali feldspar with subordinate plagioclase (Le Maitre et al., 2005, p. 146)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic (Fettes and Desmons, 2007) and igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "mgr"^^:GSWA-rock-code ;
@@ -4737,7 +4737,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-felsic-intrusive ;
-    skos:definition "A metamorphosed felsic intrusive rock derived from a tonalite, i.e. an intrusive rock consisting essentially of quartz and intermediate plagioclase, usually with biotite and amphibole. Igneous protolith defined modally in QAPF field 5 (Le Maitre et al., 2005, p. 149)."@en ;
+    skos:definition "A metamorphosed felsic intrusive rock derived from a tonalite, i.e. an intrusive rock consisting essentially of quartz and intermediate plagioclase, usually with biotite and amphibole. Igneous protolith defined modally in QAPF field 5 (Le Maitre et al., 2005, p. 149)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic (Fettes and Desmons, 2007) and igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "mgt"^^:GSWA-rock-code ;
@@ -4748,7 +4748,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-felsic-volcanic ;
-    skos:definition "A metamorphosed volcanic rock derived from a protolith consisting essentially of alkali feldspar. Igneous protolith defined modally in QAPF field 7 and, if modes are not available, chemically in TAS field T (Le Maitre et al., 2005, p. 151). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
+    skos:definition "A metamorphosed volcanic rock derived from a protolith consisting essentially of alkali feldspar. Igneous protolith defined modally in QAPF field 7 and, if modes are not available, chemically in TAS field T (Le Maitre et al., 2005, p. 151). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic (Fettes and Desmons, 2007) and igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "mft"^^:GSWA-rock-code ;
@@ -4792,7 +4792,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metamorphic-protolith-unknown-gneiss ;
-    skos:definition "A gneiss distinguished by the abundance of micaceous mineral phases. In GSWA usage, this term is reserved for a gneiss for which a protolith cannot be conclusively established. See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
+    skos:definition "A gneiss distinguished by the abundance of micaceous mineral phases. In GSWA usage, this term is reserved for a gneiss for which a protolith cannot be conclusively established. See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007) and GSWA usage." ;
     skos:inScheme cs: ;
     skos:notation "mnm"^^:GSWA-rock-code ;
@@ -4815,7 +4815,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metamorphic-protolith-unknown-schist ;
-    skos:definition "A schist distinguished by the abundance of micaceous mineral phases. In GSWA usage, this term is reserved for a schist for which a protolith cannot be conclusively established. See also definition of schist/schistose structure in Fettes and Desmons, 2007, p.  193)."@en ;
+    skos:definition "A schist distinguished by the abundance of micaceous mineral phases. In GSWA usage, this term is reserved for a schist for which a protolith cannot be conclusively established. See also definition of schist/schistose structure in Fettes and Desmons, 2007, p.  193)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007) and GSWA usage." ;
     skos:inScheme cs: ;
     skos:notation "msm"^^:GSWA-rock-code ;
@@ -4826,7 +4826,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-felsic-intrusive ;
-    skos:definition "An alkali feldspar granite with a grain size of less than 3 mm. Includes porphyritic varieties."@en ;
+    skos:definition "An alkali feldspar granite with a grain size of less than 3 mm. Includes porphyritic varieties."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005) and GSWA usage." ;
     skos:inScheme cs: ;
     skos:notation "gfa"^^:GSWA-rock-code ;
@@ -4837,7 +4837,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-felsic-intrusive ;
-    skos:definition "An alkali feldspar syenite with a grain size of less than 3 mm. Includes porphyritic varieties."@en ;
+    skos:definition "An alkali feldspar syenite with a grain size of less than 3 mm. Includes porphyritic varieties."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005) and GSWA usage." ;
     skos:inScheme cs: ;
     skos:notation "gsa"^^:GSWA-rock-code ;
@@ -4848,7 +4848,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-felsic-intrusive ;
-    skos:definition "A granitic rock, undivided, with a grain size of less than 3 mm. Includes porphyritic varieties."@en ;
+    skos:definition "A granitic rock, undivided, with a grain size of less than 3 mm. Includes porphyritic varieties."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005) and GSWA usage." ;
     skos:inScheme cs: ;
     skos:notation "gna"^^:GSWA-rock-code ;
@@ -4859,7 +4859,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-felsic-intrusive ;
-    skos:definition "A quartz alkali feldspar syenite with a grain size of less than 3 mm. Includes porphyritic varieties."@en ;
+    skos:definition "A quartz alkali feldspar syenite with a grain size of less than 3 mm. Includes porphyritic varieties."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005) and GSWA usage." ;
     skos:inScheme cs: ;
     skos:notation "gqa"^^:GSWA-rock-code ;
@@ -4870,7 +4870,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-felsic-intrusive ;
-    skos:definition "A quartz anorthosite with a grain size of less than 3 mm. Includes porphyritic varieties."@en ;
+    skos:definition "A quartz anorthosite with a grain size of less than 3 mm. Includes porphyritic varieties."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005) and GSWA usage." ;
     skos:inScheme cs: ;
     skos:notation "goa"^^:GSWA-rock-code ;
@@ -4881,7 +4881,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-felsic-intrusive ;
-    skos:definition "A quartz diorite with a grain size of less than 3 mm. Includes porphyritic varieties."@en ;
+    skos:definition "A quartz diorite with a grain size of less than 3 mm. Includes porphyritic varieties."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005) and GSWA usage." ;
     skos:inScheme cs: ;
     skos:notation "gda"^^:GSWA-rock-code ;
@@ -4892,7 +4892,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-felsic-intrusive ;
-    skos:definition "A quartz gabbro with a grain size of less than 3 mm. Includes porphyritic varieties."@en ;
+    skos:definition "A quartz gabbro with a grain size of less than 3 mm. Includes porphyritic varieties."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005) and GSWA usage." ;
     skos:inScheme cs: ;
     skos:notation "gua"^^:GSWA-rock-code ;
@@ -4903,7 +4903,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-felsic-intrusive ;
-    skos:definition "A quartz monzodiorite with a grain size of less than 3 mm. Includes porphyritic varieties."@en ;
+    skos:definition "A quartz monzodiorite with a grain size of less than 3 mm. Includes porphyritic varieties."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005) and GSWA usage." ;
     skos:inScheme cs: ;
     skos:notation "gka"^^:GSWA-rock-code ;
@@ -4914,7 +4914,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-felsic-intrusive ;
-    skos:definition "A quartz monzogabbro with a grain size of less than 3 mm. Includes porphyritic varieties."@en ;
+    skos:definition "A quartz monzogabbro with a grain size of less than 3 mm. Includes porphyritic varieties."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005) and GSWA usage." ;
     skos:inScheme cs: ;
     skos:notation "gla"^^:GSWA-rock-code ;
@@ -4925,7 +4925,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-felsic-intrusive ;
-    skos:definition "A quartz monzonite with a grain size of less than 3 mm. Includes porphyritic varieties."@en ;
+    skos:definition "A quartz monzonite with a grain size of less than 3 mm. Includes porphyritic varieties."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005) and GSWA usage." ;
     skos:inScheme cs: ;
     skos:notation "gca"^^:GSWA-rock-code ;
@@ -4936,7 +4936,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-felsic-intrusive ;
-    skos:definition "A quartz syenite with a grain size of less than 3 mm. Includes porphyritic varieties."@en ;
+    skos:definition "A quartz syenite with a grain size of less than 3 mm. Includes porphyritic varieties."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005) and GSWA usage." ;
     skos:inScheme cs: ;
     skos:notation "gea"^^:GSWA-rock-code ;
@@ -4947,7 +4947,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :dolomite ;
-    skos:definition "A dolomitic rock distinguished by the presence of microbialites, i.e. 'organosedimentary deposits that have accreted as a result of a benthic microbial community trapping and binding detrital sediment and/or forming the locus of mineral precipitation' (Burne and Moore, 1987, p. 241–242). Note that past workers (including GSWA) commonly used the term ‘stromatolite’ to refer to all types of microbialite structures, whereas current usage restricts ‘stromatolite’ to those microbialites with a layered/laminated fabric (see Grey and Awramik 2020, p. 4); therefore, legacy usage of ‘stromatolitic dolomite’ or ‘stromatolitic dolostone’ is best considered equivalent to this lithology."@en ;
+    skos:definition "A dolomitic rock distinguished by the presence of microbialites, i.e. 'organosedimentary deposits that have accreted as a result of a benthic microbial community trapping and binding detrital sediment and/or forming the locus of mineral precipitation' (Burne and Moore, 1987, p. 241–242). Note that past workers (including GSWA) commonly used the term ‘stromatolite’ to refer to all types of microbialite structures, whereas current usage restricts ‘stromatolite’ to those microbialites with a layered/laminated fabric (see Grey and Awramik 2020, p. 4); therefore, legacy usage of ‘stromatolitic dolomite’ or ‘stromatolitic dolostone’ is best considered equivalent to this lithology."@en ;
     skos:historyNote """Burne, RV and Moore, LS 1987, Microbialites: Organosedimentary deposits of benthic microbial communities: Palaios, v. 2, p. 241–245.,
 Grey, K and Awramik, SM 2020, Handbook for the study and description of microbialites: Geological Survey of Western Australia, Bulletin 147, 278p.""" ;
     skos:inScheme cs: ;
@@ -4960,7 +4960,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :limestone ;
-    skos:definition "A limestone distinguished by the presence of microbialites, i.e. 'organosedimentary deposits that have accreted as a result of a benthic microbial community trapping and binding detrital sediment and/or forming the locus of mineral precipitation' (Burne and Moore, 1987, p. 241–242). Note that past workers (including GSWA) commonly used the term ‘stromatolite’ to refer to all types of microbialite structures, whereas current usage restricts ‘stromatolite’ to those microbialites with a layered/laminated fabric (see Grey and Awramik 2020, p. 4); therefore, legacy usage of ‘stromatolitic limestone’ is best considered equivalent to this lithology."@en ;
+    skos:definition "A limestone distinguished by the presence of microbialites, i.e. 'organosedimentary deposits that have accreted as a result of a benthic microbial community trapping and binding detrital sediment and/or forming the locus of mineral precipitation' (Burne and Moore, 1987, p. 241–242). Note that past workers (including GSWA) commonly used the term ‘stromatolite’ to refer to all types of microbialite structures, whereas current usage restricts ‘stromatolite’ to those microbialites with a layered/laminated fabric (see Grey and Awramik 2020, p. 4); therefore, legacy usage of ‘stromatolitic limestone’ is best considered equivalent to this lithology."@en ;
     skos:historyNote """Burne, RV and Moore, LS 1987, Microbialites: Organosedimentary deposits of benthic microbial communities: Palaios, v. 2, p. 241–245.,
 Grey, K and Awramik, SM 2020, Handbook for the study and description of microbialites: Geological Survey of Western Australia, Bulletin 147, 278p.""" ;
     skos:inScheme cs: ;
@@ -4974,7 +4974,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     rdfs:isDefinedBy cs: ;
     skos:broader :dolomite ;
     skos:definition "Laminated dolomite rock where the laminae have formed by the trapping of grains and precipitation of dolomite mud through the effects of eubacteria, cyanobacteria, and/or fungi in a microbial mat. Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
-    skos:historyNote "Grey, K and Awramik, SM 2020, Handbook for the study and description of microbialites: Geological Survey of Western Australia, Bulletin 147, 278p." ;
+    skos:historyNote "Grey, K and Awramik, SM 2020, Handbook for the study and description of microbialites: Geological Survey of Western Australia, Bulletin 147, 278p." ;
     skos:inScheme cs: ;
     skos:notation "kdm"^^:GSWA-rock-code ;
     skos:prefLabel "microbially laminated dolomite"@en ;
@@ -4997,7 +4997,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-felsic-intrusive ;
-    skos:definition "A diorite with a grain size of less than 3 mm. Includes porphyritic varieties."@en ;
+    skos:definition "A diorite with a grain size of less than 3 mm. Includes porphyritic varieties."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005) and GSWA usage." ;
     skos:inScheme cs: ;
     skos:notation "gia"^^:GSWA-rock-code ;
@@ -5008,7 +5008,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-felsic-intrusive ;
-    skos:definition "A granodiorite with a grain size of less than 3 mm. Includes porphyritic varieties."@en ;
+    skos:definition "A granodiorite with a grain size of less than 3 mm. Includes porphyritic varieties."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005) and GSWA usage." ;
     skos:inScheme cs: ;
     skos:notation "gga"^^:GSWA-rock-code ;
@@ -5019,7 +5019,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-felsic-intrusive ;
-    skos:definition "A monzodiorite with a grain size of less than 3 mm. Includes porphyritic varieties."@en ;
+    skos:definition "A monzodiorite with a grain size of less than 3 mm. Includes porphyritic varieties."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005) and GSWA usage." ;
     skos:inScheme cs: ;
     skos:notation "gha"^^:GSWA-rock-code ;
@@ -5030,7 +5030,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-felsic-intrusive ;
-    skos:definition "A monzogabbro with a grain size of less than 3 mm. Includes porphyritic varieties."@en ;
+    skos:definition "A monzogabbro with a grain size of less than 3 mm. Includes porphyritic varieties."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005) and GSWA usage." ;
     skos:inScheme cs: ;
     skos:notation "gwa"^^:GSWA-rock-code ;
@@ -5041,7 +5041,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-felsic-intrusive ;
-    skos:definition "A monzogranite with a grain size of less than 3 mm. Includes porphyritic varieties."@en ;
+    skos:definition "A monzogranite with a grain size of less than 3 mm. Includes porphyritic varieties."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005) and GSWA usage." ;
     skos:inScheme cs: ;
     skos:notation "gma"^^:GSWA-rock-code ;
@@ -5052,7 +5052,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-felsic-intrusive ;
-    skos:definition "A monzonite with a grain size of less than 3 mm. Includes porphyritic varieties."@en ;
+    skos:definition "A monzonite with a grain size of less than 3 mm. Includes porphyritic varieties."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005) and GSWA usage." ;
     skos:inScheme cs: ;
     skos:notation "gza"^^:GSWA-rock-code ;
@@ -5063,7 +5063,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-felsic-intrusive ;
-    skos:definition "A syenite with a grain size of less than 3 mm. Includes porphyritic varieties."@en ;
+    skos:definition "A syenite with a grain size of less than 3 mm. Includes porphyritic varieties."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005) and GSWA usage." ;
     skos:inScheme cs: ;
     skos:notation "gya"^^:GSWA-rock-code ;
@@ -5074,7 +5074,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-felsic-intrusive ;
-    skos:definition "A syenogranite with a grain size of less than 3 mm. Includes porphyritic varieties."@en ;
+    skos:definition "A syenogranite with a grain size of less than 3 mm. Includes porphyritic varieties."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005) and GSWA usage." ;
     skos:inScheme cs: ;
     skos:notation "gra"^^:GSWA-rock-code ;
@@ -5085,7 +5085,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-felsic-intrusive ;
-    skos:definition "A tonalite with a grain size of less than 3 mm. Includes porphyritic varieties."@en ;
+    skos:definition "A tonalite with a grain size of less than 3 mm. Includes porphyritic varieties."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005) and GSWA usage." ;
     skos:inScheme cs: ;
     skos:notation "gta"^^:GSWA-rock-code ;
@@ -5096,7 +5096,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-felsic-intrusive ;
-    skos:definition "A trondhjemite with a grain size of less than 3 mm. Includes porphyritic varieties."@en ;
+    skos:definition "A trondhjemite with a grain size of less than 3 mm. Includes porphyritic varieties."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005) and GSWA usage." ;
     skos:inScheme cs: ;
     skos:notation "gja"^^:GSWA-rock-code ;
@@ -5144,7 +5144,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-carbonatite ;
-    skos:definition "Composite metamorphic rock derived from an igneous protolith containing a modal amount of primary carbonate minerals greater than 50% and pervasively heterogeneous on a meso- to megascopic scale. It typically consists of darker (melanosome) and lighter (leucosome) parts. The darker parts usually exhibit features of metamorphic rocks, whereas the lighter parts are of igneous appearance. See definition of migmatite in Fettes and Desmond (2007, p. 176)."@en ;
+    skos:definition "Composite metamorphic rock derived from an igneous protolith containing a modal amount of primary carbonate minerals greater than 50% and pervasively heterogeneous on a meso- to megascopic scale. It typically consists of darker (melanosome) and lighter (leucosome) parts. The darker parts usually exhibit features of metamorphic rocks, whereas the lighter parts are of igneous appearance. See definition of migmatite in Fettes and Desmond (2007, p. 176)."@en ;
     skos:inScheme cs: ;
     skos:notation "mqi"^^:GSWA-rock-code ;
     skos:prefLabel "migmatitic metacarbonatite"@en ;
@@ -5166,7 +5166,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-lamprophyres ;
-    skos:definition "Originally an old miners’ term for oolitic ironstones. Later used for a variety of lamprophyre consisting of phenocrysts of phlogopite–biotite and occasionally amphiboles in a groundmass of the same minerals plus orthoclase and minor plagioclase. Mg-olivine and diopsidic pyroxene may also be present. Now defined in the lamprophyre classification (Table 2.9, p. 19). (Le Maitre et al., 2005, p. 112)"@en ;
+    skos:definition "Originally an old miners’ term for oolitic ironstones. Later used for a variety of lamprophyre consisting of phenocrysts of phlogopite–biotite and occasionally amphiboles in a groundmass of the same minerals plus orthoclase and minor plagioclase. Mg-olivine and diopsidic pyroxene may also be present. Now defined in the lamprophyre classification (Table 2.9, p. 19). (Le Maitre et al., 2005, p. 112)"@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "ym"^^:GSWA-rock-code ;
@@ -5254,7 +5254,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-lamprophyres ;
-    skos:definition "A variety of lamprophyre similar to camptonite except that the groundmass is feldspar-free and composed of combinations of glass and feldspathoids, especially analcime. Now defined in the lamprophyre classification (Table 2.9, p. 19). (Le Maitre et al., 2005, p. 113)"@en ;
+    skos:definition "A variety of lamprophyre similar to camptonite except that the groundmass is feldspar-free and composed of combinations of glass and feldspathoids, especially analcime. Now defined in the lamprophyre classification (Table 2.9, p. 19). (Le Maitre et al., 2005, p. 113)"@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "yq"^^:GSWA-rock-code ;
@@ -5265,7 +5265,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :impact-breccia ;
-    skos:definition "Cataclasite produced by impact and displaying weak or no shock metamorphism. It occurs in the (par)autochthonous floor of an impact crater or (up to the size of blocks and megablocks) within allochthonous (polymictic) impact breccias (Fettes and Desmons, 2007, p. 177)."@en ;
+    skos:definition "Cataclasite produced by impact and displaying weak or no shock metamorphism. It occurs in the (par)autochthonous floor of an impact crater or (up to the size of blocks and megablocks) within allochthonous (polymictic) impact breccias (Fettes and Desmons, 2007, p. 177)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:notation "mpm"^^:GSWA-rock-code ;
@@ -5276,7 +5276,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-felsic-intrusive ;
-    skos:definition "A term suggested to replace syenodiorite for an intrusive rock intermediate between monzonite and diorite. Now defined modally in QAPF field 9 (Fig. 2.4, p. 22). (cf. Le Maitre et al., 2005, p. 113)"@en ;
+    skos:definition "A term suggested to replace syenodiorite for an intrusive rock intermediate between monzonite and diorite. Now defined modally in QAPF field 9 (Fig. 2.4, p. 22). (cf. Le Maitre et al., 2005, p. 113)"@en ;
     skos:exactMatch
         <http://inspire.ec.europa.eu/codelist/LithologyValue/monzodiorite> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/monzodiorite> ;
@@ -5291,7 +5291,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-felsic-intrusive ;
-    skos:definition "A term suggested to replace syenogabbro for an intrusive rock of gabbroic aspect that contains minor but essential orthoclase as well as calcic plagioclase. Now defined modally in QAPF field 9 (Fig. 2.4, p. 22). (Le Maitre et al., 2005, p. 113)"@en ;
+    skos:definition "A term suggested to replace syenogabbro for an intrusive rock of gabbroic aspect that contains minor but essential orthoclase as well as calcic plagioclase. Now defined modally in QAPF field 9 (Fig. 2.4, p. 22). (Le Maitre et al., 2005, p. 113)"@en ;
     skos:exactMatch
         <http://inspire.ec.europa.eu/codelist/LithologyValue/monzogabbro> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/monzogabbro> ;
@@ -5306,7 +5306,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-felsic-intrusive ;
-    skos:definition "An optional term for a variety of granite in QAPF field 3b (Fig. 2.4, p. 22) having roughly equal amounts of alkali feldspar and plagioclase (Le Maitre et al., 2005, p. 113)"@en ;
+    skos:definition "An optional term for a variety of granite in QAPF field 3b (Fig. 2.4, p. 22) having roughly equal amounts of alkali feldspar and plagioclase (Le Maitre et al., 2005, p. 113)"@en ;
     skos:exactMatch
         <http://inspire.ec.europa.eu/codelist/LithologyValue/monzogranite> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/monzogranite> ;
@@ -5321,7 +5321,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-felsic-intrusive ;
-    skos:definition "An intrusive rock containing almost equal amounts of plagioclase and alkali feldspar with minor amphibole and/or pyroxene. Now defined modally in QAPF field 8 (Fig. 2.4, p. 22). Adapted from Le Maitre et al. (2005, p. 113)."@en ;
+    skos:definition "An intrusive rock containing almost equal amounts of plagioclase and alkali feldspar with minor amphibole and/or pyroxene. Now defined modally in QAPF field 8 (Fig. 2.4, p. 22). Adapted from Le Maitre et al. (2005, p. 113)."@en ;
     skos:exactMatch
         <http://inspire.ec.europa.eu/codelist/LithologyValue/monzonite> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/monzonite> ;
@@ -5337,7 +5337,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     rdfs:isDefinedBy cs: ;
     skos:altLabel "mesomylonite"@en ;
     skos:broader :metamorphic-protolith-unknown-fault-rock ;
-    skos:definition "Fault rock that is cohesive and characterized by a well-developed schistosity resulting from tectonic reduction of grain size for 50–90% of the rock volume, and commonly containing rounded porphyroclasts and lithic fragments of similar composition to minerals in the matrix. Fine-scale layering and an associated mineral or stretching lineation are commonly present. Brittle deformation of some minerals may be present, but deformation is commonly by crystal plasticity. Definition adapted from Fossen (2016) and Fettes and Desmons (2007, p. 177)."@en ;
+    skos:definition "Fault rock that is cohesive and characterized by a well-developed schistosity resulting from tectonic reduction of grain size for 50–90% of the rock volume, and commonly containing rounded porphyroclasts and lithic fragments of similar composition to minerals in the matrix. Fine-scale layering and an associated mineral or stretching lineation are commonly present. Brittle deformation of some minerals may be present, but deformation is commonly by crystal plasticity. Definition adapted from Fossen (2016) and Fettes and Desmons (2007, p. 177)."@en ;
     skos:historyNote "Fossen, H 2016, Structural geology (2nd edition): Cambridge University Press, Cambridge, United Kingdom, 524p." ;
     skos:inScheme cs: ;
     skos:notation "myy"^^:GSWA-rock-code ;
@@ -5363,7 +5363,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-felsic ;
-    skos:definition "A felsic igneous rock characterized by a well-developed schistosity resulting from tectonic reduction of grain size (cf. definition of mylonite in Fettes and Desmons, 2007, p. 177)."@en ;
+    skos:definition "A felsic igneous rock characterized by a well-developed schistosity resulting from tectonic reduction of grain size (cf. definition of mylonite in Fettes and Desmons, 2007, p. 177)."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "mry"^^:GSWA-rock-code ;
@@ -5374,7 +5374,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-mafic ;
-    skos:definition "A mafic igneous rock characterized by a well-developed schistosity resulting from tectonic reduction of grain size (cf. definition of mylonite in Fettes and Desmons, 2007, p. 177)."@en ;
+    skos:definition "A mafic igneous rock characterized by a well-developed schistosity resulting from tectonic reduction of grain size (cf. definition of mylonite in Fettes and Desmons, 2007, p. 177)."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "mwy"^^:GSWA-rock-code ;
@@ -5388,7 +5388,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
         "itabirite"@en ,
         "taconite"@en ;
     skos:broader :metasedimentary-other-chemical-meta-iron-formation ;
-    skos:definition "An iron formation characterized by a well-developed schistosity resulting from tectonic reduction of grain size (cf. definition of mylonite in Fettes and Desmons, 2007, p. 177)."@en ;
+    skos:definition "An iron formation characterized by a well-developed schistosity resulting from tectonic reduction of grain size (cf. definition of mylonite in Fettes and Desmons, 2007, p. 177)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007) and GSWA usage." ;
     skos:inScheme cs: ;
     skos:notation "miy"^^:GSWA-rock-code ;
@@ -5399,7 +5399,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-ultramafic-intrusive ;
-    skos:definition "An ultramafic igneous (intrusive or coarse-grained extrusive) rock characterized by a well-developed schistosity resulting from tectonic reduction of grain size (cf. definition of mylonite in Fettes and Desmons, 2007, p. 177)."@en ;
+    skos:definition "An ultramafic igneous (intrusive or coarse-grained extrusive) rock characterized by a well-developed schistosity resulting from tectonic reduction of grain size (cf. definition of mylonite in Fettes and Desmons, 2007, p. 177)."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "may"^^:GSWA-rock-code ;
@@ -5410,7 +5410,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-ultramafic-volcanic ;
-    skos:definition "An ultramafic volcanic or volcaniclastic rock characterized by a well-developed schistosity resulting from tectonic reduction of grain size (cf. definition of mylonite in Fettes and Desmons, 2007, p. 177)."@en ;
+    skos:definition "An ultramafic volcanic or volcaniclastic rock characterized by a well-developed schistosity resulting from tectonic reduction of grain size (cf. definition of mylonite in Fettes and Desmons, 2007, p. 177)."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "muy"^^:GSWA-rock-code ;
@@ -5432,7 +5432,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-carbonatite ;
-    skos:definition "A carbonatite characterized by a well-developed schistosity resulting from tectonic reduction of grain size (cf. definition of mylonite in Fettes and Desmons, 2007, p. 177)"@en ;
+    skos:definition "A carbonatite characterized by a well-developed schistosity resulting from tectonic reduction of grain size (cf. definition of mylonite in Fettes and Desmons, 2007, p. 177)"@en ;
     skos:inScheme cs: ;
     skos:notation "mqy"^^:GSWA-rock-code ;
     skos:prefLabel "mylonitized metacarbonatite"@en ;
@@ -5442,7 +5442,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metasedimentary-other-chemical ;
-    skos:definition "A chert rock characterized by a well-developed schistosity resulting from tectonic reduction of grain size (cf. definition of mylonite in Fettes and Desmons, 2007, p. 177)."@en ;
+    skos:definition "A chert rock characterized by a well-developed schistosity resulting from tectonic reduction of grain size (cf. definition of mylonite in Fettes and Desmons, 2007, p. 177)."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "mcy"^^:GSWA-rock-code ;
@@ -5453,7 +5453,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metasedimentary-siliciclastic-psephite ;
-    skos:definition "A siliciclastic rock originally consisting of particles greater than sand size (i.e. a conglomerate) that is characterized by a well-developed schistosity resulting from tectonic reduction of grain size (cf. definition of mylonite in Fettes and Desmons, 2007, p. 177)."@en ;
+    skos:definition "A siliciclastic rock originally consisting of particles greater than sand size (i.e. a conglomerate) that is characterized by a well-developed schistosity resulting from tectonic reduction of grain size (cf. definition of mylonite in Fettes and Desmons, 2007, p. 177)."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "mxy"^^:GSWA-rock-code ;
@@ -5465,7 +5465,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-felsic-volcanic ;
-    skos:definition "A felsic volcanic rock characterized by a well-developed schistosity resulting from tectonic reduction of grain size (cf. definition of mylonite in Fettes and Desmons, 2007, p. 177). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
+    skos:definition "A felsic volcanic rock characterized by a well-developed schistosity resulting from tectonic reduction of grain size (cf. definition of mylonite in Fettes and Desmons, 2007, p. 177). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "mfy"^^:GSWA-rock-code ;
@@ -5476,7 +5476,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-felsic-intrusive ;
-    skos:definition "A felsic intrusive rock characterized by a well-developed schistosity resulting from tectonic reduction of grain size (cf. definition of mylonite in Fettes and Desmons, 2007, p. 177)."@en ;
+    skos:definition "A felsic intrusive rock characterized by a well-developed schistosity resulting from tectonic reduction of grain size (cf. definition of mylonite in Fettes and Desmons, 2007, p. 177)."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "mgy"^^:GSWA-rock-code ;
@@ -5498,7 +5498,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-mafic-volcanic ;
-    skos:definition "A mafic volcanic rock characterized by a well-developed schistosity resulting from tectonic reduction of grain size (cf. definition of mylonite in Fettes and Desmons, 2007, p. 177). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
+    skos:definition "A mafic volcanic rock characterized by a well-developed schistosity resulting from tectonic reduction of grain size (cf. definition of mylonite in Fettes and Desmons, 2007, p. 177). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "mby"^^:GSWA-rock-code ;
@@ -5509,7 +5509,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metasedimentary-siliciclastic-psammite ;
-    skos:definition "A siliciclastic rock originally consisting of sand-sized particles that is characterized by a well-developed schistosity resulting from tectonic reduction of grain size (cf. definition of mylonite in Fettes and Desmons, 2007, p. 177)."@en ;
+    skos:definition "A siliciclastic rock originally consisting of sand-sized particles that is characterized by a well-developed schistosity resulting from tectonic reduction of grain size (cf. definition of mylonite in Fettes and Desmons, 2007, p. 177)."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "mty"^^:GSWA-rock-code ;
@@ -5521,7 +5521,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metasedimentary-siliciclastic ;
-    skos:definition "A siliciclastic rock characterized by a well-developed schistosity resulting from tectonic reduction of grain size (cf. definition of mylonite in Fettes and Desmons, 2007, p. 177)."@en ;
+    skos:definition "A siliciclastic rock characterized by a well-developed schistosity resulting from tectonic reduction of grain size (cf. definition of mylonite in Fettes and Desmons, 2007, p. 177)."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "mdy"^^:GSWA-rock-code ;
@@ -5546,7 +5546,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-volcanic-or-volcaniclastic ;
-    skos:definition "A metamorphosed volcanic or volcaniclastic rock otherwise uncategorized that is characterized by a well-developed schistosity resulting from tectonic reduction of grain size (cf. definition of mylonite in Fettes and Desmons, 2007, p. 177)."@en ;
+    skos:definition "A metamorphosed volcanic or volcaniclastic rock otherwise uncategorized that is characterized by a well-developed schistosity resulting from tectonic reduction of grain size (cf. definition of mylonite in Fettes and Desmons, 2007, p. 177)."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "mvy"^^:GSWA-rock-code ;
@@ -5557,7 +5557,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metasedimentary-siliciclastic-pelite ;
-    skos:definition "A fine-grained siliciclastic rock characterized by a well-developed schistosity resulting from tectonic reduction of grain size (cf. definition of mylonite in Fettes and Desmons, 2007, p. 177)."@en ;
+    skos:definition "A fine-grained siliciclastic rock characterized by a well-developed schistosity resulting from tectonic reduction of grain size (cf. definition of mylonite in Fettes and Desmons, 2007, p. 177)."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "mly"^^:GSWA-rock-code ;
@@ -5569,7 +5569,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metasedimentary-siliciclastic-psammite-and-pelite-interlayered ;
-    skos:definition "A metamorphosed sequence of rocks originally consisting of interleaved sandstone and mudstone beds that is characterized by a well-developed schistosity resulting from tectonic reduction of grain size (cf. definition of mylonite in Fettes and Desmons, 2007, p. 177)."@en ;
+    skos:definition "A metamorphosed sequence of rocks originally consisting of interleaved sandstone and mudstone beds that is characterized by a well-developed schistosity resulting from tectonic reduction of grain size (cf. definition of mylonite in Fettes and Desmons, 2007, p. 177)."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "mhy"^^:GSWA-rock-code ;
@@ -5583,7 +5583,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metasedimentary-siliciclastic-semipelite ;
-    skos:definition "A fine-grained siliciclastic rock characterized by a well-developed schistosity resulting from tectonic reduction of grain size (cf. definition of mylonite in Fettes and Desmons, 2007, p. 177), and with a modal ratio of mica to quartz + feldspar intermediate between a pelite and a psammite."@en ;
+    skos:definition "A fine-grained siliciclastic rock characterized by a well-developed schistosity resulting from tectonic reduction of grain size (cf. definition of mylonite in Fettes and Desmons, 2007, p. 177), and with a modal ratio of mica to quartz + feldspar intermediate between a pelite and a psammite."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "mmy"^^:GSWA-rock-code ;
@@ -5594,7 +5594,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-mafic-intrusive ;
-    skos:definition "An intrusive rock composed essentially of bytownite, labradorite or andesine and orthopyroxene. Now defined modally in the gabbroic rock classification (Fig. 2.6, p. 25). (Le Maitre et al., 2005, p. 117)"@en ;
+    skos:definition "An intrusive rock composed essentially of bytownite, labradorite or andesine and orthopyroxene. Now defined modally in the gabbroic rock classification (Fig. 2.6, p. 25). (Le Maitre et al., 2005, p. 117)"@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "ow"^^:GSWA-rock-code ;
@@ -5606,7 +5606,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-mafic-intrusive ;
-    skos:definition "An intrusive rock defined modally in the gabbroic rock classification (Fig. 2.6, p. 25) as a variety of norite in which olivine is between 5% and 85% and clinopyroxene exceeds 5% of the pyroxenes. (cf. Le Maitre et al., 2005, p. 120)"@en ;
+    skos:definition "An intrusive rock defined modally in the gabbroic rock classification (Fig. 2.6, p. 25) as a variety of norite in which olivine is between 5% and 85% and clinopyroxene exceeds 5% of the pyroxenes. (cf. Le Maitre et al., 2005, p. 120)"@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "ov"^^:GSWA-rock-code ;
@@ -5617,7 +5617,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-ultramafic-intrusive ;
-    skos:definition "An ultramafic intrusive rock consisting essentially of clinopyroxene and 10–40% olivine. Now defined modally in the ultramafic rock classification (Fig. 2.9, p. 28). Adapted from Le Maitre et al. (2005, p. 119)."@en ;
+    skos:definition "An ultramafic intrusive rock consisting essentially of clinopyroxene and 10–40% olivine. Now defined modally in the ultramafic rock classification (Fig. 2.9, p. 28). Adapted from Le Maitre et al. (2005, p. 119)."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "aoc"^^:GSWA-rock-code ;
@@ -5630,7 +5630,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     rdfs:isDefinedBy cs: ;
     skos:altLabel "olivine-diopside-richterite-phlogopite lamproite"@en ;
     skos:broader :igneous-lamproites ;
-    skos:definition "Originally described as a variety of olivine phonolitic leucitite composed essentially of leucite and diopside, and with subordinate olivine, alkali feldspar and phlogopite. Now regarded as an olivine–diopside–richterite madupitic lamproite (Table 2.7, p. 17), with the term 'madupitic' referring to the presence of poikilitic groundmass phlogopite. The original name jumillite is not recommended for usage. (Le Maitre et al., 2005, p. 94)"@en ;
+    skos:definition "Originally described as a variety of olivine phonolitic leucitite composed essentially of leucite and diopside, and with subordinate olivine, alkali feldspar and phlogopite. Now regarded as an olivine–diopside–richterite madupitic lamproite (Table 2.7, p. 17), with the term 'madupitic' referring to the presence of poikilitic groundmass phlogopite. The original name jumillite is not recommended for usage. (Le Maitre et al., 2005, p. 94)"@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "ij"^^:GSWA-rock-code ;
@@ -5642,7 +5642,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-mafic-intrusive ;
-    skos:definition "A commonly used name for a gabbro containing essential olivine. Now defined modally in the gabbroic rock classification (Fig. 2.6, p. 25) as a variety of gabbro in which olivine is between 5% and 85%. (Le Maitre et al., 2005, p. 119)"@en ;
+    skos:definition "A commonly used name for a gabbro containing essential olivine. Now defined modally in the gabbroic rock classification (Fig. 2.6, p. 25) as a variety of gabbro in which olivine is between 5% and 85%. (Le Maitre et al., 2005, p. 119)"@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "oo"^^:GSWA-rock-code ;
@@ -5654,7 +5654,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-mafic-intrusive ;
-    skos:definition "A collective term for intrusive rocks consisting of 10–90% calcic plagioclase and accompanied by olivine, orthopyroxene and clinopyroxene in various amounts. Now defined modally in the gabbroic rock classification (Fig. 2.6, p. 25) as a variety of gabbronorite in which olivine is between 5% and 85%. (Le Maitre et al., 2005, p. 119)"@en ;
+    skos:definition "A collective term for intrusive rocks consisting of 10–90% calcic plagioclase and accompanied by olivine, orthopyroxene and clinopyroxene in various amounts. Now defined modally in the gabbroic rock classification (Fig. 2.6, p. 25) as a variety of gabbronorite in which olivine is between 5% and 85%. (Le Maitre et al., 2005, p. 119)"@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "ol"^^:GSWA-rock-code ;
@@ -5666,7 +5666,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-ultramafic-intrusive ;
-    skos:definition "An ultramafic intrusive rock consisting of more than 30% pyroxene accompanied by hornblende and olivine in various amounts. Now defined modally in the ultramafic rock classification (Fig. 2.9, p. 28). (cf. Le Maitre et al., 2005, p. 119)"@en ;
+    skos:definition "An ultramafic intrusive rock consisting of more than 30% pyroxene accompanied by hornblende and olivine in various amounts. Now defined modally in the ultramafic rock classification (Fig. 2.9, p. 28). (cf. Le Maitre et al., 2005, p. 119)"@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "ai"^^:GSWA-rock-code ;
@@ -5678,7 +5678,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-ultramafic-intrusive ;
-    skos:definition "An ultramafic intrusive rock consisting essentially of amphibole and up to 40% olivine. Now defined modally in the ultramafic rock classification (Fig. 2.9, p. 28). Adapted from Le Maitre et al. (2005, p. 119)."@en ;
+    skos:definition "An ultramafic intrusive rock consisting essentially of amphibole and up to 40% olivine. Now defined modally in the ultramafic rock classification (Fig. 2.9, p. 28). Adapted from Le Maitre et al. (2005, p. 119)."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "av"^^:GSWA-rock-code ;
@@ -5690,7 +5690,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-melilitic ;
-    skos:definition "An ultramafic intrusive rock containing at least 10% melilite, at least 10% olivine, and less than 10% clinopyroxene (Glossary of geology, Neuendorf et al., 2011, 5th edition, revised). Note that in Le Maitre et al.'s glossary (2005, p. 120), olivine melilitolite is described as \"originally defined as an ultramafic plutonic rock consisting essentially of melilite and olivine with minor clinopyroxene (see 1st Edition, Fig. B.3, p. 12), but not required by the new melilite-bearing rocks classification (section 2.4.1, p. 11)\"."@en ;
+    skos:definition "An ultramafic intrusive rock containing at least 10% melilite, at least 10% olivine, and less than 10% clinopyroxene (Glossary of geology, Neuendorf et al., 2011, 5th edition, revised). Note that in Le Maitre et al.'s glossary (2005, p. 120), olivine melilitolite is described as \"originally defined as an ultramafic plutonic rock consisting essentially of melilite and olivine with minor clinopyroxene (see 1st Edition, Fig. B.3, p. 12), but not required by the new melilite-bearing rocks classification (section 2.4.1, p. 11)\"."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005) and Glossary of geology (5th edition, revised; Neuendorf et al. 2011)." ;
     skos:inScheme cs: ;
     skos:notation "eo"^^:GSWA-rock-code ;
@@ -5702,7 +5702,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-mafic-intrusive ;
-    skos:definition "An old term for a norite containing essential olivine. Now defined modally in the gabbroic rock classification (Fig. 2.6, p. 25) as a variety of norite in which olivine is between 5% and 85%. (Le Maitre et al., 2005, p. 120)"@en ;
+    skos:definition "An old term for a norite containing essential olivine. Now defined modally in the gabbroic rock classification (Fig. 2.6, p. 25) as a variety of norite in which olivine is between 5% and 85%. (Le Maitre et al., 2005, p. 120)"@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "or"^^:GSWA-rock-code ;
@@ -5714,7 +5714,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-mafic-intrusive ;
-    skos:definition "An intrusive rock defined modally in the gabbroic rock classification (Fig. 2.6, p. 25) as a variety of gabbro in which olivine is between 5% and 85% and orthopyroxene exceeds 5% of the pyroxenes. (cf. olivine gabbro/gabbronorite in Le Maitre et al., 2005, p. 119)"@en ;
+    skos:definition "An intrusive rock defined modally in the gabbroic rock classification (Fig. 2.6, p. 25) as a variety of gabbro in which olivine is between 5% and 85% and orthopyroxene exceeds 5% of the pyroxenes. (cf. olivine gabbro/gabbronorite in Le Maitre et al., 2005, p. 119)"@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "oj"^^:GSWA-rock-code ;
@@ -5725,7 +5725,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-ultramafic-intrusive ;
-    skos:definition "An ultramafic intrusive rock consisting essentially of orthopyroxene and 10–40% olivine. Now defined modally in the ultramafic rock classification (Fig. 2.9, p. 28). Adapted from Le Maitre et al. (2005, p. 120)."@en ;
+    skos:definition "An ultramafic intrusive rock consisting essentially of orthopyroxene and 10–40% olivine. Now defined modally in the ultramafic rock classification (Fig. 2.9, p. 28). Adapted from Le Maitre et al. (2005, p. 120)."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "aoo"^^:GSWA-rock-code ;
@@ -5737,7 +5737,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-ultramafic-intrusive ;
-    skos:definition "An ultramafic intrusive rock consisting of more than 30% amphibole accompanied by pyroxene and olivine in various amounts. Now defined modally in the ultramafic rock classification (Fig. 2.9, p. 28). (cf. Le Maitre et al., 2005, p. 120)"@en ;
+    skos:definition "An ultramafic intrusive rock consisting of more than 30% amphibole accompanied by pyroxene and olivine in various amounts. Now defined modally in the ultramafic rock classification (Fig. 2.9, p. 28). (cf. Le Maitre et al., 2005, p. 120)"@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "at"^^:GSWA-rock-code ;
@@ -5749,7 +5749,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-kalsilitic ;
-    skos:definition "An ultrabasic rock consisting of phenocrysts of olivine and minor pyroxene in a groundmass of diopside and kalsilite with small amounts of perovskite, olivine and biotite. The historical term mafurite is considered obsolete. Cf. Tables 2.5 & 2.6 on p. 12, and p. 107 in Le Maitre et al. (2005)."@en ;
+    skos:definition "An ultrabasic rock consisting of phenocrysts of olivine and minor pyroxene in a groundmass of diopside and kalsilite with small amounts of perovskite, olivine and biotite. The historical term mafurite is considered obsolete. Cf. Tables 2.5 & 2.6 on p. 12, and p. 107 in Le Maitre et al. (2005)."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005). See also https://academic.oup.com/petrology/article/63/5/egac026/6553206." ;
     skos:inScheme cs: ;
     skos:notation "wm"^^:GSWA-rock-code ;
@@ -5761,7 +5761,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-melilitic ;
-    skos:definition "In the IUGS classification (Le Maitre et al., 2005, p. 11), an intrusive rock consisting mostly of melilite, olivine, and clinopyroxene, with clinopyroxene > olivine (Glossary of geology, Neuendorf et al., 2011, 5th edition, revised))."@en ;
+    skos:definition "In the IUGS classification (Le Maitre et al., 2005, p. 11), an intrusive rock consisting mostly of melilite, olivine, and clinopyroxene, with clinopyroxene > olivine (Glossary of geology, Neuendorf et al., 2011, 5th edition, revised))."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005) and Glossary of geology (5th edition, revised; Neuendorf et al. 2011)." ;
     skos:inScheme cs: ;
     skos:notation "el"^^:GSWA-rock-code ;
@@ -5773,7 +5773,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-ultramafic-intrusive ;
-    skos:definition "An ultramafic intrusive rock consisting essentially of pyroxene and 10–40% olivine. Now defined modally in the ultramafic rock classification (Fig. 2.9, p. 28). Adapted from Le Maitre et al. (2005, p. 120)."@en ;
+    skos:definition "An ultramafic intrusive rock consisting essentially of pyroxene and 10–40% olivine. Now defined modally in the ultramafic rock classification (Fig. 2.9, p. 28). Adapted from Le Maitre et al. (2005, p. 120)."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "ao"^^:GSWA-rock-code ;
@@ -5785,7 +5785,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-ultramafic-intrusive ;
-    skos:definition "An ultramafic intrusive rock consisting of 10–40% olivine with various amounts of clinopyroxene and orthopyroxene. Now defined modally in the ultramafic rock classification (Fig. 2.9, p. 28). (cf. Le Maitre et al., 2005, p. 120)"@en ;
+    skos:definition "An ultramafic intrusive rock consisting of 10–40% olivine with various amounts of clinopyroxene and orthopyroxene. Now defined modally in the ultramafic rock classification (Fig. 2.9, p. 28). (cf. Le Maitre et al., 2005, p. 120)"@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "aow"^^:GSWA-rock-code ;
@@ -5812,7 +5812,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :limestone ;
-    skos:definition "A limestone characterized by the presence of ooliths and/or peloids. Ooliths are small round or ovate accretionary bodies resembling the roe of fish, with a diameter of 0.25 to 2 mm (commonly 0.5 to 1 mm), and usually formed of calcium carbonate (but also dolomite, silica, or other minerals) in successive concentric layers, commonly around a nucleus such as a shell fragment, an algal pellet, or a quartz-sand grain, in shallow, wave-agitated water; ooliths commonly show an internal radiating fibrous structure indicating outward growth or enlargement at the site of deposition, and are frequently formed by inorganic precipitation. Peloids are allochems composed of micrite, irrespective of size or origin, for which an exact origin is unknown (e.g. completely micritized fossils or ooids); other types of peloid include pseudo-ooids and aggregates produced by gas bubbling, by microbial precipitation, or by other intraformational reworking of lithified or semilithified carbonate mud. Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
+    skos:definition "A limestone characterized by the presence of ooliths and/or peloids. Ooliths are small round or ovate accretionary bodies resembling the roe of fish, with a diameter of 0.25 to 2 mm (commonly 0.5 to 1 mm), and usually formed of calcium carbonate (but also dolomite, silica, or other minerals) in successive concentric layers, commonly around a nucleus such as a shell fragment, an algal pellet, or a quartz-sand grain, in shallow, wave-agitated water; ooliths commonly show an internal radiating fibrous structure indicating outward growth or enlargement at the site of deposition, and are frequently formed by inorganic precipitation. Peloids are allochems composed of micrite, irrespective of size or origin, for which an exact origin is unknown (e.g. completely micritized fossils or ooids); other types of peloid include pseudo-ooids and aggregates produced by gas bubbling, by microbial precipitation, or by other intraformational reworking of lithified or semilithified carbonate mud. Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
     skos:historyNote "Based on the Glossary of geology (5th edition, revised; Neuendorf et al. 2011)." ;
     skos:inScheme cs: ;
     skos:notation "klo"^^:GSWA-rock-code ;
@@ -5827,7 +5827,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-mafic-intrusive ;
-    skos:definition "A basic intrusive rock consisting mainly of calcic plagioclase, clinopyroxene and minor orthopyroxene. Now defined modally in the gabbroic rock classification (Fig. 2.6, p. 25). (Le Maitre et al., 2005, p. 122)"@en ;
+    skos:definition "A basic intrusive rock consisting mainly of calcic plagioclase, clinopyroxene and minor orthopyroxene. Now defined modally in the gabbroic rock classification (Fig. 2.6, p. 25). (Le Maitre et al., 2005, p. 122)"@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "op"^^:GSWA-rock-code ;
@@ -5839,7 +5839,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-ultramafic-intrusive ;
-    skos:definition "An ultramafic intrusive rock consisting almost entirely of orthopyroxene. Now defined modally in the ultramafic rock classification (Fig. 2.9, p. 28). (cf. Le Maitre et al., 2005, p. 122)"@en ;
+    skos:definition "An ultramafic intrusive rock consisting almost entirely of orthopyroxene. Now defined modally in the ultramafic rock classification (Fig. 2.9, p. 28). (cf. Le Maitre et al., 2005, p. 122)"@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "axo"^^:GSWA-rock-code ;
@@ -5855,7 +5855,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     skos:exactMatch
         <http://inspire.ec.europa.eu/codelist/LithologyValue/peat> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/peat> ;
-    skos:historyNote "Forsman, JP and Hunt, JM 1958, Insoluble organic matter (kerogen) in sedimentary rocks: Geochimica et Cosmochimica Acta, v. 15(3), p. 170–182, doi.org/10.1016/0016-7037(58)90055-3." ;
+    skos:historyNote "Forsman, JP and Hunt, JM 1958, Insoluble organic matter (kerogen) in sedimentary rocks: Geochimica et Cosmochimica Acta, v. 15(3), p. 170–182, doi.org/10.1016/0016-7037(58)90055-3." ;
     skos:inScheme cs: ;
     skos:notation "cot"^^:GSWA-rock-code ;
     skos:prefLabel "peat"@en ;
@@ -5866,8 +5866,8 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :conglomerate ;
-    skos:definition "A consolidated rock consisting mainly of pebbles (2–64 mm or -1 to -4 phi units) being somewhat rounded or otherwise modified by abrasion in the course of transport. Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
-    skos:historyNote "Wentworth, CK 1922, A scale of grade and class terms for clastic sediments: The Journal of Geology, v. 30, no. 5, p. 377–392, doi:10.1086/622910." ;
+    skos:definition "A consolidated rock consisting mainly of pebbles (2–64 mm or -1 to -4 phi units) being somewhat rounded or otherwise modified by abrasion in the course of transport. Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
+    skos:historyNote "Wentworth, CK 1922, A scale of grade and class terms for clastic sediments: The Journal of Geology, v. 30, no. 5, p. 377–392, doi:10.1086/622910." ;
     skos:inScheme cs: ;
     skos:notation "si"^^:GSWA-rock-code ;
     skos:prefLabel "pebble conglomerate"@en ;
@@ -5881,7 +5881,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     rdfs:isDefinedBy cs: ;
     skos:altLabel "conglomeratic sandstone"@en ;
     skos:broader :sedimentary-siliciclastic ;
-    skos:definition "A consolidated pebbly sand containing 10–20% pebbles in a matrix-supported framework. Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
+    skos:definition "A consolidated pebbly sand containing 10–20% pebbles in a matrix-supported framework. Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
     skos:historyNote "Based on the Glossary of geology (5th edition, revised; Neuendorf et al. 2011)." ;
     skos:inScheme cs: ;
     skos:notation "sr"^^:GSWA-rock-code ;
@@ -5893,7 +5893,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-felsic-intrusive ;
-    skos:definition "An exceptionally coarse-grained igneous rock, with interlocking crystals, usually found as irregular dykes, lenses, or veins, especially at the margins of batholiths. Most grains are 1 cm or more in diameter. Although pegmatites having gross compositions similar to other rock types are known, their composition is generally that of granite; the composition may be simple or complex and may include rare minerals rich in such elements as lithium, boron, fluorine, niobium, tantalum, uranium, and rare earths. Definition adapted from Glossary of geology (Neuendorf et al., 2011, 5th edition, revised)."@en ;
+    skos:definition "An exceptionally coarse-grained igneous rock, with interlocking crystals, usually found as irregular dykes, lenses, or veins, especially at the margins of batholiths. Most grains are 1 cm or more in diameter. Although pegmatites having gross compositions similar to other rock types are known, their composition is generally that of granite; the composition may be simple or complex and may include rare minerals rich in such elements as lithium, boron, fluorine, niobium, tantalum, uranium, and rare earths. Definition adapted from Glossary of geology (Neuendorf et al., 2011, 5th edition, revised)."@en ;
     skos:exactMatch
         <http://inspire.ec.europa.eu/codelist/LithologyValue/pegmatite> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/pegmatite> ;
@@ -5908,7 +5908,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metasedimentary-siliciclastic-pelite ;
-    skos:definition "Type of gneiss derived by metamorphism of an aluminium-rich, fine-grained sedimentary or metasedimentary protolith. See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
+    skos:definition "Type of gneiss derived by metamorphism of an aluminium-rich, fine-grained sedimentary or metasedimentary protolith. See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "mln"^^:GSWA-rock-code ;
@@ -5923,7 +5923,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
         "hornfelsed pelite"@en ,
         "peraluminous hornfels"@en ;
     skos:broader :metasedimentary-siliciclastic-pelite ;
-    skos:definition "Type of granofels/hornfels derived by (contact) metamorphism of an aluminium-rich, argillaceous or fine-grained sedimentary or metasedimentary protolith. Adapted from Fettes and Desmons (2007, p. 182). See also definition of granofels/granofelsic structure in Fettes and Desmons (2007, p. 156); hornfels are granofels formed by contact metamorphism (Fettes and Desmons, 2007, p. 159)."@en ;
+    skos:definition "Type of granofels/hornfels derived by (contact) metamorphism of an aluminium-rich, argillaceous or fine-grained sedimentary or metasedimentary protolith. Adapted from Fettes and Desmons (2007, p. 182). See also definition of granofels/granofelsic structure in Fettes and Desmons (2007, p. 156); hornfels are granofels formed by contact metamorphism (Fettes and Desmons, 2007, p. 159)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:notation "mle"^^:GSWA-rock-code ;
@@ -5935,7 +5935,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metasedimentary-siliciclastic-pelite ;
-    skos:definition "Composite silicate metamorphic rock derived from a fine-grained siliciclastic sedimentary or metasedimentary protolith, pervasively heterogeneous on a meso- to megascopic scale. It typically consists of darker (melanosome) and lighter (leucosome) parts. The darker parts usually exhibit features of metamorphic rocks, whereas the lighter parts are of igneous appearance. See definition of migmatite in Fettes and Desmond (2007, p. 176)."@en ;
+    skos:definition "Composite silicate metamorphic rock derived from a fine-grained siliciclastic sedimentary or metasedimentary protolith, pervasively heterogeneous on a meso- to megascopic scale. It typically consists of darker (melanosome) and lighter (leucosome) parts. The darker parts usually exhibit features of metamorphic rocks, whereas the lighter parts are of igneous appearance. See definition of migmatite in Fettes and Desmond (2007, p. 176)."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "mli"^^:GSWA-rock-code ;
@@ -5947,7 +5947,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metasedimentary-siliciclastic-pelite ;
-    skos:definition "Type of schist derived by metamorphism of an aluminium-rich, fine-grained sedimentary or metasedimentary protolith. See also definition of schist/schistose structure in Fettes and Desmons (2007, p. 193)."@en ;
+    skos:definition "Type of schist derived by metamorphism of an aluminium-rich, fine-grained sedimentary or metasedimentary protolith. See also definition of schist/schistose structure in Fettes and Desmons (2007, p. 193)."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "mls"^^:GSWA-rock-code ;
@@ -5959,7 +5959,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-ultramafic-volcanic-and-volcaniclastic ;
-    skos:definition "A collective term for ultramafic rocks consisting essentially of olivine with pyroxene and/or amphibole. Now defined modally in the ultramafic rock classification (Fig. 2.9, p. 28). (Le Maitre et al., 2005, p. 126)"@en ;
+    skos:definition "A collective term for ultramafic rocks consisting essentially of olivine with pyroxene and/or amphibole. Now defined modally in the ultramafic rock classification (Fig. 2.9, p. 28). (Le Maitre et al., 2005, p. 126)"@en ;
     skos:exactMatch
         <http://inspire.ec.europa.eu/codelist/LithologyValue/peridotite> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/peridotite> ;
@@ -5989,7 +5989,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metasedimentary-siliciclastic-pelite ;
-    skos:definition "Fine- to medium-grained metamorphic rock characterized by a lustrous sheen and a well-developed schistosity resulting from the parallel arrangement of phyllosilicates. Phyllite is usually of low metamorphic grade. Originally introduced as an alternative to 'phyllade' (term now superseded) to describe a fine-grained schist composed predominantly of micaceous minerals, and as such forming a transition between a (clay-)slate and a mica schist. (Fettes and Desmons, 2007, p. 183)"@en ;
+    skos:definition "Fine- to medium-grained metamorphic rock characterized by a lustrous sheen and a well-developed schistosity resulting from the parallel arrangement of phyllosilicates. Phyllite is usually of low metamorphic grade. Originally introduced as an alternative to 'phyllade' (term now superseded) to describe a fine-grained schist composed predominantly of micaceous minerals, and as such forming a transition between a (clay-)slate and a mica schist. (Fettes and Desmons, 2007, p. 183)"@en ;
     skos:exactMatch
         <http://inspire.ec.europa.eu/codelist/LithologyValue/phyllite> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/phyllite> ;
@@ -6004,7 +6004,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metamorphic-protolith-unknown-fault-rock ;
-    skos:definition "Phyllosilicate-rich mylonite that has the lustrous sheen of a phyllite (Fettes and Desmons, 2007, p. 183)."@en ;
+    skos:definition "Phyllosilicate-rich mylonite that has the lustrous sheen of a phyllite (Fettes and Desmons, 2007, p. 183)."@en ;
     skos:exactMatch
         <http://inspire.ec.europa.eu/codelist/LithologyValue/phyllonite> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/phyllonite> ;
@@ -6031,7 +6031,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metamorphic-protolith-unknown-fault-rock ;
-    skos:definition "A cohesive fault rock with a poorly developed or absent schistosity, characterized by generally angular porphyroclasts and lithic fragments in a finer-grained matrix of similar composition that constitutes between 10 and 50% of the rock volume. Definition adapted from Fossen (2016) and Fettes and Desmons (2007, p. 188)."@en ;
+    skos:definition "A cohesive fault rock with a poorly developed or absent schistosity, characterized by generally angular porphyroclasts and lithic fragments in a finer-grained matrix of similar composition that constitutes between 10 and 50% of the rock volume. Definition adapted from Fossen (2016) and Fettes and Desmons (2007, p. 188)."@en ;
     skos:historyNote "Fossen, H 2016, Structural geology (2nd edition): Cambridge University Press, Cambridge, United Kingdom, 524p." ;
     skos:inScheme cs: ;
     skos:notation "myv"^^:GSWA-rock-code ;
@@ -6054,7 +6054,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metasedimentary-siliciclastic-psammite-and-pelite-interlayered ;
-    skos:definition "A metamorphosed sequence of rocks derived from a interleaving of sandstone and mudstone, i.e. siliciclastic sedimentary protoliths with grain size between 0.0625 and 2 mm and less than 0.0625 mm respectively."@en ;
+    skos:definition "A metamorphosed sequence of rocks derived from a interleaving of sandstone and mudstone, i.e. siliciclastic sedimentary protoliths with grain size between 0.0625 and 2 mm and less than 0.0625 mm respectively."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "mh"^^:GSWA-rock-code ;
@@ -6068,7 +6068,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metasedimentary-siliciclastic-psammite-and-pelite-interlayered ;
-    skos:definition "A gneissose sequence derived by metamorphism of a sedimentary or metasedimentary succession largely consisting of interleaved sandstone and mudstone beds. See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
+    skos:definition "A gneissose sequence derived by metamorphism of a sedimentary or metasedimentary succession largely consisting of interleaved sandstone and mudstone beds. See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:notation "mhn"^^:GSWA-rock-code ;
@@ -6082,7 +6082,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metasedimentary-siliciclastic-psammite-and-pelite-interlayered ;
-    skos:definition "A granofels/hornfels derived by (contact) metamorphism of a sedimentary or metasedimentary succession largely consisting of interleaved sandstone and mudstone beds. See also definition of granofels/granofelsic structure in Fettes and Desmons (2007, p. 156); hornfels are granofels formed by contact metamorphism (Fettes and Desmons, 2007, p. 159)."@en ;
+    skos:definition "A granofels/hornfels derived by (contact) metamorphism of a sedimentary or metasedimentary succession largely consisting of interleaved sandstone and mudstone beds. See also definition of granofels/granofelsic structure in Fettes and Desmons (2007, p. 156); hornfels are granofels formed by contact metamorphism (Fettes and Desmons, 2007, p. 159)."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "mhe"^^:GSWA-rock-code ;
@@ -6096,7 +6096,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metasedimentary-siliciclastic-psammite-and-pelite-interlayered ;
-    skos:definition "Composite silicate metamorphic rock derived from a siliciclastic sedimentary or metasedimentary succession consisting of interleaved sandstone and mudstone beds, and pervasively heterogeneous on a meso- to megascopic scale. It typically consists of darker (melanosome) and lighter (leucosome) parts. The darker parts usually exhibit features of metamorphic rocks, whereas the lighter parts are of igneous appearance. See definition of migmatite in Fettes and Desmond (2007, p. 176)."@en ;
+    skos:definition "Composite silicate metamorphic rock derived from a siliciclastic sedimentary or metasedimentary succession consisting of interleaved sandstone and mudstone beds, and pervasively heterogeneous on a meso- to megascopic scale. It typically consists of darker (melanosome) and lighter (leucosome) parts. The darker parts usually exhibit features of metamorphic rocks, whereas the lighter parts are of igneous appearance. See definition of migmatite in Fettes and Desmond (2007, p. 176)."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "mhi"^^:GSWA-rock-code ;
@@ -6110,7 +6110,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metasedimentary-siliciclastic-psammite-and-pelite-interlayered ;
-    skos:definition "A schistose sequence derived by metamorphism of a sedimentary or metasedimentary succession largely consisting of interleaved sandstone and mudstone beds. See also definition of schist/schistose structure in Fettes and Desmons (2007, p. 193)."@en ;
+    skos:definition "A schistose sequence derived by metamorphism of a sedimentary or metasedimentary succession largely consisting of interleaved sandstone and mudstone beds. See also definition of schist/schistose structure in Fettes and Desmons (2007, p. 193)."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "mhs"^^:GSWA-rock-code ;
@@ -6124,7 +6124,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metasedimentary-siliciclastic-psammite ;
-    skos:definition "Type of gneiss derived by metamorphism of a sedimentary or metasedimentary protolith largely consisting of sand-size particles. See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
+    skos:definition "Type of gneiss derived by metamorphism of a sedimentary or metasedimentary protolith largely consisting of sand-size particles. See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:notation "mtn"^^:GSWA-rock-code ;
@@ -6136,7 +6136,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metasedimentary-siliciclastic-psammite ;
-    skos:definition "Type of granofels/hornfels derived by (contact) metamorphism of a sedimentary or metasedimentary protolith largely consisting of sand-size particles. See also definition of granofels/granofelsic structure in Fettes and Desmons (2007, p. 156); hornfels are granofels formed by contact metamorphism (Fettes and Desmons, 2007, p. 159)."@en ;
+    skos:definition "Type of granofels/hornfels derived by (contact) metamorphism of a sedimentary or metasedimentary protolith largely consisting of sand-size particles. See also definition of granofels/granofelsic structure in Fettes and Desmons (2007, p. 156); hornfels are granofels formed by contact metamorphism (Fettes and Desmons, 2007, p. 159)."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "mte"^^:GSWA-rock-code ;
@@ -6148,7 +6148,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metasedimentary-siliciclastic-psammite ;
-    skos:definition "Composite silicate metamorphic rock derived from a siliciclastic sedimentary or metasedimentary protolith largely consisting of sand-size particles. Pervasively heterogeneous on a meso- to megascopic scale, it typically consists of darker (melanosome) and lighter (leucosome) parts. The darker parts usually exhibit features of metamorphic rocks, whereas the lighter parts are of igneous appearance. See definition of migmatite in Fettes and Desmond (2007, p. 176)."@en ;
+    skos:definition "Composite silicate metamorphic rock derived from a siliciclastic sedimentary or metasedimentary protolith largely consisting of sand-size particles. Pervasively heterogeneous on a meso- to megascopic scale, it typically consists of darker (melanosome) and lighter (leucosome) parts. The darker parts usually exhibit features of metamorphic rocks, whereas the lighter parts are of igneous appearance. See definition of migmatite in Fettes and Desmond (2007, p. 176)."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "mti"^^:GSWA-rock-code ;
@@ -6160,7 +6160,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metasedimentary-siliciclastic-psammite ;
-    skos:definition "Type of schist derived by metamorphism of a sedimentary or metasedimentary protolith largely consisting of sand-size particles. See also definition of schist/schistose structure in Fettes and Desmons (2007, p. 193)."@en ;
+    skos:definition "Type of schist derived by metamorphism of a sedimentary or metasedimentary protolith largely consisting of sand-size particles. See also definition of schist/schistose structure in Fettes and Desmons (2007, p. 193)."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "mts"^^:GSWA-rock-code ;
@@ -6172,7 +6172,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metasedimentary-siliciclastic-psephite ;
-    skos:definition "Type of gneiss derived by metamorphism of a sedimentary or metasedimentary protolith largely consisting of conglomerate. See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
+    skos:definition "Type of gneiss derived by metamorphism of a sedimentary or metasedimentary protolith largely consisting of conglomerate. See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "mxn"^^:GSWA-rock-code ;
@@ -6184,7 +6184,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metasedimentary-siliciclastic-psephite ;
-    skos:definition "Type of granofels/hornfels derived by (contact) metamorphism of a sedimentary or metasedimentary protolith largely consisting of particles larger than sand size. See also definition of granofels/granofelsic structure in Fettes and Desmons (2007, p. 156); hornfels are granofels formed by contact metamorphism (Fettes and Desmons, 2007, p. 159)."@en ;
+    skos:definition "Type of granofels/hornfels derived by (contact) metamorphism of a sedimentary or metasedimentary protolith largely consisting of particles larger than sand size. See also definition of granofels/granofelsic structure in Fettes and Desmons (2007, p. 156); hornfels are granofels formed by contact metamorphism (Fettes and Desmons, 2007, p. 159)."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "mxe"^^:GSWA-rock-code ;
@@ -6233,7 +6233,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-mafic-intrusive ;
-    skos:definition "An intrusive rock (and including coarse-grained parts of extrusive successions) defined modally in the gabbroic rock classification (Fig. 2.6, p. 25) as a variety of gabbro in which hornblende is between 5% and 85% (cf. Le Maitre et al., 2005, p. 133)."@en ;
+    skos:definition "An intrusive rock (and including coarse-grained parts of extrusive successions) defined modally in the gabbroic rock classification (Fig. 2.6, p. 25) as a variety of gabbro in which hornblende is between 5% and 85% (cf. Le Maitre et al., 2005, p. 133)."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "oe"^^:GSWA-rock-code ;
@@ -6244,7 +6244,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-mafic-intrusive ;
-    skos:definition "An intrusive rock (and including coarse-grained parts of extrusive successions) defined modally in the gabbroic rock classification (Fig. 2.6, p. 25) as a variety of gabbronorite in which hornblende is between 5% and 85% (Le Maitre et al., 2005, p. 133)."@en ;
+    skos:definition "An intrusive rock (and including coarse-grained parts of extrusive successions) defined modally in the gabbroic rock classification (Fig. 2.6, p. 25) as a variety of gabbronorite in which hornblende is between 5% and 85% (Le Maitre et al., 2005, p. 133)."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "ob"^^:GSWA-rock-code ;
@@ -6256,7 +6256,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-mafic-intrusive ;
-    skos:definition "An intrusive rock (and including coarse-grained parts of extrusive successions) defined modally in the gabbroic rock classification (Fig. 2.6, p. 25) as a variety of norite in which hornblende is between 5% and 85% (cf. Le Maitre et al., 2005, p. 133)."@en ;
+    skos:definition "An intrusive rock (and including coarse-grained parts of extrusive successions) defined modally in the gabbroic rock classification (Fig. 2.6, p. 25) as a variety of norite in which hornblende is between 5% and 85% (cf. Le Maitre et al., 2005, p. 133)."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "of"^^:GSWA-rock-code ;
@@ -6267,7 +6267,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-ultramafic-intrusive ;
-    skos:definition "An ultramafic intrusive rock consisting of 40–90% olivine and various amounts of pyroxene and amphibole. Now defined modally in the ultramafic rock classification (Fig. 2.9, p. 28). (cf. Le Maitre et al., 2005, p. 133)"@en ;
+    skos:definition "An ultramafic intrusive rock consisting of 40–90% olivine and various amounts of pyroxene and amphibole. Now defined modally in the ultramafic rock classification (Fig. 2.9, p. 28). (cf. Le Maitre et al., 2005, p. 133)"@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "au"^^:GSWA-rock-code ;
@@ -6279,7 +6279,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-ultramafic-intrusive ;
-    skos:definition "A term for ultramafic intrusive rocks composed mainly of amphibole with up to 50% pyroxene. Now defined modally in the ultramafic rock classification (Fig. 2.9, p. 28). (cf. Le Maitre et al., 2005, p. 133)"@en ;
+    skos:definition "A term for ultramafic intrusive rocks composed mainly of amphibole with up to 50% pyroxene. Now defined modally in the ultramafic rock classification (Fig. 2.9, p. 28). (cf. Le Maitre et al., 2005, p. 133)"@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "ab"^^:GSWA-rock-code ;
@@ -6291,7 +6291,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-melilitic ;
-    skos:definition "In the IUGS classification (Le Maitre et al., 2005, p. 11), an ultramafic intrusive rock consisting mostly of melilite and clinopyroxene, with less than 10% olivine (adapted from Glossary of geology, Neuendorf et al., 2011, 5th edition, revised). Note that in Le Maitre et al.'s glossary (2005, p. 133), pyroxene olivine melilitolite is described as \"originally defined as an ultramafic plutonic rock consisting essentially of melilite and clinopyroxene with minor olivine (see 1st Edition, Fig. B.3, p. 12), but not required by the new melilite-bearing rocks classification (section 2.4.1, p. 11).\""@en ;
+    skos:definition "In the IUGS classification (Le Maitre et al., 2005, p. 11), an ultramafic intrusive rock consisting mostly of melilite and clinopyroxene, with less than 10% olivine (adapted from Glossary of geology, Neuendorf et al., 2011, 5th edition, revised). Note that in Le Maitre et al.'s glossary (2005, p. 133), pyroxene olivine melilitolite is described as \"originally defined as an ultramafic plutonic rock consisting essentially of melilite and clinopyroxene with minor olivine (see 1st Edition, Fig. B.3, p. 12), but not required by the new melilite-bearing rocks classification (section 2.4.1, p. 11).\""@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005) and Glossary of geology (5th edition, revised; Neuendorf et al. 2011)." ;
     skos:inScheme cs: ;
     skos:notation "ep"^^:GSWA-rock-code ;
@@ -6303,7 +6303,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-melilitic ;
-    skos:definition "In the IUGS classification (Le Maitre et al., p. 11), an ultramafic intrusive rock consisting mostly of melilite, olivine, and clinopyroxene, with olivine>clinopyroxene (adapted from Glossary of geology, Neuendorf et al., 2011, 5th edition, revised). Note that in Le Maitre et al.'s glossary (2005, p. 133), pyroxene olivine melilitolite is described as \"originally defined as an ultramafic plutonic rock consisting essentially of melilite, olivine and lesser amounts of clinopyroxene (see 1st Edition, Fig. B.3, p. 12), but not required by the new melilite-bearing rocks classification (section 2.4.1, p. 11)\"."@en ;
+    skos:definition "In the IUGS classification (Le Maitre et al., p. 11), an ultramafic intrusive rock consisting mostly of melilite, olivine, and clinopyroxene, with olivine>clinopyroxene (adapted from Glossary of geology, Neuendorf et al., 2011, 5th edition, revised). Note that in Le Maitre et al.'s glossary (2005, p. 133), pyroxene olivine melilitolite is described as \"originally defined as an ultramafic plutonic rock consisting essentially of melilite, olivine and lesser amounts of clinopyroxene (see 1st Edition, Fig. B.3, p. 12), but not required by the new melilite-bearing rocks classification (section 2.4.1, p. 11)\"."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005) and Glossary of geology (5th edition, revised; Neuendorf et al. 2011)." ;
     skos:inScheme cs: ;
     skos:notation "ey"^^:GSWA-rock-code ;
@@ -6315,7 +6315,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-ultramafic-intrusive ;
-    skos:definition "A term for intrusive rocks composed mainly of olivine with 10–60% pyroxene. Now defined modally in the ultramafic rock classification (Fig. 2.9, p. 28). Adapted from Le Maitre et al. (2005, p. 134)."@en ;
+    skos:definition "A term for intrusive rocks composed mainly of olivine with 10–60% pyroxene. Now defined modally in the ultramafic rock classification (Fig. 2.9, p. 28). Adapted from Le Maitre et al. (2005, p. 134)."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "ap"^^:GSWA-rock-code ;
@@ -6341,7 +6341,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-ultramafic-volcanic-and-volcaniclastic ;
-    skos:definition "An ultramafic igneous rock composed almost entirely of one or more pyroxenes and occasionally biotite, hornblende and olivine. Now defined modally in the ultramafic rock classification (Fig. 2.9, p. 28). Definition adapted from Le Maitre et al. (2005, p. 134). In GSWA usage an 'extrusive' pyroxenite is identified as one formed from fractionation within thick bodies of ultramafic volcanic or subvolcanic magmas. GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
+    skos:definition "An ultramafic igneous rock composed almost entirely of one or more pyroxenes and occasionally biotite, hornblende and olivine. Now defined modally in the ultramafic rock classification (Fig. 2.9, p. 28). Definition adapted from Le Maitre et al. (2005, p. 134). In GSWA usage an 'extrusive' pyroxenite is identified as one formed from fractionation within thick bodies of ultramafic volcanic or subvolcanic magmas. GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "ux"^^:GSWA-rock-code ;
@@ -6353,7 +6353,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-ultramafic-intrusive ;
-    skos:definition "An ultramafic intrusive rocks composed almost entirely of one or more pyroxenes and occasionally biotite, hornblende and olivine. Now defined modally in the ultramafic rock classification (Fig. 2.9, p. 28). Adapted from Le Maitre et al. (2005, p. 134)."@en ;
+    skos:definition "An ultramafic intrusive rocks composed almost entirely of one or more pyroxenes and occasionally biotite, hornblende and olivine. Now defined modally in the ultramafic rock classification (Fig. 2.9, p. 28). Adapted from Le Maitre et al. (2005, p. 134)."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "ax"^^:GSWA-rock-code ;
@@ -6376,7 +6376,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metamorphic-protolith-unknown-gneiss ;
-    skos:definition "A gneiss distinguished by the abundance of pyroxenes. In GSWA usage, this term is reserved for gneiss for which a protolith cannot be conclusively established. See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
+    skos:definition "A gneiss distinguished by the abundance of pyroxenes. In GSWA usage, this term is reserved for gneiss for which a protolith cannot be conclusively established. See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007) and GSWA usage." ;
     skos:inScheme cs: ;
     skos:notation "mnx"^^:GSWA-rock-code ;
@@ -6399,7 +6399,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metamorphic-protolith-unknown-schist ;
-    skos:definition "A schist distinguished by the abundance of pyroxenes. In GSWA usage, this term is reserved for a schist for which a protolith cannot be conclusively established. See also definition of schist/schistose structure in Fettes and Desmons, 2007, p. 193)."@en ;
+    skos:definition "A schist distinguished by the abundance of pyroxenes. In GSWA usage, this term is reserved for a schist for which a protolith cannot be conclusively established. See also definition of schist/schistose structure in Fettes and Desmons, 2007, p. 193)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007) and GSWA usage." ;
     skos:inScheme cs: ;
     skos:notation "msx"^^:GSWA-rock-code ;
@@ -6410,7 +6410,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-felsic-intrusive ;
-    skos:definition "A felsic intrusive rock composed mainly of alkali feldspar, quartz and mafic minerals. Now defined modally in QAPF field 6* (Fig. 2.4, p. 22). (cf. Le Maitre et al., 2005, p. 134)"@en ;
+    skos:definition "A felsic intrusive rock composed mainly of alkali feldspar, quartz and mafic minerals. Now defined modally in QAPF field 6* (Fig. 2.4, p. 22). (cf. Le Maitre et al., 2005, p. 134)"@en ;
     skos:exactMatch
         <http://inspire.ec.europa.eu/codelist/LithologyValue/quartzAlkaliFeldsparSyenite> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/quartz_alkali_feldspar_syenite> ;
@@ -6426,7 +6426,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     rdfs:isDefinedBy cs: ;
     skos:altLabel "plagioclasite"@en ;
     skos:broader :igneous-felsic-intrusive ;
-    skos:definition "A leucocratic intrusive rock consisting essentially of calcic plagioclase, quartz and with small amounts of pyroxene. Now defined modally in QAPF field 10* (Fig. 2.4, p. 22). The term is synonymous with plagioclasite. (cf. Le Maitre et al., 2005, p. 134)"@en ;
+    skos:definition "A leucocratic intrusive rock consisting essentially of calcic plagioclase, quartz and with small amounts of pyroxene. Now defined modally in QAPF field 10* (Fig. 2.4, p. 22). The term is synonymous with plagioclasite. (cf. Le Maitre et al., 2005, p. 134)"@en ;
     skos:exactMatch
         <http://inspire.ec.europa.eu/codelist/LithologyValue/quartzAnorthosite> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/quartz_anorthosite> ;
@@ -6441,7 +6441,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-felsic-intrusive ;
-    skos:definition "An intrusive rock having the composition of diorite but with an appreciable amount of quartz, i.e. between 5 and 20% of the felsic minerals, and defined modally in QAPF field 10* (Fig. 2.4, p. 22). Adapted from Le Maitre et al. (2005, p. 134)."@en ;
+    skos:definition "An intrusive rock having the composition of diorite but with an appreciable amount of quartz, i.e. between 5 and 20% of the felsic minerals, and defined modally in QAPF field 10* (Fig. 2.4, p. 22). Adapted from Le Maitre et al. (2005, p. 134)."@en ;
     skos:exactMatch
         <http://inspire.ec.europa.eu/codelist/LithologyValue/quartzDiorite> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/quartz_diorite> ;
@@ -6456,7 +6456,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-felsic-intrusive ;
-    skos:definition "An intrusive rock composed mainly of calcic plagioclase, clinopyroxene and quartz. Now defined modally in QAPF field 10* (Fig. 2.4, p. 22). (cf. Le Maitre et al., 2005, p. 134)"@en ;
+    skos:definition "An intrusive rock composed mainly of calcic plagioclase, clinopyroxene and quartz. Now defined modally in QAPF field 10* (Fig. 2.4, p. 22). (cf. Le Maitre et al., 2005, p. 134)"@en ;
     skos:exactMatch
         <http://inspire.ec.europa.eu/codelist/LithologyValue/quartzGabbro> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/quartz_gabbro> ;
@@ -6471,7 +6471,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-felsic-volcanic ;
-    skos:definition "A term originally used for a volcanic rock composed of phenocrysts of quartz, plagioclase, biotite and hornblende in a glassy matrix potentially of quartz and alkali feldspar. Now commonly used for volcanic rocks composed of alkali feldspar and plagioclase in roughly equal amounts, quartz and mafic minerals. Now defined modally in QAPF field 8* (Fig. 2.4, p. 22). Definition from Le Maitre et al. (2005, p. 135). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
+    skos:definition "A term originally used for a volcanic rock composed of phenocrysts of quartz, plagioclase, biotite and hornblende in a glassy matrix potentially of quartz and alkali feldspar. Now commonly used for volcanic rocks composed of alkali feldspar and plagioclase in roughly equal amounts, quartz and mafic minerals. Now defined modally in QAPF field 8* (Fig. 2.4, p. 22). Definition from Le Maitre et al. (2005, p. 135). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
     skos:exactMatch
         <http://inspire.ec.europa.eu/codelist/LithologyValue/quartzLatite> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/quartz_latite> ;
@@ -6486,7 +6486,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metamorphic-protolith-unknown-schist ;
-    skos:definition "A schist distinguished by the abundance of quartz and micaceous mineral phases. In GSWA usage, this term is reserved for a schist for which a protolith cannot be conclusively established. See also definition of schist/schistose structure in Fettes and Desmons, 2007, p. 193)."@en ;
+    skos:definition "A schist distinguished by the abundance of quartz and micaceous mineral phases. In GSWA usage, this term is reserved for a schist for which a protolith cannot be conclusively established. See also definition of schist/schistose structure in Fettes and Desmons, 2007, p. 193)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007) and GSWA usage." ;
     skos:inScheme cs: ;
     skos:notation "msqm"^^:GSWA-rock-code ;
@@ -6498,7 +6498,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-felsic-intrusive ;
-    skos:definition "An intrusive rock consisting essentially of sodic plagioclase, alkali feldspar, quartz and mafic minerals. Now defined modally in QAPF field 9* (Fig. 2.4, p. 22). (cf. Le Maitre et al., 2005, p. 135)."@en ;
+    skos:definition "An intrusive rock consisting essentially of sodic plagioclase, alkali feldspar, quartz and mafic minerals. Now defined modally in QAPF field 9* (Fig. 2.4, p. 22). (cf. Le Maitre et al., 2005, p. 135)."@en ;
     skos:exactMatch
         <http://inspire.ec.europa.eu/codelist/LithologyValue/quartzMonzodiorite> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/quartz_monzodiorite> ;
@@ -6513,7 +6513,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-felsic-intrusive ;
-    skos:definition "An intrusive rock consisting essentially of calcic plagioclase, alkali feldspar, quartz and mafic minerals. Now defined modally in QAPF field 9* (Fig. 2.4, p. 22). (cf. Le Maitre et al., 2005, p. 135)."@en ;
+    skos:definition "An intrusive rock consisting essentially of calcic plagioclase, alkali feldspar, quartz and mafic minerals. Now defined modally in QAPF field 9* (Fig. 2.4, p. 22). (cf. Le Maitre et al., 2005, p. 135)."@en ;
     skos:exactMatch
         <http://inspire.ec.europa.eu/codelist/LithologyValue/quartzMonzogabbro> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/quartz_monzogabbro> ;
@@ -6528,7 +6528,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-felsic-intrusive ;
-    skos:definition "An intrusive rock consisting of approximately equal amounts of alkali feldspar and plagioclase and with essential quartz (5–20% of felsic minerals) but not enough to make the rock a granite. Now defined modally in QAPF field 8* (Fig. 2.4, p. 22). (cf. Le Maitre et al., 2005, p.  135)"@en ;
+    skos:definition "An intrusive rock consisting of approximately equal amounts of alkali feldspar and plagioclase and with essential quartz (5–20% of felsic minerals) but not enough to make the rock a granite. Now defined modally in QAPF field 8* (Fig. 2.4, p. 22). (cf. Le Maitre et al., 2005, p.  135)"@en ;
     skos:exactMatch
         <http://inspire.ec.europa.eu/codelist/LithologyValue/quartzMonzonite> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/quartz_monzonite> ;
@@ -6543,7 +6543,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-felsic-intrusive ;
-    skos:definition "An intrusive rock consisting essentially of alkali feldspar, quartz and mafic minerals. Now defined modally in QAPF field 7* (Fig. 2.4, p. 22). (cf. Le Maitre et al., 2005, p. 135)"@en ;
+    skos:definition "An intrusive rock consisting essentially of alkali feldspar, quartz and mafic minerals. Now defined modally in QAPF field 7* (Fig. 2.4, p. 22). (cf. Le Maitre et al., 2005, p. 135)"@en ;
     skos:exactMatch
         <http://inspire.ec.europa.eu/codelist/LithologyValue/quartzSyenite> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/quartz_syenite> ;
@@ -6558,7 +6558,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-felsic-volcanic ;
-    skos:definition "A volcanic rock consisting of phenocrysts of alkali feldspar and quartz in a cryptocrystalline or glassy matrix. It is the volcanic equivalent of quartz syenite. Now defined modally in QAPF field 7* (Fig. 2.11, p. 31). Definition from Le Maitre et al. (2005, p. 135). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
+    skos:definition "A volcanic rock consisting of phenocrysts of alkali feldspar and quartz in a cryptocrystalline or glassy matrix. It is the volcanic equivalent of quartz syenite. Now defined modally in QAPF field 7* (Fig. 2.11, p. 31). Definition from Le Maitre et al. (2005, p. 135). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
     skos:exactMatch
         <http://inspire.ec.europa.eu/codelist/LithologyValue/quartzTrachyte> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/quartz_trachyte> ;
@@ -6606,7 +6606,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
         "quartz sandstone"@en ,
         "quartzite"@en ;
     skos:broader :arenite ;
-    skos:definition "An arenite composed primarily of quartz (excluding detrital chert grains); specifically one containing more than 95% quartz framework grains and less than 5% feldspar and rock/lithic grains. The term is essentially equivalent to orthoquartzite, which in some past GSWA usage has been abbreviated to quartzite. GSWA reserves the use of 'quartzite' for a demonstrably metamorphosed rock. Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
+    skos:definition "An arenite composed primarily of quartz (excluding detrital chert grains); specifically one containing more than 95% quartz framework grains and less than 5% feldspar and rock/lithic grains. The term is essentially equivalent to orthoquartzite, which in some past GSWA usage has been abbreviated to quartzite. GSWA reserves the use of 'quartzite' for a demonstrably metamorphosed rock. Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
     skos:historyNote "Pettijohn, FJ 1975, Sedimentary Rocks: New York, Harper and Row, 628p." ;
     skos:inScheme cs: ;
     skos:notation "saq"^^:GSWA-rock-code ;
@@ -6644,7 +6644,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metamorphic-protolith-unknown-gneiss ;
-    skos:definition "A gneiss distinguished by the abundance of quartz and feldspar mineral phases. In GSWA usage, this term is reserved for a gneiss for which a protolith cannot be conclusively established. See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
+    skos:definition "A gneiss distinguished by the abundance of quartz and feldspar mineral phases. In GSWA usage, this term is reserved for a gneiss for which a protolith cannot be conclusively established. See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007) and GSWA usage." ;
     skos:inScheme cs: ;
     skos:notation "mnqf"^^:GSWA-rock-code ;
@@ -6667,7 +6667,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metamorphic-protolith-unknown-schist ;
-    skos:definition "A schist distinguished by the abundance of quartz and feldspar mineral phases. In GSWA usage, this term is reserved for a schist for which a protolith cannot be conclusively established. See also definition of schist/schistose structure in Fettes and Desmons, 2007, p. 193)."@en ;
+    skos:definition "A schist distinguished by the abundance of quartz and feldspar mineral phases. In GSWA usage, this term is reserved for a schist for which a protolith cannot be conclusively established. See also definition of schist/schistose structure in Fettes and Desmons, 2007, p. 193)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007) and GSWA usage." ;
     skos:inScheme cs: ;
     skos:notation "msqf"^^:GSWA-rock-code ;
@@ -6690,7 +6690,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metamorphic-protolith-unknown-gneiss ;
-    skos:definition "A gneiss distinguished by the abundance of quartz. In GSWA usage, this term is reserved for a gneiss for which a protolith cannot be conclusively established. See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
+    skos:definition "A gneiss distinguished by the abundance of quartz. In GSWA usage, this term is reserved for a gneiss for which a protolith cannot be conclusively established. See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007) and GSWA usage." ;
     skos:inScheme cs: ;
     skos:notation "mnq"^^:GSWA-rock-code ;
@@ -6714,7 +6714,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metamorphic-protolith-unknown-schist ;
-    skos:definition "A schist distinguished by the abundance of quartz. In GSWA usage, this term is reserved for a schist for which a protolith cannot be conclusively established. See also definition of schist/schistose structure in Fettes and Desmons, 2007, p. 193)."@en ;
+    skos:definition "A schist distinguished by the abundance of quartz. In GSWA usage, this term is reserved for a schist for which a protolith cannot be conclusively established. See also definition of schist/schistose structure in Fettes and Desmons, 2007, p. 193)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007) and GSWA usage." ;
     skos:inScheme cs: ;
     skos:notation "msq"^^:GSWA-rock-code ;
@@ -6741,7 +6741,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     skos:altLabel "bimetasomatic skarn"@en ;
     skos:broader :skarn ;
     skos:definition "A skarn formed by local exchange of material by diffusion and reaction across contacts between carbonate beds and silicate sedimentary or other suitable (chemically different) rock types."@en ;
-    skos:historyNote "Einaudi, MT and Burt, DM 1982, Introduction – terminology, classification, and composition of skarn deposits: Economic Geology, v. 77, p. 745–754." ;
+    skos:historyNote "Einaudi, MT and Burt, DM 1982, Introduction – terminology, classification, and composition of skarn deposits: Economic Geology, v. 77, p. 745–754." ;
     skos:inScheme cs: ;
     skos:notation "mjks"^^:GSWA-rock-code ;
     skos:prefLabel "reaction skarn"@en ;
@@ -6751,7 +6751,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-felsic-volcanic ;
-    skos:definition "A term used for volcanic rocks intermediate between rhyolite and dacite, usually consisting of phenocrysts of quartz, plagioclase and a few ferromagnesian minerals in a microcrystalline groundmass. Definition from Le Maitre et al. (2005, p. 137). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
+    skos:definition "A term used for volcanic rocks intermediate between rhyolite and dacite, usually consisting of phenocrysts of quartz, plagioclase and a few ferromagnesian minerals in a microcrystalline groundmass. Definition from Le Maitre et al. (2005, p. 137). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "fc"^^:GSWA-rock-code ;
@@ -6763,7 +6763,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-felsic-volcanic ;
-    skos:definition "A collective term for silicic volcanic rocks consisting of phenocrysts of quartz and alkali feldspar, often with minor plagioclase and biotite, in a microcrystalline or glassy groundmass and having the chemical composition of granite. Now defined modally in QAPF field 3 (Fig. 2.11, p. 31) and, if modes are not available, chemically in TAS field R (Fig. 2.14, p. 35). Definition from Le Maitre et al. (2005, p. 137). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
+    skos:definition "A collective term for silicic volcanic rocks consisting of phenocrysts of quartz and alkali feldspar, often with minor plagioclase and biotite, in a microcrystalline or glassy groundmass and having the chemical composition of granite. Now defined modally in QAPF field 3 (Fig. 2.11, p. 31) and, if modes are not available, chemically in TAS field R (Fig. 2.14, p. 35). Definition from Le Maitre et al. (2005, p. 137). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
     skos:exactMatch
         <http://inspire.ec.europa.eu/codelist/LithologyValue/rhyolite> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/rhyolite> ;
@@ -6778,7 +6778,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metasomatic ;
-    skos:definition "Metasomatic rock primarily composed of grossular–andradite garnet and calcic pyroxene; epidote, scapolite and iron ore are characteristic accessories. Rodingite mostly replaces dykes or inclusions of basic rocks within serpentinized ultramafic bodies, such as volcanic rocks or amphibolites associated with ultramafic bodies. (Fettes and Desmons, 2007, p. 191)"@en ;
+    skos:definition "Metasomatic rock primarily composed of grossular–andradite garnet and calcic pyroxene; epidote, scapolite and iron ore are characteristic accessories. Rodingite mostly replaces dykes or inclusions of basic rocks within serpentinized ultramafic bodies, such as volcanic rocks or amphibolites associated with ultramafic bodies. (Fettes and Desmons, 2007, p. 191)"@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:notation "mjo"^^:GSWA-rock-code ;
@@ -6792,7 +6792,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :sedimentary-siliciclastic ;
-    skos:definition "A weekly cemented aggregate of mineral or rock particles of sand size, having a diameter in the range of 0.0625 to 2 mm (62–2000 μm, or 4 to -1 phi units). The material is most commonly composed of quartz resulting from rock disintegration, and when the term 'sand' is used without qualification, a siliceous composition is implied; but the particles may be of any mineral composition or mixture of rock or mineral fragments, such as 'coral sand' consisting of limestone fragments. Also, a mass of such material, especially on a beach, a desert or in a stream bed. Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
+    skos:definition "A weekly cemented aggregate of mineral or rock particles of sand size, having a diameter in the range of 0.0625 to 2 mm (62–2000 μm, or 4 to -1 phi units). The material is most commonly composed of quartz resulting from rock disintegration, and when the term 'sand' is used without qualification, a siliceous composition is implied; but the particles may be of any mineral composition or mixture of rock or mineral fragments, such as 'coral sand' consisting of limestone fragments. Also, a mass of such material, especially on a beach, a desert or in a stream bed. Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
     skos:exactMatch
         <http://inspire.ec.europa.eu/codelist/LithologyValue/sand> ,
         <http://inspire.ec.europa.eu/codelist/LithologyValue/sandSizeSediment> ,
@@ -6841,7 +6841,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-lamprophyres ;
-    skos:definition "A variety of lamprophyre composed of combinations of olivine, titanian augite, kaersutite and Ti-rich biotite phenocrysts with alkali feldspar dominating over plagioclase in the groundmass that also contains nepheline. Now defined in the lamprophyre classification (Table 2.9, p. 19). (Le Maitre et al., 2005, p. 139)"@en ;
+    skos:definition "A variety of lamprophyre composed of combinations of olivine, titanian augite, kaersutite and Ti-rich biotite phenocrysts with alkali feldspar dominating over plagioclase in the groundmass that also contains nepheline. Now defined in the lamprophyre classification (Table 2.9, p. 19). (Le Maitre et al., 2005, p. 139)"@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "ya"^^:GSWA-rock-code ;
@@ -6852,7 +6852,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metamorphic-protolith-unknown-schist ;
-    skos:definition "A metamorphic rock for which a protolith cannot be conclusively identified and displaying a schistose structure, i.e. a preferred orientation of inequant mineral grains or grain aggregates produced by metamorphic processes. A schist can be readily split into thin flakes or slabs because of the well-developed parallelism of more than 50% of the minerals present, particularly those of lamellar or elongate prismatic habit (e.g. mica and hornblende). For phyllosilicate-rich rocks the term schist is commonly used for medium- to coarse-grained varieties, whereas finer-grained rocks may be given more specific names such as slates or phyllites. Adapted from Fettes and Desmons (2007, p. 193) and Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
+    skos:definition "A metamorphic rock for which a protolith cannot be conclusively identified and displaying a schistose structure, i.e. a preferred orientation of inequant mineral grains or grain aggregates produced by metamorphic processes. A schist can be readily split into thin flakes or slabs because of the well-developed parallelism of more than 50% of the minerals present, particularly those of lamellar or elongate prismatic habit (e.g. mica and hornblende). For phyllosilicate-rich rocks the term schist is commonly used for medium- to coarse-grained varieties, whereas finer-grained rocks may be given more specific names such as slates or phyllites. Adapted from Fettes and Desmons (2007, p. 193) and Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
     skos:exactMatch
         <http://inspire.ec.europa.eu/codelist/LithologyValue/schist> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/schist> ;
@@ -6878,7 +6878,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metamorphic-protolith-unknown-schist ;
-    skos:definition "A high-grade metamorphic rock, with a granoblastic texture and in which Fe–Mg silicates are dominantly hydroxyl-free, feldspar is a critical phase, and primary muscovite is absent, and with a superimposed foliation. In GSWA usage, this term is reserved for a schist for which a protolith cannot be conclusively established. See also definition of schist/schistose structure in Fettes and Desmons, 2007, p. 193)."@en ;
+    skos:definition "A high-grade metamorphic rock, with a granoblastic texture and in which Fe–Mg silicates are dominantly hydroxyl-free, feldspar is a critical phase, and primary muscovite is absent, and with a superimposed foliation. In GSWA usage, this term is reserved for a schist for which a protolith cannot be conclusively established. See also definition of schist/schistose structure in Fettes and Desmons, 2007, p. 193)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007) and GSWA usage." ;
     skos:inScheme cs: ;
     skos:notation "mso"^^:GSWA-rock-code ;
@@ -6917,7 +6917,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
         "itabirite"@en ,
         "taconite"@en ;
     skos:broader :metasedimentary-other-chemical-meta-iron-formation ;
-    skos:definition "A metamorphosed iron formation displaying a schistose structure, i.e. a schist derived from a chemical or biochemical sedimentary protolith containing at least 15% iron of sedimentary origin. See also definition of schist/schistose structure in Fettes and Desmons, 2007, p. 193)."@en ;
+    skos:definition "A metamorphosed iron formation displaying a schistose structure, i.e. a schist derived from a chemical or biochemical sedimentary protolith containing at least 15% iron of sedimentary origin. See also definition of schist/schistose structure in Fettes and Desmons, 2007, p. 193)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007) and GSWA usage." ;
     skos:inScheme cs: ;
     skos:notation "mis"^^:GSWA-rock-code ;
@@ -6929,7 +6929,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-carbonatite ;
-    skos:definition "A schist derived by metamorphism of an igneous protolith containing a modal amount of primary carbonate minerals greater than 50%. See also definition of schist/schistose structure in Fettes and Desmons (2007, p. 193)."@en ;
+    skos:definition "A schist derived by metamorphism of an igneous protolith containing a modal amount of primary carbonate minerals greater than 50%. See also definition of schist/schistose structure in Fettes and Desmons (2007, p. 193)."@en ;
     skos:inScheme cs: ;
     skos:notation "mqs"^^:GSWA-rock-code ;
     skos:prefLabel "schistose metacarbonatite"@en ;
@@ -6950,7 +6950,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :para-amphibolite-derived-from-carbonate-rock ;
-    skos:definition "A metamorphosed amphibole-rich rock derived from a sedimentary carbonate protolith and displaying a schistose structure. See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
+    skos:definition "A metamorphosed amphibole-rich rock derived from a sedimentary carbonate protolith and displaying a schistose structure. See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "mkas"^^:GSWA-rock-code ;
@@ -6961,7 +6961,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :para-amphibolite ;
-    skos:definition "A metamorphosed amphibole-rich rock derived from a sedimentary siliciclastic protolith and displaying a schistose structure. See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
+    skos:definition "A metamorphosed amphibole-rich rock derived from a sedimentary siliciclastic protolith and displaying a schistose structure. See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "mdas"^^:GSWA-rock-code ;
@@ -6975,7 +6975,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
         "rubble rock"@en ,
         "sharpstone conglomerate"@en ;
     skos:broader :sedimentary-siliciclastic ;
-    skos:definition "A coarse epiclastic rock formed by lithification of angular gravel (in which 30% of large particles are greater than 2 mm). Breccia differs from conglomerate in that the fragments have sharp edges and unworn corners, and may originate as a result of sedimentary processes such as talus accumulation, disturbance during sedimentation (intraclastic breccia), or collapse of rock material (solution breccia, collapse breccia). Excludes breccias formed by volcaniclastic processes. Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
+    skos:definition "A coarse epiclastic rock formed by lithification of angular gravel (in which 30% of large particles are greater than 2 mm). Breccia differs from conglomerate in that the fragments have sharp edges and unworn corners, and may originate as a result of sedimentary processes such as talus accumulation, disturbance during sedimentation (intraclastic breccia), or collapse of rock material (solution breccia, collapse breccia). Excludes breccias formed by volcaniclastic processes. Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
     skos:historyNote "Based on the Glossary of geology (5th edition, revised; Neuendorf et al. 2011)." ;
     skos:inScheme cs: ;
     skos:notation "sx"^^:GSWA-rock-code ;
@@ -7004,7 +7004,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metasedimentary-siliciclastic-semipelite ;
-    skos:definition "A metamorphic rock that has a modal ratio of mica to quartz + feldspar intermediate between a pelite and a psammite (adapted from Fettes and Desmons, 2007, p. 194)."@en ;
+    skos:definition "A metamorphic rock that has a modal ratio of mica to quartz + feldspar intermediate between a pelite and a psammite (adapted from Fettes and Desmons, 2007, p. 194)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:notation "mm"^^:GSWA-rock-code ;
@@ -7015,7 +7015,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metasedimentary-siliciclastic-semipelite ;
-    skos:definition "Type of gneiss derived by metamorphism of a fine- to medium-grained sedimentary or metasedimentary protolith, and with a modal ratio of mica to quartz + feldspar intermediate between a pelite and a psammite. See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
+    skos:definition "Type of gneiss derived by metamorphism of a fine- to medium-grained sedimentary or metasedimentary protolith, and with a modal ratio of mica to quartz + feldspar intermediate between a pelite and a psammite. See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "mmn"^^:GSWA-rock-code ;
@@ -7029,7 +7029,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
         "hornfelsed pelite"@en ,
         "peraluminous hornfels"@en ;
     skos:broader :metasedimentary-siliciclastic-semipelite ;
-    skos:definition "Type of micaceous granofels/hornfels derived by (contact) metamorphism of a fine- to medium-grained sedimentary or metasedimentary protolith, and with a modal ratio of mica to quartz + feldspar intermediate between a pelite and a psammite. See also definition of granofels/granofelsic structure in Fettes and Desmons (2007, p. 156); hornfels are granofels formed by contact metamorphism (Fettes and Desmons, 2007, p. 159)."@en ;
+    skos:definition "Type of micaceous granofels/hornfels derived by (contact) metamorphism of a fine- to medium-grained sedimentary or metasedimentary protolith, and with a modal ratio of mica to quartz + feldspar intermediate between a pelite and a psammite. See also definition of granofels/granofelsic structure in Fettes and Desmons (2007, p. 156); hornfels are granofels formed by contact metamorphism (Fettes and Desmons, 2007, p. 159)."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "mme"^^:GSWA-rock-code ;
@@ -7040,7 +7040,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metasedimentary-siliciclastic-semipelite ;
-    skos:definition "Composite, micaceous silicate metamorphic rock derived from a fine- to medium-grained siliciclastic sedimentary or metasedimentary protolith, with a modal ratio of mica to quartz + feldspar intermediate between a pelite and a psammite, and pervasively heterogeneous on a meso- to megascopic scale. It typically consists of darker (melanosome) and lighter (leucosome) parts. The darker parts usually exhibit features of metamorphic rocks, whereas the lighter parts are of igneous appearance. See definition of migmatite in Fettes and Desmond (2007, p. 176)."@en ;
+    skos:definition "Composite, micaceous silicate metamorphic rock derived from a fine- to medium-grained siliciclastic sedimentary or metasedimentary protolith, with a modal ratio of mica to quartz + feldspar intermediate between a pelite and a psammite, and pervasively heterogeneous on a meso- to megascopic scale. It typically consists of darker (melanosome) and lighter (leucosome) parts. The darker parts usually exhibit features of metamorphic rocks, whereas the lighter parts are of igneous appearance. See definition of migmatite in Fettes and Desmond (2007, p. 176)."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "mmi"^^:GSWA-rock-code ;
@@ -7051,7 +7051,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metasedimentary-siliciclastic-semipelite ;
-    skos:definition "Type of schist derived by metamorphism of a fine- to medium-grained sedimentary or metasedimentary protolith, and with a modal ratio of mica to quartz + feldspar intermediate between a pelite and a psammite. See also definition of schist/schistose structure in Fettes and Desmons (2007, p. 193)."@en ;
+    skos:definition "Type of schist derived by metamorphism of a fine- to medium-grained sedimentary or metasedimentary protolith, and with a modal ratio of mica to quartz + feldspar intermediate between a pelite and a psammite. See also definition of schist/schistose structure in Fettes and Desmons (2007, p. 193)."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "mms"^^:GSWA-rock-code ;
@@ -7062,7 +7062,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-ultramafic-intrusive ;
-    skos:definition "Metamorphic rock composed of more than 75% vol. of minerals of the serpentine group, and demonstrably derived from an igneous (intrusive or coarse-grained extrusive) protolith (adapted from Fettes and Desmons, 2007, p. 194)."@en ;
+    skos:definition "Metamorphic rock composed of more than 75% vol. of minerals of the serpentine group, and demonstrably derived from an igneous (intrusive or coarse-grained extrusive) protolith (adapted from Fettes and Desmons, 2007, p. 194)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:notation "mat"^^:GSWA-rock-code ;
@@ -7073,7 +7073,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-ultramafic-volcanic ;
-    skos:definition "Metamorphic rock composed of more than 75% vol. of minerals of the serpentine group, and demonstrably derived from an igneous extrusive protolith (adapted from Fettes and Desmons, 2007, p. 194)."@en ;
+    skos:definition "Metamorphic rock composed of more than 75% vol. of minerals of the serpentine group, and demonstrably derived from an igneous extrusive protolith (adapted from Fettes and Desmons, 2007, p. 194)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:notation "mut"^^:GSWA-rock-code ;
@@ -7084,7 +7084,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :sedimentary-siliciclastic ;
-    skos:definition "A laminated, indurated very fine-grained rock with more than 66% clay-sized minerals; a claystone with fissility. GSWA now discourages the use of 'shale' as it is considered predominantly a textural term. Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
+    skos:definition "A laminated, indurated very fine-grained rock with more than 66% clay-sized minerals; a claystone with fissility. GSWA now discourages the use of 'shale' as it is considered predominantly a textural term. Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
     skos:exactMatch
         <http://inspire.ec.europa.eu/codelist/LithologyValue/shale> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/shale> ;
@@ -7126,7 +7126,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     rdfs:isDefinedBy cs: ;
     skos:altLabel "paragneiss"@en ;
     skos:broader :metasedimentary-siliciclastic ;
-    skos:definition "A metamorphosed siliciclastic rock displaying a gneissose structure, i.e. a gneiss from a clastic sedimentary protolith and largely consisting of silicates and quartz. See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
+    skos:definition "A metamorphosed siliciclastic rock displaying a gneissose structure, i.e. a gneiss from a clastic sedimentary protolith and largely consisting of silicates and quartz. See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:narrowMatch
@@ -7140,7 +7140,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metasedimentary-siliciclastic ;
-    skos:definition "A metamorphosed siliciclastic rock displaying a granofelsic structure, i.e. a granofels/hornfels derived from a clastic sedimentary protolith and largely consisting of silicates and quartz. See also definition of granofels/granofelsic structure in Fettes and Desmons (2007, p. 156); hornfels are granofels formed by contact metamorphism (Fettes and Desmons, 2007, p. 159)."@en ;
+    skos:definition "A metamorphosed siliciclastic rock displaying a granofelsic structure, i.e. a granofels/hornfels derived from a clastic sedimentary protolith and largely consisting of silicates and quartz. See also definition of granofels/granofelsic structure in Fettes and Desmons (2007, p. 156); hornfels are granofels formed by contact metamorphism (Fettes and Desmons, 2007, p. 159)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:notation "mde"^^:GSWA-rock-code ;
@@ -7151,7 +7151,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metasedimentary-siliciclastic ;
-    skos:definition "Composite silicate metamorphic rock derived from a siliciclastic protolith, pervasively heterogeneous on a meso- to megascopic scale. It typically consists of darker (melanosome) and lighter (leucosome) parts. The darker parts usually exhibit features of metamorphic rocks, whereas the lighter parts are of igneous appearance. Adapted from Fettes and Desmond (2007, p. 176)."@en ;
+    skos:definition "Composite silicate metamorphic rock derived from a siliciclastic protolith, pervasively heterogeneous on a meso- to megascopic scale. It typically consists of darker (melanosome) and lighter (leucosome) parts. The darker parts usually exhibit features of metamorphic rocks, whereas the lighter parts are of igneous appearance. Adapted from Fettes and Desmond (2007, p. 176)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:notation "mdi"^^:GSWA-rock-code ;
@@ -7190,7 +7190,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metasedimentary-siliciclastic ;
-    skos:definition "A metamorphosed siliciclastic rock displaying a schistose structure, i.e. a schist derived from a clastic sedimentary protolith and largely consisting of silicates and quartz. See also definition of schist/schistose structure in Fettes and Desmons, 2007, p. 193)."@en ;
+    skos:definition "A metamorphosed siliciclastic rock displaying a schistose structure, i.e. a schist derived from a clastic sedimentary protolith and largely consisting of silicates and quartz. See also definition of schist/schistose structure in Fettes and Desmons, 2007, p. 193)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:notation "mds"^^:GSWA-rock-code ;
@@ -7448,7 +7448,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-lamprophyres ;
-    skos:definition "A variety of lamprophyre consisting of phenocrysts of hornblende with or without biotite, olivine or pyroxene in a groundmass of the same minerals plus plagioclase and subordinate alkali feldspar. Now defined in the lamprophyre classification (Table 2.9, p. 19). (Le Maitre et al., 2005, p. 144)"@en ;
+    skos:definition "A variety of lamprophyre consisting of phenocrysts of hornblende with or without biotite, olivine or pyroxene in a groundmass of the same minerals plus plagioclase and subordinate alkali feldspar. Now defined in the lamprophyre classification (Table 2.9, p. 19). (Le Maitre et al., 2005, p. 144)"@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "ys"^^:GSWA-rock-code ;
@@ -7499,7 +7499,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
         "metalignitous coal"@en ;
     skos:broader :coal ;
     skos:definition "A black coal, intermediate in rank between lignite and bituminous coals or, in some classifications, the equivalent of black lignite. It is distinguished from lignite by higher carbon and lower moisture content. Further classification of sub-bituminous coal is made on the basis of calorific value. Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
-    skos:historyNote "Forsman, JP and Hunt, JM 1958, Insoluble organic matter (kerogen) in sedimentary rocks: Geochimica et Cosmochimica Acta, v. 15(3), p. 170–182, doi.org/10.1016/0016-7037(58)90055-3." ;
+    skos:historyNote "Forsman, JP and Hunt, JM 1958, Insoluble organic matter (kerogen) in sedimentary rocks: Geochimica et Cosmochimica Acta, v. 15(3), p. 170–182, doi.org/10.1016/0016-7037(58)90055-3." ;
     skos:inScheme cs: ;
     skos:notation "cob"^^:GSWA-rock-code ;
     skos:prefLabel "sub-bituminous coal"@en ;
@@ -7513,7 +7513,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
         "feldspathic arenite"@en ,
         "feldspathic sandstone"@en ;
     skos:broader :arkose ;
-    skos:definition "An arenite that does not have enough feldspar to be classed as an arkose, or that is intermediate in composition between arkose and quartzarenite. Subarkose specifically contains 75–95% quartz and chert, and 5–25% unstable materials in which the ratio of feldspar:lithic grains is greater than 1:1. Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
+    skos:definition "An arenite that does not have enough feldspar to be classed as an arkose, or that is intermediate in composition between arkose and quartzarenite. Subarkose specifically contains 75–95% quartz and chert, and 5–25% unstable materials in which the ratio of feldspar:lithic grains is greater than 1:1. Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
     skos:historyNote "Pettijohn, FJ 1975, Sedimentary Rocks: New York, Harper and Row, 628p." ;
     skos:inScheme cs: ;
     skos:notation "sja"^^:GSWA-rock-code ;
@@ -7540,7 +7540,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
         "suevite breccia"@en ,
         "suevitic impact breccia"@en ;
     skos:broader :impact-breccia ;
-    skos:definition "Polymictic impact breccia with particulate matrix containing lithic and mineral clasts in all stages of shock metamorphism including cogenetic impact melt particles, which are in a glassy or crystallized state (Fettes and Desmons, 2007, p. 198)."@en ;
+    skos:definition "Polymictic impact breccia with particulate matrix containing lithic and mineral clasts in all stages of shock metamorphism including cogenetic impact melt particles, which are in a glassy or crystallized state (Fettes and Desmons, 2007, p. 198)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:notation "mpu"^^:GSWA-rock-code ;
@@ -7552,7 +7552,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-felsic-intrusive ;
-    skos:definition "An intrusive rock consisting mainly of alkali feldspar with subordinate sodic plagioclase, biotite, pyroxene, amphibole and occasional fayalite. Minor quartz or nepheline may also be present. Now defined modally in QAPF field 7 (Fig. 2.4, p. 22). (cf. Le Maitre et al., 2005, p. 145)"@en ;
+    skos:definition "An intrusive rock consisting mainly of alkali feldspar with subordinate sodic plagioclase, biotite, pyroxene, amphibole and occasional fayalite. Minor quartz or nepheline may also be present. Now defined modally in QAPF field 7 (Fig. 2.4, p. 22). (cf. Le Maitre et al., 2005, p. 145)"@en ;
     skos:exactMatch
         <http://inspire.ec.europa.eu/codelist/LithologyValue/syenite> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/syenite> ;
@@ -7567,7 +7567,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-felsic-intrusive ;
-    skos:definition "An optional term for a variety of granite in QAPF field 3a (Fig. 2.4, p. 22) consisting of alkali feldspar with subordinate plagioclase (Le Maitre et al., 2005, p. 146)."@en ;
+    skos:definition "An optional term for a variety of granite in QAPF field 3a (Fig. 2.4, p. 22) consisting of alkali feldspar with subordinate plagioclase (Le Maitre et al., 2005, p. 146)."@en ;
     skos:exactMatch
         <http://inspire.ec.europa.eu/codelist/LithologyValue/syenogranite> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/syenogranite> ;
@@ -7582,7 +7582,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :distal-impactite ;
-    skos:definition "Impact glass formed at terrestrial impact craters from melt ejected ballistically and deposited as aerodynamically shaped bodies in a strewn field outside the continuous ejecta blanket. The size of tektites ranges from the submillimetre range (microtektites, generally found in deep sea sediments) to the subdecimetre range, rarely to decimetres. (Fettes and Desmons, 2007, p.  200)"@en ;
+    skos:definition "Impact glass formed at terrestrial impact craters from melt ejected ballistically and deposited as aerodynamically shaped bodies in a strewn field outside the continuous ejecta blanket. The size of tektites ranges from the submillimetre range (microtektites, generally found in deep sea sediments) to the subdecimetre range, rarely to decimetres. (Fettes and Desmons, 2007, p.  200)"@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:notation "mpk"^^:GSWA-rock-code ;
@@ -7594,7 +7594,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-felsic-intrusive ;
-    skos:definition "An intrusive rock consisting essentially of quartz and intermediate plagioclase, usually with biotite and amphibole. Now defined modally in QAPF field 5 (Fig. 2.4, p. 22). (cf. Le Maitre et al., 2005, p. 149)"@en ;
+    skos:definition "An intrusive rock consisting essentially of quartz and intermediate plagioclase, usually with biotite and amphibole. Now defined modally in QAPF field 5 (Fig. 2.4, p. 22). (cf. Le Maitre et al., 2005, p. 149)"@en ;
     skos:exactMatch
         <http://inspire.ec.europa.eu/codelist/LithologyValue/tonalite> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/tonalite> ;
@@ -7620,7 +7620,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-felsic-volcanic ;
-    skos:definition "A volcanic rock consisting essentially of alkali feldspar. Now defined modally in QAPF field 7 (Fig. 2.11, p. 31) and, if modes are not available, chemically in TAS field T (Fig. 2.14, p. 35). Definition from Le Maitre et al. (2005, p. 151). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
+    skos:definition "A volcanic rock consisting essentially of alkali feldspar. Now defined modally in QAPF field 7 (Fig. 2.11, p. 31) and, if modes are not available, chemically in TAS field T (Fig. 2.14, p. 35). Definition from Le Maitre et al. (2005, p. 151). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
     skos:exactMatch
         <http://inspire.ec.europa.eu/codelist/LithologyValue/trachyte> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/trachyte> ;
@@ -7639,7 +7639,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
         "meteogenic travertine"@en ,
         "tufa"@en ;
     skos:broader :sedimentary-other-chemical-or-biochemical ;
-    skos:definition "Biotically and/or abiotically precipitated calcium carbonate (predominantly calcite and aragonite) from spring-fed, heated and/or ambient-temperature waters. The spongy or less compact variety is named tufa. Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
+    skos:definition "Biotically and/or abiotically precipitated calcium carbonate (predominantly calcite and aragonite) from spring-fed, heated and/or ambient-temperature waters. The spongy or less compact variety is named tufa. Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
     skos:exactMatch
         <http://inspire.ec.europa.eu/codelist/LithologyValue/travertine> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/travertine> ;
@@ -7654,7 +7654,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-mafic-intrusive ;
-    skos:definition "A variety of gabbro composed essentially of highly calcic plagioclase and olivine with little or no pyroxene. Now defined modally in the gabbroic rock classification (Fig. 2.6, p. 25). (Le Maitre et al., 2005, p. 151)"@en ;
+    skos:definition "A variety of gabbro composed essentially of highly calcic plagioclase and olivine with little or no pyroxene. Now defined modally in the gabbroic rock classification (Fig. 2.6, p. 25). (Le Maitre et al., 2005, p. 151)"@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "ot"^^:GSWA-rock-code ;
@@ -7669,7 +7669,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
         "leucocratic tonalite"@en ,
         "plagiogranite;"@en ;
     skos:broader :igneous-felsic-intrusive ;
-    skos:definition "A leucocratic variety of tonalite consisting essentially of sodic plagioclase and quartz with minor biotite. Orthoclase is characteristically absent and hornblende is rare. May be used as a synonym for plagiogranite and leucocratic tonalite of QAPF field 5 (p. 23). (Le Maitre et al., 2005, p. 152)"@en ;
+    skos:definition "A leucocratic variety of tonalite consisting essentially of sodic plagioclase and quartz with minor biotite. Orthoclase is characteristically absent and hornblende is rare. May be used as a synonym for plagiogranite and leucocratic tonalite of QAPF field 5 (p. 23). (Le Maitre et al., 2005, p. 152)"@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "gj"^^:GSWA-rock-code ;
@@ -7681,7 +7681,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metamorphic-protolith-unknown-fault-rock ;
-    skos:definition "A cohesive fault rock with a poorly developed or absent schistosity, characterized by generally angular porphyroclasts and lithic fragments in a finer-grained matrix of similar composition that constitutes more than 90% of the rock volume. Definition adapted from Fossen (2016) and Fettes and Desmons (2007, p. 202)."@en ;
+    skos:definition "A cohesive fault rock with a poorly developed or absent schistosity, characterized by generally angular porphyroclasts and lithic fragments in a finer-grained matrix of similar composition that constitutes more than 90% of the rock volume. Definition adapted from Fossen (2016) and Fettes and Desmons (2007, p. 202)."@en ;
     skos:historyNote "Fossen, H 2016, Structural geology (2nd edition): Cambridge University Press, Cambridge, United Kingdom, 524p." ;
     skos:inScheme cs: ;
     skos:notation "myw"^^:GSWA-rock-code ;
@@ -7692,7 +7692,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-ultramafic-intrusive ;
-    skos:definition "A metamorphosed ultramafic igneous (intrusive or coarse-grained extrusive) rock displaying a gneissose structure, i.e. a gneiss derived from an intrusive rock with one or more mafic minerals as the main component(s). See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
+    skos:definition "A metamorphosed ultramafic igneous (intrusive or coarse-grained extrusive) rock displaying a gneissose structure, i.e. a gneiss derived from an intrusive rock with one or more mafic minerals as the main component(s). See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:notation "man"^^:GSWA-rock-code ;
@@ -7703,7 +7703,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-ultramafic-volcanic ;
-    skos:definition "A metamorphosed ultramafic volcanic or volcaniclastic rock displaying a gneissose structure, i.e. a gneiss derived from an extrusive or related rock with one or more mafic minerals as the main component(s). See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
+    skos:definition "A metamorphosed ultramafic volcanic or volcaniclastic rock displaying a gneissose structure, i.e. a gneiss derived from an extrusive or related rock with one or more mafic minerals as the main component(s). See also definition of gneiss/gneissose structure in Fettes and Desmons (2007, p. 154–155)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:notation "mun"^^:GSWA-rock-code ;
@@ -7714,7 +7714,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-ultramafic-intrusive ;
-    skos:definition "A metamorphosed ultramafic igneous (intrusive or coarse-grained extrusive) rock displaying a granofelsic structure, i.e. a granofels/hornfels derived from an intrusive rock with one or more mafic minerals as the main components (adapted from Fettes and Desmons, 2007, p. 202). See also definition of granofels/granofelsic structure in Fettes and Desmons (2007, p. 156); hornfels are granofels formed by contact metamorphism (Fettes and Desmons, 2007, p. 159)."@en ;
+    skos:definition "A metamorphosed ultramafic igneous (intrusive or coarse-grained extrusive) rock displaying a granofelsic structure, i.e. a granofels/hornfels derived from an intrusive rock with one or more mafic minerals as the main components (adapted from Fettes and Desmons, 2007, p. 202). See also definition of granofels/granofelsic structure in Fettes and Desmons (2007, p. 156); hornfels are granofels formed by contact metamorphism (Fettes and Desmons, 2007, p. 159)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:notation "mae"^^:GSWA-rock-code ;
@@ -7725,7 +7725,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-ultramafic-volcanic ;
-    skos:definition "A metamorphosed ultramafic volcanic or volcaniclastic rock displaying a granofelsic structure, i.e. a granofels/hornfels derived from an extrusive or related rock with one or more mafic minerals as the main components (adapted from Fettes and Desmons, 2007, p. 202). See also definition of granofels/granofelsic structure in Fettes and Desmons (2007, p. 156); hornfels are granofels formed by contact metamorphism (Fettes and Desmons, 2007, p. 159)."@en ;
+    skos:definition "A metamorphosed ultramafic volcanic or volcaniclastic rock displaying a granofelsic structure, i.e. a granofels/hornfels derived from an extrusive or related rock with one or more mafic minerals as the main components (adapted from Fettes and Desmons, 2007, p. 202). See also definition of granofels/granofelsic structure in Fettes and Desmons (2007, p. 156); hornfels are granofels formed by contact metamorphism (Fettes and Desmons, 2007, p. 159)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:notation "mue"^^:GSWA-rock-code ;
@@ -7739,7 +7739,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
         <http://inspire.ec.europa.eu/codelist/LithologyValue/ultramaficIgneousRock> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/ultramafic_igneous_rock> ;
     skos:broader :igneous-ultramafic-intrusive ;
-    skos:definition "Originally a term for a rock consisting essentially of mafic minerals, e.g. peridotite, dunite. Now defined as a rock with M>90%. Adapted from Le Maitre et al. (2005, p. 21 and p. 153)."@en ;
+    skos:definition "Originally a term for a rock consisting essentially of mafic minerals, e.g. peridotite, dunite. Now defined as a rock with M>90%. Adapted from Le Maitre et al. (2005, p. 21 and p. 153)."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "a"^^:GSWA-rock-code ;
@@ -7761,7 +7761,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-ultramafic-intrusive ;
-    skos:definition "A metamorphosed ultramafic igneous (intrusive or coarse-grained extrusive) rock displaying a schistose structure, i.e. a schist derived from an intrusive rock with one or more mafic minerals as the main component(s). See also definition of schist/schistose structure in Fettes and Desmons, 2007, p. 193)."@en ;
+    skos:definition "A metamorphosed ultramafic igneous (intrusive or coarse-grained extrusive) rock displaying a schistose structure, i.e. a schist derived from an intrusive rock with one or more mafic minerals as the main component(s). See also definition of schist/schistose structure in Fettes and Desmons, 2007, p. 193)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:notation "mas"^^:GSWA-rock-code ;
@@ -7772,7 +7772,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :meta-igneous-ultramafic-volcanic ;
-    skos:definition "A metamorphosed ultramafic volcanic or volcaniclastic rock displaying a schistose structure, i.e. a schist derived from an intrusive rock with one or more mafic minerals as the main component(s). See also definition of schist/schistose structure in Fettes and Desmons, 2007, p. 193)."@en ;
+    skos:definition "A metamorphosed ultramafic volcanic or volcaniclastic rock displaying a schistose structure, i.e. a schist derived from an intrusive rock with one or more mafic minerals as the main component(s). See also definition of schist/schistose structure in Fettes and Desmons, 2007, p. 193)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:notation "mus"^^:GSWA-rock-code ;
@@ -7786,7 +7786,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
         <http://inspire.ec.europa.eu/codelist/LithologyValue/ultramaficIgneousRock> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/ultramafic_igneous_rock> ;
     skos:broader :igneous-ultramafic-volcanic-and-volcaniclastic ;
-    skos:definition "An igneous volcanic rock composed chiefly of one or more ferromagnesian, dark-coloured minerals in its mode (adapted from Glossary of geology, 5th edition revised; Neuendorf et al., 2011). Originally a term for a rock consisting essentially of mafic minerals, e.g. peridotite, dunite. Now defined as a rock with M greater than 90% (section 2.11.2, p. 28), where M represents the volume modal percentage of mafic and related minerals (Le Maitre et al., 2005, p. 4 and 153). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
+    skos:definition "An igneous volcanic rock composed chiefly of one or more ferromagnesian, dark-coloured minerals in its mode (adapted from Glossary of geology, 5th edition revised; Neuendorf et al., 2011). Originally a term for a rock consisting essentially of mafic minerals, e.g. peridotite, dunite. Now defined as a rock with M greater than 90% (section 2.11.2, p. 28), where M represents the volume modal percentage of mafic and related minerals (Le Maitre et al., 2005, p. 4 and 153). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "u"^^:GSWA-rock-code ;
@@ -7808,7 +7808,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-ultramafic-volcanic-and-volcaniclastic ;
-    skos:definition "A volcaniclastic rock composed mostly of angular fragments greater than 2 mm in size consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with an overall ultramafic composition. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
+    skos:definition "A volcaniclastic rock composed mostly of angular fragments greater than 2 mm in size consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with an overall ultramafic composition. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "uvb"^^:GSWA-rock-code ;
@@ -7819,7 +7819,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-ultramafic-volcanic-and-volcaniclastic ;
-    skos:definition "A volcaniclastic rock composed mostly of angular fragments ranging in size from sand (0.0625 – 2 mm) and above, consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with an overall ultramafic composition. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
+    skos:definition "A volcaniclastic rock composed mostly of angular fragments ranging in size from sand (0.0625 – 2 mm) and above, consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with an overall ultramafic composition. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "uvbs"^^:GSWA-rock-code ;
@@ -7841,7 +7841,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-ultramafic-volcanic-and-volcaniclastic ;
-    skos:definition "A breccia composed mostly of angular fragments ranging in size from granule (2–4 mm) to pebble (4–32 mm) consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with an overall ultramafic composition. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
+    skos:definition "A breccia composed mostly of angular fragments ranging in size from granule (2–4 mm) to pebble (4–32 mm) consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with an overall ultramafic composition. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "uvg"^^:GSWA-rock-code ;
@@ -7852,7 +7852,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-ultramafic-volcanic-and-volcaniclastic ;
-    skos:definition "A mudstone (grain size ranging from silt to clay, i.e. less than 0.0625 mm) consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with an overall mafic composition. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
+    skos:definition "A mudstone (grain size ranging from silt to clay, i.e. less than 0.0625 mm) consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with an overall mafic composition. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "uvsm"^^:GSWA-rock-code ;
@@ -7874,7 +7874,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-ultramafic-volcanic-and-volcaniclastic ;
-    skos:definition "A sandstone (grain size 0.0625 – 2 mm) consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with an overall ultramafic composition. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
+    skos:definition "A sandstone (grain size 0.0625 – 2 mm) consisting of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with an overall ultramafic composition. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "uvs"^^:GSWA-rock-code ;
@@ -7885,7 +7885,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-ultramafic-volcanic-and-volcaniclastic ;
-    skos:definition "A volcaniclastic rock composed mostly of fragments ranging in size from sand (0.0625 – 2 mm) to silt (0.0039 – 0.0625 mm) of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with an overall ultramafic composition. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion."@en ;
+    skos:definition "A volcaniclastic rock composed mostly of fragments ranging in size from sand (0.0625 – 2 mm) to silt (0.0039 – 0.0625 mm) of either (a) pyroclastic detritus or (b) terrigenous volcanic detritus of epiclastic origin, and with an overall ultramafic composition. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "uvss"^^:GSWA-rock-code ;
@@ -7896,7 +7896,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-ultramafic-volcanic-and-volcaniclastic ;
-    skos:definition "A commonly monomictic breccia of overall ultramafic composition composed of angular, coarse igneous fragments cemented by a fine-grained matrix that is clastic though not necessarily strictly sedimentary in origin. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
+    skos:definition "A commonly monomictic breccia of overall ultramafic composition composed of angular, coarse igneous fragments cemented by a fine-grained matrix that is clastic though not necessarily strictly sedimentary in origin. 'Volcaniclastic' includes all clastic volcanic materials formed by any process of fragmentation, dispersed by any kind of transporting agent, deposited in any environment, or mixed in any significant portion with non-volcanic fragments."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:notation "uvsb"^^:GSWA-rock-code ;
@@ -7907,7 +7907,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metamorphic-protolith-unknown-fault-rock ;
-    skos:definition "Mylonite in which more than 90% of the rock volume has undergone grain-size reduction (Fettes and Desmons, 2007, p.  202); a mylonite with over 90% matrix and less than 10% porphyroclasts (Passchier and Trouw, 2005)."@en ;
+    skos:definition "Mylonite in which more than 90% of the rock volume has undergone grain-size reduction (Fettes and Desmons, 2007, p.  202); a mylonite with over 90% matrix and less than 10% porphyroclasts (Passchier and Trouw, 2005)."@en ;
     skos:historyNote "Passchier, CW and Trouw, RAJ 2005, Microtectonics (2nd edition): Springer, Berlin, 366p." ;
     skos:inScheme cs: ;
     skos:notation "myu"^^:GSWA-rock-code ;
@@ -7930,7 +7930,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :hydrothermal ;
-    skos:definition "A distinct sheet-like body of crystallized minerals within a rock. Veins form when mineral constituents carried by an aqueous solution within the rock mass are deposited through precipitation. The hydraulic flow involved is usually due to hydrothermal circulation. (https://en.wikipedia.org/wiki/Vein_(geology))."@en ;
+    skos:definition "A distinct sheet-like body of crystallized minerals within a rock. Veins form when mineral constituents carried by an aqueous solution within the rock mass are deposited through precipitation. The hydraulic flow involved is usually due to hydrothermal circulation. (https://en.wikipedia.org/wiki/Vein_(geology))."@en ;
     skos:historyNote "Based on the Glossary of geology (5th edition, revised; Neuendorf et al. 2011)." ;
     skos:inScheme cs: ;
     skos:notation "vein"^^:GSWA-rock-code ;
@@ -7942,7 +7942,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-lamprophyres ;
-    skos:definition "A variety of lamprophyre in which amphibole is more abundant than biotite and alkali feldspar is more abundant than plagioclase. Augite is frequently present. Now defined in the lamprophyre classification (Table 2.9, p. 19). (Le Maitre et al., 2005, p. 155)"@en ;
+    skos:definition "A variety of lamprophyre in which amphibole is more abundant than biotite and alkali feldspar is more abundant than plagioclase. Augite is frequently present. Now defined in the lamprophyre classification (Table 2.9, p. 19). (Le Maitre et al., 2005, p. 155)"@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "yv"^^:GSWA-rock-code ;
@@ -7964,7 +7964,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-ultramafic-intrusive ;
-    skos:definition "A variety of pyroxenite consisting largely of varying amounts of orthopyroxene and clinopyroxene, with less than 10% olivine. Now defined modally in the ultramafic rock classification (Fig. 2.9, p. 28). Adapted from Le Maitre et al. (2005, p. 156)."@en ;
+    skos:definition "A variety of pyroxenite consisting largely of varying amounts of orthopyroxene and clinopyroxene, with less than 10% olivine. Now defined modally in the ultramafic rock classification (Fig. 2.9, p. 28). Adapted from Le Maitre et al. (2005, p. 156)."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "axw"^^:GSWA-rock-code ;
@@ -7976,7 +7976,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :igneous-ultramafic-intrusive ;
-    skos:definition "An ultramafic intrusive rock composed of olivine and clinopyroxene often with minor brown hornblende. Now defined modally in the ultramafic rock classification (Fig. 2.9, p. 28). (cf. Le Maitre et al., 2005, p. 156)"@en ;
+    skos:definition "An ultramafic intrusive rock composed of olivine and clinopyroxene often with minor brown hornblende. Now defined modally in the ultramafic rock classification (Fig. 2.9, p. 28). (cf. Le Maitre et al., 2005, p. 156)"@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:notation "apw"^^:GSWA-rock-code ;
@@ -8099,7 +8099,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metamorphic-protolith-unknown ;
-    skos:definition "Composite silicate metamorphic rock of uncertain protolith, pervasively heterogeneous on a meso- to megascopic scale. It typically consists of darker (melanosome) and lighter (leucosome) parts. The darker parts usually exhibit features of metamorphic rocks, whereas the lighter parts are of igneous appearance. Adapted from Fettes and Desmond (2007, p. 176)."@en ;
+    skos:definition "Composite silicate metamorphic rock of uncertain protolith, pervasively heterogeneous on a meso- to megascopic scale. It typically consists of darker (melanosome) and lighter (leucosome) parts. The darker parts usually exhibit features of metamorphic rocks, whereas the lighter parts are of igneous appearance. Adapted from Fettes and Desmond (2007, p. 176)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:narrower :felsic-migmatite-protolith-unknown ;
@@ -8186,7 +8186,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metamorphic-protolith-unknown-impactite ;
-    skos:definition "Impactite occurring as distal ejecta outside the outer limit of the continuous ejecta blanket. It includes tektite, microtektite and impactoclastic (global) airfall bed. (Fettes and Desmons, p. 147)"@en ;
+    skos:definition "Impactite occurring as distal ejecta outside the outer limit of the continuous ejecta blanket. It includes tektite, microtektite and impactoclastic (global) airfall bed. (Fettes and Desmons, p. 147)"@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:narrower
@@ -8201,8 +8201,8 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
     rdfs:isDefinedBy cs: ;
     skos:altLabel "GIF"@en ;
     skos:broader :iron-formation ;
-    skos:definition "Granular iron-formation (GIF) is an iron formation lacking even, continuous bedding and containing sand-sized endoclasts in a finer-grained matrix. GIFs originate from well-sorted chemical sands disrupted by storm waves and currents to generate discontinuous layers; uninterrupted layers thicker than a few metres are rare for GIFs. They generally belong to the oxide or silicate mineral facies. Adapted from https://en.wikipedia.org/wiki/Iron-rich_sedimentary_rocks and Beukes and Gutzmer (2008)."@en ;
-    skos:historyNote "Beukes, NJ and Gutzmer, J 2008, Origin and paleoenvironmental significance of major iron formations at the Archean-Paleoproterozoic boundary: Reviews in Economic Geology, v. 15, p. 5–47, doi:10.5382/Rev.15.01." ;
+    skos:definition "Granular iron-formation (GIF) is an iron formation lacking even, continuous bedding and containing sand-sized endoclasts in a finer-grained matrix. GIFs originate from well-sorted chemical sands disrupted by storm waves and currents to generate discontinuous layers; uninterrupted layers thicker than a few metres are rare for GIFs. They generally belong to the oxide or silicate mineral facies. Adapted from https://en.wikipedia.org/wiki/Iron-rich_sedimentary_rocks and Beukes and Gutzmer (2008)."@en ;
+    skos:historyNote "Beukes, NJ and Gutzmer, J 2008, Origin and paleoenvironmental significance of major iron formations at the Archean-Paleoproterozoic boundary: Reviews in Economic Geology, v. 15, p. 5–47, doi:10.5382/Rev.15.01." ;
     skos:inScheme cs: ;
     skos:narrower
         :fearenite ,
@@ -8220,7 +8220,7 @@ Grey, K and Awramik, SM 2020, Handbook for the study and description of microbia
         "femicrite"@en ;
     skos:broader :iron-formation ;
     skos:definition "A femicrite / micritic iron-formation (MIF) is an indurated chemical iron-rich mud, i.e. an ironstone or iron-formation consisting predominantly of matrix (micrite) and lacking substantial granules. When distinctly chert-mesobanded, they are referred to as banded micritic iron-formations (BMIF). Adapted from Beukes and Gutzmer (2008)."@en ;
-    skos:historyNote "Beukes, NJ and Gutzmer, J 2008, Origin and paleoenvironmental significance of major iron formations at the Archean-Paleoproterozoic boundary: Reviews in Economic Geology, v. 15, p. 5–47, doi:10.5382/Rev.15.01." ;
+    skos:historyNote "Beukes, NJ and Gutzmer, J 2008, Origin and paleoenvironmental significance of major iron formations at the Archean-Paleoproterozoic boundary: Reviews in Economic Geology, v. 15, p. 5–47, doi:10.5382/Rev.15.01." ;
     skos:inScheme cs: ;
     skos:narrower
         :felutite ,
@@ -8279,7 +8279,7 @@ Pettijohn, FJ 1975, Sedimentary Rocks: New York, Harper and Row, 628p.""" ;
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metasedimentary-carbonate ;
-    skos:definition "Metamorphic rock mainly composed of calc-silicate minerals (i.e. calcium-rich silicate minerals) and containing less than 5% volume of carbonate minerals (calcite and/or aragonite and/or dolomite). Adapted from Fettes and Desmons (2007, p. 137)"@en ;
+    skos:definition "Metamorphic rock mainly composed of calc-silicate minerals (i.e. calcium-rich silicate minerals) and containing less than 5% volume of carbonate minerals (calcite and/or aragonite and/or dolomite). Adapted from Fettes and Desmons (2007, p. 137)"@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:narrower
@@ -8298,9 +8298,9 @@ Pettijohn, FJ 1975, Sedimentary Rocks: New York, Harper and Row, 628p.""" ;
         <http://inspire.ec.europa.eu/codelist/LithologyValue/boundstone> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/boundstone> ;
     skos:broader :dolomite ;
-    skos:definition "A term used by Dunham (1962) for an autochthonous carbonate sedimentary rock consisting mostly of dolomite whose original components were bound together during deposition and remained substantially in the position of growth (as shown by such features as intergrown skeletal matter and lamination contrary to gravity); e.g. most reef rocks and some biohermal and biostromal rocks. It is composed of bioclasts, over 2 mm in diameter and forming more than 10% of the rock, that are organically attached or cemented to each other; these may form a structural framework or be interspersed among coarse skeletal debris. Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
-    skos:historyNote """Dunham, RJ 1962, Classification of carbonate rocks according to depositional texture, in Classification of carbonate rocks edited by WE Hamm: American Association of Petroleum Geologists, Tulsa, Oklahoma, USA, p. 108–121.,
-Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Island, N.W.T: Bulletin of Canadian Petroleum Geology, v. 19(4), p. 730–781.""" ;
+    skos:definition "A term used by Dunham (1962) for an autochthonous carbonate sedimentary rock consisting mostly of dolomite whose original components were bound together during deposition and remained substantially in the position of growth (as shown by such features as intergrown skeletal matter and lamination contrary to gravity); e.g. most reef rocks and some biohermal and biostromal rocks. It is composed of bioclasts, over 2 mm in diameter and forming more than 10% of the rock, that are organically attached or cemented to each other; these may form a structural framework or be interspersed among coarse skeletal debris. Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
+    skos:historyNote """Dunham, RJ 1962, Classification of carbonate rocks according to depositional texture, in Classification of carbonate rocks edited by WE Hamm: American Association of Petroleum Geologists, Tulsa, Oklahoma, USA, p. 108–121.,
+Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Island, N.W.T: Bulletin of Canadian Petroleum Geology, v. 19(4), p. 730–781.""" ;
     skos:inScheme cs: ;
     skos:narrower
         :dolobafflestone ,
@@ -8315,7 +8315,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metamorphic-protolith-unknown-impactite ;
-    skos:definition "Monomictic or polymictic breccia that occurs around, inside and below impact craters (Fettes and Desmons, 2007, p. 161). Impact breccias are classified based on the degree of mixing of various target lithologies and their content of melt particles. Lithic breccias and suevites are generally polymictic breccias except for single lithology targets. The matrix of lithic breccias is truly clastic and consists exclusively of lithic and mineral clasts whereas the matrix of suevite additionally contains melt particles. Megabreccias are polymictic impact breccia containing lithic clasts up to the size of several hundred metres as part of the ejecta blanket of an impact crater (Fettes and Desmons, 2007, p. 171)."@en ;
+    skos:definition "Monomictic or polymictic breccia that occurs around, inside and below impact craters (Fettes and Desmons, 2007, p. 161). Impact breccias are classified based on the degree of mixing of various target lithologies and their content of melt particles. Lithic breccias and suevites are generally polymictic breccias except for single lithology targets. The matrix of lithic breccias is truly clastic and consists exclusively of lithic and mineral clasts whereas the matrix of suevite additionally contains melt particles. Megabreccias are polymictic impact breccia containing lithic clasts up to the size of several hundred metres as part of the ejecta blanket of an impact crater (Fettes and Desmons, 2007, p. 171)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:narrower
@@ -8335,8 +8335,8 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
         <http://resource.geosciml.org/classifier/cgi/lithology/boundstone> ;
     skos:broader :limestone ;
     skos:definition "A term used by Dunham (1962) for a sedimentary carbonate rock consisting mostly of calcite whose original components were bound together during deposition and remained substantially in the position of growth (as shown by such features as intergrown skeletal matter and lamination contrary to gravity); e.g. most reef rocks and some biohermal and biostromal rocks. It is composed of bioclasts, over 2 mm in diameter and forming more than 10% of the rock, that are organically attached or cemented to each other; these may form a structural framework or be interspersed among coarse skeletal debris. Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011). The limestone prefix is commonly omitted since it is implied by Dunham's (1962) classification."@en ;
-    skos:historyNote """Dunham, RJ 1962, Classification of carbonate rocks according to depositional texture, in Classification of carbonate rocks edited by WE Hamm: American Association of Petroleum Geologists, Tulsa, Oklahoma, USA, p. 108–121.,
-Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Island, N.W.T: Bulletin of Canadian Petroleum Geology, v. 19(4), p. 730–781.""" ;
+    skos:historyNote """Dunham, RJ 1962, Classification of carbonate rocks according to depositional texture, in Classification of carbonate rocks edited by WE Hamm: American Association of Petroleum Geologists, Tulsa, Oklahoma, USA, p. 108–121.,
+Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Island, N.W.T: Bulletin of Canadian Petroleum Geology, v. 19(4), p. 730–781.""" ;
     skos:inScheme cs: ;
     skos:narrower
         :limestone-bafflestone ,
@@ -8351,7 +8351,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :metasedimentary-carbonate ;
-    skos:definition "Metamorphic rock containing more than 50% volume of carbonate minerals (calcite and/or aragonite and/or dolomite). Pure marble contains more than 95% volume of carbonate minerals; a marble containing less than 95% of carbonate minerals is classified as impure marble. Adapted from Fettes and Desmons (2007, p. 170)."@en ;
+    skos:definition "Metamorphic rock containing more than 50% volume of carbonate minerals (calcite and/or aragonite and/or dolomite). Pure marble contains more than 95% volume of carbonate minerals; a marble containing less than 95% of carbonate minerals is classified as impure marble. Adapted from Fettes and Desmons (2007, p. 170)."@en ;
     skos:exactMatch
         <http://inspire.ec.europa.eu/codelist/LithologyValue/marble> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/marble> ;
@@ -8417,8 +8417,8 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     rdfs:isDefinedBy cs: ;
     skos:altLabel "tactite"@en ;
     skos:broader :metasomatic ;
-    skos:definition "Skarns or tactites are coarse-grained metamorphic rocks that form by replacement of carbonate-bearing rocks during regional or contact metamorphism and metasomatism. Skarns may form by metamorphic recrystallization of impure carbonate protoliths, bimetasomatic reaction of different lithologies, and infiltration metasomatism by magmatic-hydrothermal fluids. Skarns tend to be rich in calcium–magnesium–iron–manganese–aluminium silicate minerals, which are also referred to as calc-silicate minerals. (Fettes and Desmons, 2007, p. 195)"@en ;
-    skos:historyNote "Einaudi, MT, Meinert, LD and Newberry, RJ, 1981, Skarn deposits: in 75th Anniversary Volume, 1906–1980, edited by BJ Skinner: Society of Economic Geology, Pennsylvania, USA, p. 317–391." ;
+    skos:definition "Skarns or tactites are coarse-grained metamorphic rocks that form by replacement of carbonate-bearing rocks during regional or contact metamorphism and metasomatism. Skarns may form by metamorphic recrystallization of impure carbonate protoliths, bimetasomatic reaction of different lithologies, and infiltration metasomatism by magmatic-hydrothermal fluids. Skarns tend to be rich in calcium–magnesium–iron–manganese–aluminium silicate minerals, which are also referred to as calc-silicate minerals. (Fettes and Desmons, 2007, p. 195)"@en ;
+    skos:historyNote "Einaudi, MT, Meinert, LD and Newberry, RJ, 1981, Skarn deposits: in 75th Anniversary Volume, 1906–1980, edited by BJ Skinner: Society of Economic Geology, Pennsylvania, USA, p. 317–391." ;
     skos:inScheme cs: ;
     skos:narrower
         :endoskarn ,
@@ -8459,7 +8459,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     rdfs:isDefinedBy cs: ;
     skos:altLabel "sandstone"@en ;
     skos:broader :sedimentary-siliciclastic ;
-    skos:definition "A general term used for well-sorted, consolidated sedimentary rocks composed of sand-sized fragments (irrespective of composition) with a pure or nearly pure chemical cement and less than 10% argillaceous matrix; as distinguished from wacke. Further subdivision is based on proportions of quartz (Q), feldspar (F) and rock/lithic fragments (R/L). Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)"@en ;
+    skos:definition "A general term used for well-sorted, consolidated sedimentary rocks composed of sand-sized fragments (irrespective of composition) with a pure or nearly pure chemical cement and less than 10% argillaceous matrix; as distinguished from wacke. Further subdivision is based on proportions of quartz (Q), feldspar (F) and rock/lithic fragments (R/L). Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)"@en ;
     skos:exactMatch
         <http://inspire.ec.europa.eu/codelist/LithologyValue/arenite> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/arenite> ;
@@ -8479,11 +8479,11 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:broader :sedimentary-siliciclastic ;
-    skos:definition "A coarse-grained clastic sedimentary rock, composed of rounded to subangular fragments larger than 2 mm in diameter (granules, pebbles, cobbles, boulders) typically containing fine-grained particles (sand, silt, clay) in the interstices, and commonly cemented by iron oxide, silica, carbonate or hardened clay; the consolidated equivalent of gravel both in size range and in the essential roundness and sorting of its constituent particles. The rock or mineral fragments may be of varied composition and range widely in size. Conglomerates may be classified according to nature or composition of fragments, proportion of matrix, degree of size sorting, type of cement, and agent or environment of formation. Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
+    skos:definition "A coarse-grained clastic sedimentary rock, composed of rounded to subangular fragments larger than 2 mm in diameter (granules, pebbles, cobbles, boulders) typically containing fine-grained particles (sand, silt, clay) in the interstices, and commonly cemented by iron oxide, silica, carbonate or hardened clay; the consolidated equivalent of gravel both in size range and in the essential roundness and sorting of its constituent particles. The rock or mineral fragments may be of varied composition and range widely in size. Conglomerates may be classified according to nature or composition of fragments, proportion of matrix, degree of size sorting, type of cement, and agent or environment of formation. Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
     skos:exactMatch
         <http://inspire.ec.europa.eu/codelist/LithologyValue/clasticConglomerate> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/clastic_conglomerate> ;
-    skos:historyNote "Wentworth, CK 1922, A scale of grade and class terms for clastic sediments: The Journal of Geology, v. 30, no. 5, p. 377–392, doi:10.1086/622910." ;
+    skos:historyNote "Wentworth, CK 1922, A scale of grade and class terms for clastic sediments: The Journal of Geology, v. 30, no. 5, p. 377–392, doi:10.1086/622910." ;
     skos:inScheme cs: ;
     skos:narrower
         :boulder-conglomerate ,
@@ -8521,7 +8521,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     rdfs:isDefinedBy cs: ;
     skos:broader :sedimentary-other-chemical-or-biochemical ;
     skos:definition "A chemical sedimentary rock, typically thin-bedded and/or finely laminated, containing at least 15% iron of sedimentary origin, and commonly but not necessarily containing layers of chert. Various primary facies (usually not weathered) of iron formation are distinguished on the basis of whether the iron occurs predominantly as oxide, silicate, carbonate, or sulfide. Most iron formation is of Precambrian age and was deposited as chemical muds. Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
-    skos:historyNote "Beukes, NJ and Gutzmer, J 2008, Origin and paleoenvironmental significance of major iron formations at the Archean-Paleoproterozoic boundary: Reviews in Economic Geology, v. 15, p. 5–47, doi:10.5382/Rev.15.01." ;
+    skos:historyNote "Beukes, NJ and Gutzmer, J 2008, Origin and paleoenvironmental significance of major iron formations at the Archean-Paleoproterozoic boundary: Reviews in Economic Geology, v. 15, p. 5–47, doi:10.5382/Rev.15.01." ;
     skos:inScheme cs: ;
     skos:narrower
         :banded-iron-formation ,
@@ -8541,7 +8541,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     skos:exactMatch
         <http://inspire.ec.europa.eu/codelist/LithologyValue/coal> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/coal> ;
-    skos:historyNote "Forsman, JP and Hunt, JM 1958, Insoluble organic matter (kerogen) in sedimentary rocks: Geochimica et Cosmochimica Acta, v. 15(3), p. 170–182, doi.org/10.1016/0016-7037(58)90055-3." ;
+    skos:historyNote "Forsman, JP and Hunt, JM 1958, Insoluble organic matter (kerogen) in sedimentary rocks: Geochimica et Cosmochimica Acta, v. 15(3), p. 170–182, doi.org/10.1016/0016-7037(58)90055-3." ;
     skos:inScheme cs: ;
     skos:narrower
         :anthracite ,
@@ -8557,7 +8557,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
 :igneous-kalsilitic
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
-    skos:definition "A group name for a dominantly mafic, melanocratic volcanic rocks consisting essentially of clinopyroxene, kalsilite, leucite, melilite, olivine and phlogopite (cf. Le Maitre et al., 2005, p. 12). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
+    skos:definition "A group name for a dominantly mafic, melanocratic volcanic rocks consisting essentially of clinopyroxene, kalsilite, leucite, melilite, olivine and phlogopite (cf. Le Maitre et al., 2005, p. 12). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005). See also https://academic.oup.com/petrology/article/63/5/egac026/6553206." ;
     skos:inScheme cs: ;
     skos:narrower
@@ -8574,7 +8574,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
 :igneous-melilitic
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
-    skos:definition "A group name for ultramafic intrusive rocks that consist essentially of melilite, pyroxene and olivine. The term is reserved for rocks that contain greater than 10% modal melilite, and, if feldspathoids are present, melilite > feldspathoid; modal content of mafic minerals (M) is usually greater than 90%. Melilites are honey-coloured minerals with the general formula (Na,Ca)₂(Mg,Al)(Si,Al)₂O₇. Definitions adapted from Le Maitre et al. (2005, p. 11) and Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
+    skos:definition "A group name for ultramafic intrusive rocks that consist essentially of melilite, pyroxene and olivine. The term is reserved for rocks that contain greater than 10% modal melilite, and, if feldspathoids are present, melilite > feldspathoid; modal content of mafic minerals (M) is usually greater than 90%. Melilites are honey-coloured minerals with the general formula (Na,Ca)₂(Mg,Al)(Si,Al)₂O₇. Definitions adapted from Le Maitre et al. (2005, p. 11) and Glossary of geology (5th edition revised; Neuendorf et al., 2011)."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005) and Glossary of geology (5th edition, revised; Neuendorf et al. 2011)." ;
     skos:inScheme cs: ;
     skos:narrower
@@ -8594,7 +8594,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:altLabel "psephyte"@en ;
-    skos:definition "A group name for metamorphosed rocks derived from a sedimentary siliciclastic protolith with grain size greater than 2 mm, i.e. the metamorphosed equivalent of a conglomerate. Acknowledging entrenched practises, GSWA usage allows the use of psephite as a noun for a metamorphosed equivalent of conglomerate lithologies (i.e. grain size greater than 2 mm), as well as an adjective to qualify metamorphic rocks derived from these sedimentary types (e.g. psephitic schist)."@en ;
+    skos:definition "A group name for metamorphosed rocks derived from a sedimentary siliciclastic protolith with grain size greater than 2 mm, i.e. the metamorphosed equivalent of a conglomerate. Acknowledging entrenched practises, GSWA usage allows the use of psephite as a noun for a metamorphosed equivalent of conglomerate lithologies (i.e. grain size greater than 2 mm), as well as an adjective to qualify metamorphic rocks derived from these sedimentary types (e.g. psephitic schist)."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:narrower
@@ -8613,7 +8613,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
 :meta-igneous-carbonatite
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
-    skos:definition "A group name for metamorphosed rocks derived from carbonatites, i.e. igneous rocks containing more than 50% modal carbonates (cf. Le Maitre et al., 2005, p. 10)."@en ;
+    skos:definition "A group name for metamorphosed rocks derived from carbonatites, i.e. igneous rocks containing more than 50% modal carbonates (cf. Le Maitre et al., 2005, p. 10)."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:narrower
@@ -8632,7 +8632,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
 :metamorphic-protolith-unknown-impactite
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
-    skos:definition "A group name for all rocks affected by one or more hypervelocity impact(s) resulting from collision(s) of two planetary bodies. Only impactites derived from a single impact (e.g. at terrestrial impact craters) are considered in this vocabulary, impactites resulting from multiple impacts (i.e. as known from the Moon and from meteorites) are not considered. (Osinski et al., 2022)"@en ;
+    skos:definition "A group name for all rocks affected by one or more hypervelocity impact(s) resulting from collision(s) of two planetary bodies. Only impactites derived from a single impact (e.g. at terrestrial impact craters) are considered in this vocabulary, impactites resulting from multiple impacts (i.e. as known from the Moon and from meteorites) are not considered. (Osinski et al., 2022)"@en ;
     skos:historyNote "Osinski, GR, Grieve, RAF, Ferrière, L, Losiak, A, Pickersgill, AE, Cavosie, AJ, Hibbard, SM, Hill, PJA, Bermudez, JJ, Marion, CL, Newman, JD and Simpson, SL 2022, Impact Earth: A review of the terrestrial impact record: Earth-Science Reviews, v. 232, 104112, doi.org/10.1016/j.earscirev.2022.104112." ;
     skos:inScheme cs: ;
     skos:narrower
@@ -8712,7 +8712,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
 :metasedimentary-siliciclastic-psammite-and-pelite-interlayered
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
-    skos:definition "A group name for metamorphosed rocks derived from a succession of interleaved sandstone and mudstone beds, i.e. sedimentary siliciclastic protoliths with grain size between 0.0625 and 2 mm and less than 0.0625 mm respectively. Acknowledging entrenched practises, GSWA usage allows the use of psammite and pelite as nouns for metamorphosed equivalent of sandstone and mudstone lithologies, as well as adjectives to qualify metamorphic rocks derived from these sedimentary types."@en ;
+    skos:definition "A group name for metamorphosed rocks derived from a succession of interleaved sandstone and mudstone beds, i.e. sedimentary siliciclastic protoliths with grain size between 0.0625 and 2 mm and less than 0.0625 mm respectively. Acknowledging entrenched practises, GSWA usage allows the use of psammite and pelite as nouns for metamorphosed equivalent of sandstone and mudstone lithologies, as well as adjectives to qualify metamorphic rocks derived from these sedimentary types."@en ;
     skos:historyNote "Partly based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:narrower
@@ -8734,7 +8734,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
 :metasedimentary-siliciclastic-semipelite
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
-    skos:definition "A group name for metamorphosed rocks with a modal ratio of mica to quartz + feldspar intermediate between a pelite and a psammite, a crystalloblastic nature, and derived from a fine- to medium-grained siliciclastic sedimentary protolith."@en ;
+    skos:definition "A group name for metamorphosed rocks with a modal ratio of mica to quartz + feldspar intermediate between a pelite and a psammite, a crystalloblastic nature, and derived from a fine- to medium-grained siliciclastic sedimentary protolith."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:narrower
@@ -8754,7 +8754,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
 :meta-igneous-felsic
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
-    skos:definition "A group name for metamorphosed igneous lithologies that are composed chiefly of felsic minerals, for which an intrusive or extrusive protolith cannot be conclusively identified. These rocks are derived from igneous or volcaniclastic protoliths with modal quartz and feldspar and M smaller than 90% (cf. Le Maitre et al., 2005, p. 153), where M represents the volume modal percentage of mafic and related minerals (Le Maitre et al., 2005, p. 4)."@en ;
+    skos:definition "A group name for metamorphosed igneous lithologies that are composed chiefly of felsic minerals, for which an intrusive or extrusive protolith cannot be conclusively identified. These rocks are derived from igneous or volcaniclastic protoliths with modal quartz and feldspar and M smaller than 90% (cf. Le Maitre et al., 2005, p. 153), where M represents the volume modal percentage of mafic and related minerals (Le Maitre et al., 2005, p. 4)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic (Fettes and Desmons, 2007) and igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:narrower
@@ -8775,7 +8775,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
 :metasedimentary-siliciclastic-psammite
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
-    skos:definition "A group name for metamorphosed rocks derived from a medium-grained siliciclastic sedimentary protolith (grain size between 0.0625 and 2 mm), i.e. the metamorphosed equivalent of a sandstone. Fettes and Desmons (2007, p. 188) identify psammite as a restricted-use term, and define it as \"... a term for a sedimentary rock composed of sand-sized particles. It has also been used locally for the metamorphosed equivalent of these sedimentary rocks, that is, metamorphic rocks with a low modal ratio of mica to quartz + feldspar (Tyrrell, Robertson). The SCMR recommends that it should be used only for sedimentary rocks and the term metapsammite should be used for the metamorphosed equivalents.\" Acknowledging entrenched practises, GSWA usage departs from this recommendation, and allows the use of psammite as a noun for a metamorphosed equivalent of sandstone lithologies (i.e. grain size between 0.0625 and 2 mm), as well as an adjective to qualify metamorphic rocks derived from these sedimentary types (e.g. pelitic schist)."@en ;
+    skos:definition "A group name for metamorphosed rocks derived from a medium-grained siliciclastic sedimentary protolith (grain size between 0.0625 and 2 mm), i.e. the metamorphosed equivalent of a sandstone. Fettes and Desmons (2007, p. 188) identify psammite as a restricted-use term, and define it as \"... a term for a sedimentary rock composed of sand-sized particles. It has also been used locally for the metamorphosed equivalent of these sedimentary rocks, that is, metamorphic rocks with a low modal ratio of mica to quartz + feldspar (Tyrrell, Robertson). The SCMR recommends that it should be used only for sedimentary rocks and the term metapsammite should be used for the metamorphosed equivalents.\" Acknowledging entrenched practises, GSWA usage departs from this recommendation, and allows the use of psammite as a noun for a metamorphosed equivalent of sandstone lithologies (i.e. grain size between 0.0625 and 2 mm), as well as an adjective to qualify metamorphic rocks derived from these sedimentary types (e.g. pelitic schist)."@en ;
     skos:historyNote "Partly based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:narrower
@@ -8796,7 +8796,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
 :igneous-lamprophyres
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
-    skos:definition "A group name for a distinctive group of igneous rocks that are strongly porphyritic in mafic minerals, typically biotite, amphiboles and pyroxenes, with any feldspars being confined to the groundmass. They commonly occur as dykes or small intrusions and commonly show signs of hydrothermal alteration. (Le Maitre et al., 2005, p. 100)"@en ;
+    skos:definition "A group name for a distinctive group of igneous rocks that are strongly porphyritic in mafic minerals, typically biotite, amphiboles and pyroxenes, with any feldspars being confined to the groundmass. They commonly occur as dykes or small intrusions and commonly show signs of hydrothermal alteration. (Le Maitre et al., 2005, p. 100)"@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:narrower
@@ -8862,7 +8862,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
 :metasedimentary-siliciclastic-pelite
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
-    skos:definition "A group name for metamorphosed rocks derived from a fine-grained sedimentary siliciclastic protolith (usually with grain size below 0.0625 mm), i.e. the metamorphosed equivalent of a mudstone. Fettes and Desmons (2007, p. 181) identify pelite as a restricted-use term, and define it as \"... a term for a sedimentary rock composed of clay-sized particles. It has also been used locally for the metamorphosed equivalent of these sedimentary rocks, that is, a metamorphic rock with a high modal ratio of mica to quartz+feldspar. The SCMR recommends that it should be used only for sedimentary rocks and the term metapelite should be used for the metamorphosed equivalents.\" Acknowledging entrenched practises, GSWA usage departs from this recommendation, and allows the use of pelite as a noun for a metamorphosed equivalent of mudstone lithologies, as well as an adjective to qualify metamorphic rocks derived from these sedimentary types (e.g. pelitic schist)."@en ;
+    skos:definition "A group name for metamorphosed rocks derived from a fine-grained sedimentary siliciclastic protolith (usually with grain size below 0.0625 mm), i.e. the metamorphosed equivalent of a mudstone. Fettes and Desmons (2007, p. 181) identify pelite as a restricted-use term, and define it as \"... a term for a sedimentary rock composed of clay-sized particles. It has also been used locally for the metamorphosed equivalent of these sedimentary rocks, that is, a metamorphic rock with a high modal ratio of mica to quartz+feldspar. The SCMR recommends that it should be used only for sedimentary rocks and the term metapelite should be used for the metamorphosed equivalents.\" Acknowledging entrenched practises, GSWA usage departs from this recommendation, and allows the use of pelite as a noun for a metamorphosed equivalent of mudstone lithologies, as well as an adjective to qualify metamorphic rocks derived from these sedimentary types (e.g. pelitic schist)."@en ;
     skos:historyNote "Partly based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:narrower
@@ -8884,7 +8884,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
 :metasomatic
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
-    skos:definition "A group name for lithologies formed via metasomatic processes, i.e. the open-system metamorphic processes by which the chemical composition of a rock or rock portion is altered in a pervasive manner and which involves the introduction and/or removal of chemical components as a result of the interaction of the rock with aqueous fluids/solutions (usually hydrothermal or static fluids); during metasomatism the rock remains in a solid state (Fettes and Desmons, 2007, p. 174)."@en ;
+    skos:definition "A group name for lithologies formed via metasomatic processes, i.e. the open-system metamorphic processes by which the chemical composition of a rock or rock portion is altered in a pervasive manner and which involves the introduction and/or removal of chemical components as a result of the interaction of the rock with aqueous fluids/solutions (usually hydrothermal or static fluids); during metasomatism the rock remains in a solid state (Fettes and Desmons, 2007, p. 174)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:narrower
@@ -8930,7 +8930,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
 :meta-igneous-ultramafic-intrusive
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
-    skos:definition "A group name for metamorphosed intrusive lithologies or coarse-grained parts of extrusive successions that are composed chiefly of mafic minerals, i.e. derived from intrusive protoliths with M greater than or equal to 90% (cf. Le Maitre et al., 2005, p. 153), where M represents the volume modal percentage of mafic and related minerals (Le Maitre et al., 2005, p. 4)."@en ;
+    skos:definition "A group name for metamorphosed intrusive lithologies or coarse-grained parts of extrusive successions that are composed chiefly of mafic minerals, i.e. derived from intrusive protoliths with M greater than or equal to 90% (cf. Le Maitre et al., 2005, p. 153), where M represents the volume modal percentage of mafic and related minerals (Le Maitre et al., 2005, p. 4)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic (Fettes and Desmons, 2007) and igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:narrower
@@ -8977,7 +8977,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
 :meta-igneous-mafic
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
-    skos:definition "A group name for metamorphosed igneous lithologies that are composed chiefly of mafic minerals, for which an intrusive, extrusive or volcaniclastic protolith cannot be conclusively identified. These rocks are derived from igneous or volcanic/volcaniclastic protoliths with M smaller than 90% (cf. Le Maitre et al., 2005, p. 153), where M represents the volume modal percentage of mafic and related minerals (Le Maitre et al., 2005, p. 4), and varying amounts of pyroxene, olivine and hornblende (cf. Le Maitre et al., 2005, p. 24)."@en ;
+    skos:definition "A group name for metamorphosed igneous lithologies that are composed chiefly of mafic minerals, for which an intrusive, extrusive or volcaniclastic protolith cannot be conclusively identified. These rocks are derived from igneous or volcanic/volcaniclastic protoliths with M smaller than 90% (cf. Le Maitre et al., 2005, p. 153), where M represents the volume modal percentage of mafic and related minerals (Le Maitre et al., 2005, p. 4), and varying amounts of pyroxene, olivine and hornblende (cf. Le Maitre et al., 2005, p. 24)."@en ;
     skos:historyNote "Compiled by the Geological Survey of Western Australia" ;
     skos:inScheme cs: ;
     skos:narrower
@@ -9001,7 +9001,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
 :meta-igneous-ultramafic-volcanic
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
-    skos:definition "A group name for metamorphosed volcanic and volcaniclastic lithologies derived from protoliths composed chiefly of one or more ferromagnesian, dark-coloured minerals such as olivine, pyroxene, etc. in their mode, with the volume modal percentage of mafic and related minerals (M) greater than or equal to 90% (cf. Le Maitre et al., 2005, p. 4)."@en ;
+    skos:definition "A group name for metamorphosed volcanic and volcaniclastic lithologies derived from protoliths composed chiefly of one or more ferromagnesian, dark-coloured minerals such as olivine, pyroxene, etc. in their mode, with the volume modal percentage of mafic and related minerals (M) greater than or equal to 90% (cf. Le Maitre et al., 2005, p. 4)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic (Fettes and Desmons, 2007) and igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:narrower
@@ -9051,7 +9051,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
 :igneous-feldspathoid-bearing-volcanic
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
-    skos:definition "A group name for volcanic, silica-undersaturated lithologies that are characterized by the presence of feldspathoid (or foid, F) mineral phases, where the feldspathoid content is between 0 and 10% (cf. Le Maitre et al., 2005, p. 31) and the modal content of mafic and related minerals (M) is less than 90% (Le Maitre et al., 2005, p.  4). Note that the GSWA rock classification scheme does not include volcanic rocks with F greater than 10%. GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
+    skos:definition "A group name for volcanic, silica-undersaturated lithologies that are characterized by the presence of feldspathoid (or foid, F) mineral phases, where the feldspathoid content is between 0 and 10% (cf. Le Maitre et al., 2005, p. 31) and the modal content of mafic and related minerals (M) is less than 90% (Le Maitre et al., 2005, p.  4). Note that the GSWA rock classification scheme does not include volcanic rocks with F greater than 10%. GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005) and GSWA usage." ;
     skos:inScheme cs: ;
     skos:narrower
@@ -9076,7 +9076,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
 :meta-igneous-mafic-volcanic
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
-    skos:definition "A group name for metamorphosed volcanic and volcaniclastic lithologies composed chiefly of one or more ferromagnesian, dark-coloured minerals and derived from volcanic protoliths with M less than 90% (cf. Le Maitre et al., 2005, p. 153), where M represents the volume modal percentage of mafic and related minerals (Le Maitre et al., 2005, p. 4). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
+    skos:definition "A group name for metamorphosed volcanic and volcaniclastic lithologies composed chiefly of one or more ferromagnesian, dark-coloured minerals and derived from volcanic protoliths with M less than 90% (cf. Le Maitre et al., 2005, p. 153), where M represents the volume modal percentage of mafic and related minerals (Le Maitre et al., 2005, p. 4). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic (Fettes and Desmons, 2007) and igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:narrower
@@ -9102,7 +9102,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
 :metamorphic-protolith-unknown-gneiss
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
-    skos:definition "A group name for metamorphic rocks for which a protolith cannot be conclusively established and displaying a gneissose structure, i.e. a type of structure characterized by a schistosity that is either poorly developed throughout the rock or, if well developed, occurs in broadly spaced zones, such that the rock will split on a scale of more than one centimetre. Mineralogical or lithological layering is commonly present. (Cf. Fettes and Desmons, 2007, p. 154–155)."@en ;
+    skos:definition "A group name for metamorphic rocks for which a protolith cannot be conclusively established and displaying a gneissose structure, i.e. a type of structure characterized by a schistosity that is either poorly developed throughout the rock or, if well developed, occurs in broadly spaced zones, such that the rock will split on a scale of more than one centimetre. Mineralogical or lithological layering is commonly present. (Cf. Fettes and Desmons, 2007, p. 154–155)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:narrower
@@ -9128,7 +9128,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
 :metamorphic-protolith-unknown-granofels-hornfels
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
-    skos:definition "A group name for metamorphic rocks for which a protolith cannot be conclusively established and displaying a granofelsic structure, i.e. a structure resulting from the absence of schistosity such that the mineral grains and aggregates of mineral grains are equant (for example quartz, feldspar, garnet and pyroxene) or, if inequant, have a random orientation. Mineralogical or lithological layering may be present. Definition adapted from Fettes and Desmons (2007, p. 156). Hornfels are granofels that are typically formed by contact metasomatism and occur mostly (though not exclusively) in the innermost part of contact aureoles. Definition adapted from Fettes and Desmons (2007, p. 159) and Glossary of geology 2011, 5th edition revised)."@en ;
+    skos:definition "A group name for metamorphic rocks for which a protolith cannot be conclusively established and displaying a granofelsic structure, i.e. a structure resulting from the absence of schistosity such that the mineral grains and aggregates of mineral grains are equant (for example quartz, feldspar, garnet and pyroxene) or, if inequant, have a random orientation. Mineralogical or lithological layering may be present. Definition adapted from Fettes and Desmons (2007, p. 156). Hornfels are granofels that are typically formed by contact metasomatism and occur mostly (though not exclusively) in the innermost part of contact aureoles. Definition adapted from Fettes and Desmons (2007, p. 159) and Glossary of geology 2011, 5th edition revised)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:narrower
@@ -9156,7 +9156,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
 :igneous-carbonatite
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
-    skos:definition "A group name for igneous rocks containing more than 50% modal carbonates. Carbonatites may be either intrusive or volcanic in origin, and are distinguished based on the relative abundance of different carbonate phases. (cf. Le Maitre et al., 2005, p. 10)."@en ;
+    skos:definition "A group name for igneous rocks containing more than 50% modal carbonates. Carbonatites may be either intrusive or volcanic in origin, and are distinguished based on the relative abundance of different carbonate phases. (cf. Le Maitre et al., 2005, p. 10)."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:narrower
@@ -9183,7 +9183,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
 :meta-igneous-mafic-intrusive
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
-    skos:definition "A group name for metamorphosed intrusive lithologies (and including coarse-grained parts of extrusive successions) derived from protoliths composed chiefly of one or ferromagnesian, dark-coloured minerals in their mode (cf. Le Maitre et al., 2005, p. 25 and 107) and with the volume modal percentage of mafic and related minerals (M) less then 90%. As for their protolith equivalents, metamorphic lithologies in this group are distinguished by the relative abundance of orthopyroxene, clinopyroxene, olivine and hornblende (cf. Le Maitre et al., 2005, p. 24)."@en ;
+    skos:definition "A group name for metamorphosed intrusive lithologies (and including coarse-grained parts of extrusive successions) derived from protoliths composed chiefly of one or ferromagnesian, dark-coloured minerals in their mode (cf. Le Maitre et al., 2005, p. 25 and 107) and with the volume modal percentage of mafic and related minerals (M) less then 90%. As for their protolith equivalents, metamorphic lithologies in this group are distinguished by the relative abundance of orthopyroxene, clinopyroxene, olivine and hornblende (cf. Le Maitre et al., 2005, p. 24)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic (Fettes and Desmons, 2007) and igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:narrower
@@ -9209,7 +9209,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
 :metamorphic-protolith-unknown-schist
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
-    skos:definition "A group name for metamorphic rocks for which a protolith cannot be conclusively established and displaying a schistose structure, i.e. a type of structure characterized by a schistosity that is either poorly developed throughout the rock or, if well developed, occurs in broadly spaced zones, such that the rock will split on a scale of more than one centimetre. Mineralogical or lithological layering is commonly present. Cf. Fettes and Desmons (2007, p.  193)."@en ;
+    skos:definition "A group name for metamorphic rocks for which a protolith cannot be conclusively established and displaying a schistose structure, i.e. a type of structure characterized by a schistosity that is either poorly developed throughout the rock or, if well developed, occurs in broadly spaced zones, such that the rock will split on a scale of more than one centimetre. Mineralogical or lithological layering is commonly present. Cf. Fettes and Desmons (2007, p.  193)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic rocks (Fettes and Desmons, 2007)." ;
     skos:inScheme cs: ;
     skos:narrower
@@ -9236,7 +9236,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
 :igneous-mafic-volcanic
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
-    skos:definition "A group name for volcanic and volcaniclastic lithologies composed chiefly of one or more ferromagnesian, dark-coloured minerals such as olivine, pyroxene, etc. in their mode, with the volume modal percentage of mafic and related minerals (M) less than 90% (cf. Le Maitre et al., 2005, p. 4 and 107). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
+    skos:definition "A group name for volcanic and volcaniclastic lithologies composed chiefly of one or more ferromagnesian, dark-coloured minerals such as olivine, pyroxene, etc. in their mode, with the volume modal percentage of mafic and related minerals (M) less than 90% (cf. Le Maitre et al., 2005, p. 4 and 107). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:narrower
@@ -9264,7 +9264,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
 :igneous-ultramafic-volcanic-and-volcaniclastic
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
-    skos:definition "A group name for volcanic and volcaniclastic lithologies composed chiefly of one or more ferromagnesian, dark-coloured minerals such as olivine, pyroxene, etc. in their mode, with the volume modal percentage of mafic and related minerals (M) greater than or equal to 90% (cf. Le Maitre et al., 2005, p. 4). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
+    skos:definition "A group name for volcanic and volcaniclastic lithologies composed chiefly of one or more ferromagnesian, dark-coloured minerals such as olivine, pyroxene, etc. in their mode, with the volume modal percentage of mafic and related minerals (M) greater than or equal to 90% (cf. Le Maitre et al., 2005, p. 4). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:narrower
@@ -9291,7 +9291,7 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
 :meta-igneous-felsic-volcanic
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
-    skos:definition "A group name for metamorphosed volcanic (and volcaniclastic) lithologies composed chiefly of felsic minerals and derived from volcanic protoliths with M less than 90% (cf. Le Maitre et al., 2005, p. 153), where M represents the volume modal percentage of mafic and related minerals (Le Maitre et al., 2005, p. 4). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
+    skos:definition "A group name for metamorphosed volcanic (and volcaniclastic) lithologies composed chiefly of felsic minerals and derived from volcanic protoliths with M less than 90% (cf. Le Maitre et al., 2005, p. 153), where M represents the volume modal percentage of mafic and related minerals (Le Maitre et al., 2005, p. 4). GSWA's rock classification scheme prefers the use of volcanic terminology for any igneous rock formed on or near the Earth's surface, i.e. for those hypabyssal or subvolcanic rocks such as dykes, sills, and cryptodomes that are demonstrably both spatially and temporally associated with extrusive volcanic rocks."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic (Fettes and Desmons, 2007) and igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:narrower
@@ -9323,12 +9323,12 @@ Embry, AF, Klovan, JE 1971, A late Devonian reef tract on northeastern Banks Isl
         "dolomite rock"@en ,
         "dolostone"@en ;
     skos:broader :sedimentary-carbonate ;
-    skos:definition "A carbonate sedimentary rock of which more than 50% by weight or by areal percentages under the microscope consists of the mineral dolomite, or a variety of limestone rich in magnesium carbonate; specifically a carbonate sedimentary rock containing more than 90% dolomite and less than 10% calcite, or one having a Ca/Mg ratio in the range of 1.5 – 1.7 (Chilingar, 1957), or one having an approximate MgO equivalent of 19.5 – 21.6% or magnesium–carbonate equivalent of 41.0 – 45.4% (Pettijohn, 1957, p. 418). Dolomite occurs with well-developed crystalline habits as well as anhedral forms, is clearly associated and commonly interbedded with limestone, and usually represents a post-depositional replacement of limestone. Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011). GSWA usage has in the past included the term dolostone as a synonym of dolomite (rock), to avoid confusion with the mineral dolomite; however, dolomite (rock) has technical precedence over dolostone, and use of the latter is discouraged."@en ;
+    skos:definition "A carbonate sedimentary rock of which more than 50% by weight or by areal percentages under the microscope consists of the mineral dolomite, or a variety of limestone rich in magnesium carbonate; specifically a carbonate sedimentary rock containing more than 90% dolomite and less than 10% calcite, or one having a Ca/Mg ratio in the range of 1.5 – 1.7 (Chilingar, 1957), or one having an approximate MgO equivalent of 19.5 – 21.6% or magnesium–carbonate equivalent of 41.0 – 45.4% (Pettijohn, 1957, p. 418). Dolomite occurs with well-developed crystalline habits as well as anhedral forms, is clearly associated and commonly interbedded with limestone, and usually represents a post-depositional replacement of limestone. Adapted from Glossary of geology (5th edition revised; Neuendorf et al., 2011). GSWA usage has in the past included the term dolostone as a synonym of dolomite (rock), to avoid confusion with the mineral dolomite; however, dolomite (rock) has technical precedence over dolostone, and use of the latter is discouraged."@en ;
     skos:exactMatch
         <http://inspire.ec.europa.eu/codelist/LithologyValue/dolostone> ,
         <http://resource.geosciml.org/classifier/cgi/lithology/dolostone> ;
     skos:historyNote """Pettijohn, FJ 1957, Sedimentary rocks, Harper and Brothers, New York, 718p.,
-Chilingar, GV, Bissell, HJ and Wolf, KH 1967, Chapter 5 Diagenesis of Carbonate Rocks: in Developments in Sedimentology, v. 8, p. 179–322, doi:10.1016/S0070-4571(08)70844-6.""" ;
+Chilingar, GV, Bissell, HJ and Wolf, KH 1967, Chapter 5 Diagenesis of Carbonate Rocks: in Developments in Sedimentology, v. 8, p. 179–322, doi:10.1016/S0070-4571(08)70844-6.""" ;
     skos:inScheme cs: ;
     skos:narrower
         :crystalline-dolomite ,
@@ -9357,7 +9357,7 @@ Chilingar, GV, Bissell, HJ and Wolf, KH 1967, Chapter 5 Diagenesis of Carbonate 
 :igneous-foid-bearing-intrusive
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
-    skos:definition "A group name for intrusive, silica-undersaturated lithologies that are characterized by the presence of feldspathoid (or foid, F) mineral phases (e.g. nepheline, leucite, kalsilite, analcime, sodalite, etc.), where the feldspathoid content is between 0 and 100% (cf. Le Maitre et al., 2005, p. 22). When preceding a rock name (syenite, monzonite, etc.) the modifier 'foid-bearing' indicates an intrusive rock with F between 0 and 10% of the modal composition; when F is greater than 10, the term 'foid' is used in front of the rock name."@en ;
+    skos:definition "A group name for intrusive, silica-undersaturated lithologies that are characterized by the presence of feldspathoid (or foid, F) mineral phases (e.g. nepheline, leucite, kalsilite, analcime, sodalite, etc.), where the feldspathoid content is between 0 and 100% (cf. Le Maitre et al., 2005, p. 22). When preceding a rock name (syenite, monzonite, etc.) the modifier 'foid-bearing' indicates an intrusive rock with F between 0 and 10% of the modal composition; when F is greater than 10, the term 'foid' is used in front of the rock name."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:narrower
@@ -9419,7 +9419,7 @@ Chilingar, GV, Bissell, HJ and Wolf, KH 1967, Chapter 5 Diagenesis of Carbonate 
 :meta-igneous-felsic-intrusive
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
-    skos:definition "A group name for metamorphosed intrusive lithologies that are composed chiefly of felsic minerals, i.e. derived from intrusive protoliths with modal quartz and feldspar and M smaller than 90% (cf. Le Maitre et al., 2005, p. 153), where M represents the volume modal percentage of mafic and related minerals (Le Maitre et al., 2005, p. 4)."@en ;
+    skos:definition "A group name for metamorphosed intrusive lithologies that are composed chiefly of felsic minerals, i.e. derived from intrusive protoliths with modal quartz and feldspar and M smaller than 90% (cf. Le Maitre et al., 2005, p. 153), where M represents the volume modal percentage of mafic and related minerals (Le Maitre et al., 2005, p. 4)."@en ;
     skos:historyNote "Based on the IUGS classification of metamorphic (Fettes and Desmons, 2007) and igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:narrower
@@ -9512,7 +9512,7 @@ Chilingar, GV, Bissell, HJ and Wolf, KH 1967, Chapter 5 Diagenesis of Carbonate 
 :igneous-mafic-intrusive
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
-    skos:definition "A group name for intrusive lithologies (and including coarse-grained parts of extrusive successions) that are composed chiefly of one or more ferromagnesian, dark-coloured minerals in their mode (cf. Le Maitre et al., 2005, p. 25 and 107) and with the volume modal percentage of mafic and related minerals (M) less then 90%. Individual lithologies within the group are distinguished by the relative abundance of orthopyroxene, clinopyroxene, olivine and hornblende (cf. Le Maitre et al., 2005, p. 24)."@en ;
+    skos:definition "A group name for intrusive lithologies (and including coarse-grained parts of extrusive successions) that are composed chiefly of one or more ferromagnesian, dark-coloured minerals in their mode (cf. Le Maitre et al., 2005, p. 25 and 107) and with the volume modal percentage of mafic and related minerals (M) less then 90%. Individual lithologies within the group are distinguished by the relative abundance of orthopyroxene, clinopyroxene, olivine and hornblende (cf. Le Maitre et al., 2005, p. 24)."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:narrower
@@ -9545,7 +9545,7 @@ Chilingar, GV, Bissell, HJ and Wolf, KH 1967, Chapter 5 Diagenesis of Carbonate 
 :igneous-lamproites
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
-    skos:definition "A group name for hypabyssal or extrusive rocks rich in potassium and magnesium, usually occurring as dyke or small intrusions. The subdivision of the lamproites follows the scheme of Mitchell and Bergman (1991; Petrology of lamproites: Plenum Press, New York, London, 447p.; https://link.springer.com/book/10.1007/978-1-4615-3788-5), in which the historical terminology (e.g. wyomingite, madupite, etc.) is discarded in favour of compound names based on the predominance of phlogopite, richterite, olivine, diopside, sanidine and leucite (Le Maitre et al., 2005, p. 16)."@en ;
+    skos:definition "A group name for hypabyssal or extrusive rocks rich in potassium and magnesium, usually occurring as dyke or small intrusions. The subdivision of the lamproites follows the scheme of Mitchell and Bergman (1991; Petrology of lamproites: Plenum Press, New York, London, 447p.; https://link.springer.com/book/10.1007/978-1-4615-3788-5), in which the historical terminology (e.g. wyomingite, madupite, etc.) is discarded in favour of compound names based on the predominance of phlogopite, richterite, olivine, diopside, sanidine and leucite (Le Maitre et al., 2005, p. 16)."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:narrower
@@ -9617,7 +9617,7 @@ Chilingar, GV, Bissell, HJ and Wolf, KH 1967, Chapter 5 Diagenesis of Carbonate 
 :igneous-ultramafic-intrusive
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
-    skos:definition "A group name for intrusive lithologies composed chiefly of mafic minerals and with M greater than or equal to 90% (cf. Le Maitre et al., 2005, p. 153), where M represents the volume modal percentage of mafic and related minerals (Le Maitre et al., 2005, p. 4)."@en ;
+    skos:definition "A group name for intrusive lithologies composed chiefly of mafic minerals and with M greater than or equal to 90% (cf. Le Maitre et al., 2005, p. 153), where M represents the volume modal percentage of mafic and related minerals (Le Maitre et al., 2005, p. 4)."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005)." ;
     skos:inScheme cs: ;
     skos:narrower
@@ -9695,7 +9695,7 @@ Chilingar, GV, Bissell, HJ and Wolf, KH 1967, Chapter 5 Diagenesis of Carbonate 
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:altLabel "igneous granitic"@en ;
-    skos:definition "A group name for intrusive lithologies composed chiefly of one or more felsic minerals (e.g. containing modal quartz, feldspar and feldspathoids), with modal content of mafic and related minerals (M) less than 90%, where M represents the volume modal percentage of mafic and related minerals (Le Maitre et al., 2005, p. 4). Previous GSWA usage of 'igneous granitic' is not recommended."@en ;
+    skos:definition "A group name for intrusive lithologies composed chiefly of one or more felsic minerals (e.g. containing modal quartz, feldspar and feldspathoids), with modal content of mafic and related minerals (M) less than 90%, where M represents the volume modal percentage of mafic and related minerals (Le Maitre et al., 2005, p. 4). Previous GSWA usage of 'igneous granitic' is not recommended."@en ;
     skos:historyNote "Based on the IUGS classification of igneous rocks (Le Maitre et al., 2005) and GSWA usage." ;
     skos:inScheme cs: ;
     skos:narrower

--- a/vocabularies/GSWA-vocabulary-themes.ttl
+++ b/vocabularies/GSWA-vocabulary-themes.ttl
@@ -122,10 +122,10 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     schema:citation "https://www.eia.gov/energyexplained/us-energy-facts/"^^xsd:anyURI ;
 .
 
-<https://linked.data.g​ov.au/org/gswa>
+<https://linked.data.gov.au/org/gswa>
     a schema:Organization ;
-    schema:name "Gswa" ;
-    schema:url ""^^xsd:anyURI ;
+    schema:name "Geological Survey of Western Australia" ;
+    schema:url "https://dmp.wa.gov.au/Geological-Survey/Geological-Survey-262.aspx"^^xsd:anyURI ;
 .
 
 :resources
@@ -191,9 +191,9 @@ cs:
                     schema:name "Angela Riganti" ;
                 ] ;
         ] ;
-    schema:creator <https://linked.data.g​ov.au/org/gswa> ;
+    schema:creator <https://linked.data.gov.au/org/gswa> ;
     schema:dateCreated "2024-06-06"^^xsd:date ;
     schema:dateModified "2024-07-12"^^xsd:date ;
-    schema:publisher <https://linked.data.g​ov.au/org/gswa> ;
+    schema:publisher <https://linked.data.gov.au/org/gswa> ;
     schema:version "1" ;
 .

--- a/vocabularies/Geoscience-units-of-measurement.ttl
+++ b/vocabularies/Geoscience-units-of-measurement.ttl
@@ -311,7 +311,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy <http://linked.data.gov.au/def/geou> ;
     skos:altLabel "g_kg"@en ;
-    skos:definition "Grams per kilogram (g/kg) is a measure of concentration. The number of grams of a material of interest within the mass of 1 kg of total material."@en ;
+    skos:definition "Grams per kilogram (g/kg) is a measure of concentration. The number of grams of a material of interest within the mass of 1 kg of total material."@en ;
     skos:inScheme cs: ;
     skos:notation "g/kg"^^xsd:token ;
     skos:prefLabel "grams per kilogram"@en ;
@@ -382,7 +382,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:altLabel
         "h_ft"@en ,
         "hr/ft"@en ;
-    skos:definition "An imperial unit for linear velocity. Used in borehole drilling to describe the rate of penetration and describes the number of hours taken to penetrate 1 ft of material."@en ;
+    skos:definition "An imperial unit for linear velocity. Used in borehole drilling to describe the rate of penetration and describes the number of hours taken to penetrate 1 ft of material."@en ;
     skos:inScheme cs: ;
     skos:notation "h/ft"^^xsd:token ;
     skos:prefLabel "hours per foot"@en ;
@@ -396,7 +396,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:altLabel
         "h_m"@en ,
         "hr/m"@en ;
-    skos:definition "A unit for linear velocity. Used in borehole drilling to describe the rate of penetration and describes the number of hours taken to penetrate 1 m of material."@en ;
+    skos:definition "A unit for linear velocity. Used in borehole drilling to describe the rate of penetration and describes the number of hours taken to penetrate 1 m of material."@en ;
     skos:inScheme cs: ;
     skos:notation "h/m"^^xsd:token ;
     skos:prefLabel "hours per metre"@en ;
@@ -448,7 +448,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:altLabel
         "MBTU_Ml"@en ,
         "kBTU/ML"@en ;
-    skos:definition "A measure of oil quality or energy density defined as the energy in 1000 BTU (British Thermal Units; 1 055 000 J) per million litres."@en ;
+    skos:definition "A measure of oil quality or energy density defined as the energy in 1000 BTU (British Thermal Units; 1 055 000 J) per million litres."@en ;
     skos:inScheme cs: ;
     skos:notation "MBTU/Ml"^^xsd:token ;
     skos:prefLabel "thousand British thermal units per megalitre"@en ;
@@ -513,7 +513,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         "l_50 kg"@en ;
     skos:definition "A proportional concentration ratio typically used for cement mixtures. The number of litres of water added to 50 kg of additive(s)."@en ;
     skos:inScheme cs: ;
-    skos:notation "l/50 kg"^^xsd:token ;
+    skos:notation "l/50 kg"^^xsd:token ;
     skos:prefLabel "litres per 50 kg sack"@en ;
     skos:topConceptOf cs: ;
     schema:citation "http://linked.data.gov.au/def/geou/L-PER-50SACK"^^xsd:anyURI ;
@@ -538,10 +538,10 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <http://linked.data.gov.au/def/geou/LB_F-PER-100FT2>
     a skos:Concept ;
     rdfs:isDefinedBy <http://linked.data.gov.au/def/geou> ;
-    skos:altLabel "lbf_100 ft²"@en ;
-    skos:definition "Pounds force per 100 square feet (lbf/100 ft²) is a British (imperial) and US pressure unit. The number of pounds force applied to an area of 100 ft²."@en ;
+    skos:altLabel "lbf_100 ft²"@en ;
+    skos:definition "Pounds force per 100 square feet (lbf/100 ft²) is a British (imperial) and US pressure unit. The number of pounds force applied to an area of 100 ft²."@en ;
     skos:inScheme cs: ;
-    skos:notation "lbf/100 ft²"^^xsd:token ;
+    skos:notation "lbf/100 ft²"^^xsd:token ;
     skos:prefLabel "pounds force per 100 square feet"@en ;
     skos:topConceptOf cs: ;
     schema:citation "http://linked.data.gov.au/def/geou/LB_F-PER-100FT2"^^xsd:anyURI ;
@@ -565,10 +565,10 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <http://linked.data.gov.au/def/geou/LB_M-PER-100FT2>
     a skos:Concept ;
     rdfs:isDefinedBy <http://linked.data.gov.au/def/geou> ;
-    skos:altLabel "lb_100 ft²"@en ;
-    skos:definition "Pounds per 100 square feet (lb/100 ft²) is a British (imperial) and US pressure unit. The force equivalent to the number of pounds mass under standard gravity conditions applied to an area of 100 ft²."@en ;
+    skos:altLabel "lb_100 ft²"@en ;
+    skos:definition "Pounds per 100 square feet (lb/100 ft²) is a British (imperial) and US pressure unit. The force equivalent to the number of pounds mass under standard gravity conditions applied to an area of 100 ft²."@en ;
     skos:inScheme cs: ;
-    skos:notation "lb/100 ft²"^^xsd:token ;
+    skos:notation "lb/100 ft²"^^xsd:token ;
     skos:prefLabel "pounds per 100 square feet"@en ;
     skos:topConceptOf cs: ;
     schema:citation "http://linked.data.gov.au/def/geou/LB_M-PER-100FT2"^^xsd:anyURI ;
@@ -580,9 +580,9 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:altLabel
         "lb/50kg"@en ,
         "lb_50 kg"@en ;
-    skos:definition "A proportional concentration ratio typically used for cement mixtures. The number of pounds of water added to 50 kg of additive(s)."@en ;
+    skos:definition "A proportional concentration ratio typically used for cement mixtures. The number of pounds of water added to 50 kg of additive(s)."@en ;
     skos:inScheme cs: ;
-    skos:notation "lb/50 kg"^^xsd:token ;
+    skos:notation "lb/50 kg"^^xsd:token ;
     skos:prefLabel "pounds per 50 kg sack"@en ;
     skos:topConceptOf cs: ;
     schema:citation "http://linked.data.gov.au/def/geou/LB_M-PER-50SAC"^^xsd:anyURI ;
@@ -692,7 +692,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:altLabel
         "MMBTU/ML"@en ,
         "MMBTU_Ml"@en ;
-    skos:definition "A measure of oil quality or energy density defined as the energy in 1 000 000 British thermal units (BTU) (1 055 000 000 J) per million litres."@en ;
+    skos:definition "A measure of oil quality or energy density defined as the energy in 1 000 000 British thermal units (BTU) (1 055 000 000 J) per million litres."@en ;
     skos:inScheme cs: ;
     skos:notation "MMBTU/Ml"^^xsd:token ;
     skos:prefLabel "million British thermal units per megalitre"@en ;
@@ -770,7 +770,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <http://linked.data.gov.au/def/geou/MilliD>
     a skos:Concept ;
     rdfs:isDefinedBy <http://linked.data.gov.au/def/geou> ;
-    skos:definition "A measure of permeability. A medium with a permeability of 1 millidarcy (mD) permits a flow of 0.001 cm³/s of a fluid with viscosity 1 cP (1 mPa·s) under a pressure gradient of 1 atm/cm acting across an area of 1 cm²."@en ;
+    skos:definition "A measure of permeability. A medium with a permeability of 1 millidarcy (mD) permits a flow of 0.001 cm³/s of a fluid with viscosity 1 cP (1 mPa·s) under a pressure gradient of 1 atm/cm acting across an area of 1 cm²."@en ;
     skos:inScheme cs: ;
     skos:notation "md"^^xsd:token ;
     skos:prefLabel "millidarcy"@en ;
@@ -1006,7 +1006,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         "MOA"@en ,
         "minute arc"@en ,
         "minute of arc"@en ;
-    skos:definition "A minute of arc, arcminute, or minute arc (MOA), is a unit of angular measurement equal to one sixtieth (1/60) of one degree (circle/21 600), or π/10 800 radians. In turn, a second of arc or arcsecond is one sixtieth (1/60) of one minute of arc. Since one degree is defined as one three hundred and sixtieth (1/360) of a rotation, one minute of arc is 1/21 600 of a rotation. Prime (') is the symbol for the arcminute."@en ;
+    skos:definition "A minute of arc, arcminute, or minute arc (MOA), is a unit of angular measurement equal to one sixtieth (1/60) of one degree (circle/21 600), or π/10 800 radians. In turn, a second of arc or arcsecond is one sixtieth (1/60) of one minute of arc. Since one degree is defined as one three hundred and sixtieth (1/360) of a rotation, one minute of arc is 1/21 600 of a rotation. Prime (') is the symbol for the arcminute."@en ;
     skos:inScheme cs: ;
     skos:notation "'"^^<https://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
     skos:prefLabel "arcminute"@en ;
@@ -1020,7 +1020,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:altLabel
         "ARCSEC"@en ,
         "second of arc"@en ;
-    skos:definition "Arcsecond is a unit of angular measure, also called the second of arc, equal to 1/60 arcminute. One arcsecond is a very small angle: there are 1 296 000 in a circle. The International System of Units (SI) recommends double prime (ʺ) as the symbol for the arcsecond. The symbol has become common in astronomy, where very small angles are stated in milliarcseconds (mas)."@en ;
+    skos:definition "Arcsecond is a unit of angular measure, also called the second of arc, equal to 1/60 arcminute. One arcsecond is a very small angle: there are 1 296 000 in a circle. The International System of Units (SI) recommends double prime (ʺ) as the symbol for the arcsecond. The symbol has become common in astronomy, where very small angles are stated in milliarcseconds (mas)."@en ;
     skos:inScheme cs: ;
     skos:notation "\""^^<https://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
     skos:prefLabel "arcsecond"@en ;
@@ -1031,7 +1031,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <http://qudt.org/vocab/unit/ATM>
     a skos:Concept ;
     rdfs:isDefinedBy <http://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
-    skos:definition "The standard atmosphere (atm) is an international reference pressure defined as 101.325 kPa and formerly used as unit of pressure. For practical purposes it has been replaced by the bar which is 100 kPa. The difference of about 1% is not significant for many applications, and is within the error range of common pressure gauges."@en ;
+    skos:definition "The standard atmosphere (atm) is an international reference pressure defined as 101.325 kPa and formerly used as unit of pressure. For practical purposes it has been replaced by the bar which is 100 kPa. The difference of about 1% is not significant for many applications, and is within the error range of common pressure gauges."@en ;
     skos:inScheme cs: ;
     skos:notation "atm"^^<https://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
     skos:prefLabel "standard atmosphere"@en ;
@@ -1043,10 +1043,10 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy <https://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
     skos:altLabel
-        "a. u"@en ,
+        "a. u"@en ,
         "au"@en ,
         "ua"@en ;
-    skos:definition "An astronomical unit, abbreviated as AU, au, a. u, or ua is a unit of length equal to 149,597,870,700 m (92,955,807.273 mi) or approximately the mean Earth–Sun distance."@en ;
+    skos:definition "An astronomical unit, abbreviated as AU, au, a. u, or ua is a unit of length equal to 149,597,870,700 m (92,955,807.273 mi) or approximately the mean Earth–Sun distance."@en ;
     skos:inScheme cs: ;
     skos:notation "AU"^^xsd:token ;
     skos:prefLabel "astronomical unit"@en ;
@@ -1057,7 +1057,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <http://qudt.org/vocab/unit/BAR>
     a skos:Concept ;
     rdfs:isDefinedBy <https://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
-    skos:definition "The bar is a non-International System of Units (SI) unit of pressure, defined by the International Union of Pure and Applied Chemistry (IUPAC) as exactly equal to 100 000 Pa. It is about equal to the atmospheric pressure on Earth at sea level, and since 1982 the IUPAC has recommended that the standard for atmospheric pressure should be harmonized to 100 000 Pa = 1 bar ≈ 750.0616827 Torr. Units derived from the bar are the megabar (Mbar), kilobar (kbar), decibar (dbar), centibar (cbar) and millibar (mbar or mb). They are not part of either the SI or Centimetre–Gram–Second (CGS) system of units, but they are accepted for use with the SI."@en ;
+    skos:definition "The bar is a non-International System of Units (SI) unit of pressure, defined by the International Union of Pure and Applied Chemistry (IUPAC) as exactly equal to 100 000 Pa. It is about equal to the atmospheric pressure on Earth at sea level, and since 1982 the IUPAC has recommended that the standard for atmospheric pressure should be harmonized to 100 000 Pa = 1 bar ≈ 750.0616827 Torr. Units derived from the bar are the megabar (Mbar), kilobar (kbar), decibar (dbar), centibar (cbar) and millibar (mbar or mb). They are not part of either the SI or Centimetre–Gram–Second (CGS) system of units, but they are accepted for use with the SI."@en ;
     skos:inScheme cs: ;
     skos:notation "bar"^^<https://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
     skos:prefLabel "bar"@en ;
@@ -1080,7 +1080,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <http://qudt.org/vocab/unit/BIT>
     a skos:Concept ;
     skos:altLabel "bit"@en ;
-    skos:definition "The bit is the most basic unit of information in computing and digital communications, representing the capacity of data storage systems or communication channels. The name is a portmanteau of binary digit. A byte corresponds to 8 bits. Terms for large quantities of bits can be formed using the standard range of SI prefixes for powers of 10, e.g., kilo = 10³ = 1000 (as in kilobit or kbit), mega = 10⁶ = 1 000 000 (as in megabit or Mbit) and giga = 10⁹ = 1 000 000 000 (as in gigabit or Gbit). These prefixes are more often used for multiples of bytes, as in kilobyte (1 kB = 8000 bit), megabyte (1 MB = 8 000 000 bit), and gigabyte (1 GB = 8 000 000 000 bit)."@en ;
+    skos:definition "The bit is the most basic unit of information in computing and digital communications, representing the capacity of data storage systems or communication channels. The name is a portmanteau of binary digit. A byte corresponds to 8 bits. Terms for large quantities of bits can be formed using the standard range of SI prefixes for powers of 10, e.g., kilo = 10³ = 1000 (as in kilobit or kbit), mega = 10⁶ = 1 000 000 (as in megabit or Mbit) and giga = 10⁹ = 1 000 000 000 (as in gigabit or Gbit). These prefixes are more often used for multiples of bytes, as in kilobyte (1 kB = 8000 bit), megabyte (1 MB = 8 000 000 bit), and gigabyte (1 GB = 8 000 000 000 bit)."@en ;
     skos:inScheme cs: ;
     skos:notation "b"^^<https://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
     skos:prefLabel "bit"@en ;
@@ -1154,7 +1154,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         "carat"@en ,
         "carats"@en ,
         "cts"@en ;
-    skos:definition "The carat is a unit of mass equal to 200 mg (0.2 g) and is used for measuring gemstones and pearls. The current definition, sometimes known as the metric carat, was adopted in 1907 at the Fourth General Conference on Weights and Measures, and soon afterward in many countries around the world. The carat is divisible into one hundred points of 2 mg each. Other subdivisions, and slightly different mass values, have been used in the past in different locations. In terms of diamonds, a paragon is a flawless stone of at least 100 carats (20 g). The ANSI X.12 EDI standard abbreviation for the carat is CD."@en ;
+    skos:definition "The carat is a unit of mass equal to 200 mg (0.2 g) and is used for measuring gemstones and pearls. The current definition, sometimes known as the metric carat, was adopted in 1907 at the Fourth General Conference on Weights and Measures, and soon afterward in many countries around the world. The carat is divisible into one hundred points of 2 mg each. Other subdivisions, and slightly different mass values, have been used in the past in different locations. In terms of diamonds, a paragon is a flawless stone of at least 100 carats (20 g). The ANSI X.12 EDI standard abbreviation for the carat is CD."@en ;
     skos:inScheme cs: ;
     skos:notation "ct"^^<https://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
     skos:prefLabel "carat"@en ;
@@ -1195,7 +1195,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:altLabel
         "CM2"@en ,
         "square centimeter"@en ;
-    skos:definition "A unit of area equal to that of a square of sides 1 cm."@en ;
+    skos:definition "A unit of area equal to that of a square of sides 1 cm."@en ;
     skos:inScheme cs: ;
     skos:notation "cm²"^^<https://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
     skos:prefLabel "square centimetre"@en ;
@@ -1233,7 +1233,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <http://qudt.org/vocab/unit/Ci>
     a skos:Concept ;
     rdfs:isDefinedBy <http://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
-    skos:definition "The curie (symbol Ci) is a non-International System of Units (SI) unit of radioactivity, named after Marie and Pierre Curie. It is defined as 1 Ci = 3.7 × 10¹⁰ decays per second. Its continued use is discouraged. One curie is roughly the activity of 1 gram of the radium isotope Ra, a substance studied by the Curies. The SI derived unit of radioactivity is the becquerel (Bq), which equates to one decay per second. Therefore: 1 Ci = 3.7 × 10¹⁰ Bq and 1 Bq = 2.703 × 10⁻¹¹ Ci."@en ;
+    skos:definition "The curie (symbol Ci) is a non-International System of Units (SI) unit of radioactivity, named after Marie and Pierre Curie. It is defined as 1 Ci = 3.7 × 10¹⁰ decays per second. Its continued use is discouraged. One curie is roughly the activity of 1 gram of the radium isotope Ra, a substance studied by the Curies. The SI derived unit of radioactivity is the becquerel (Bq), which equates to one decay per second. Therefore: 1 Ci = 3.7 × 10¹⁰ Bq and 1 Bq = 2.703 × 10⁻¹¹ Ci."@en ;
     skos:inScheme cs: ;
     skos:notation "Ci"^^xsd:token ;
     skos:prefLabel "curie"@en ;
@@ -1441,7 +1441,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         "cm/s²"@en ,
         "cm_s²"@en ,
         "gal"@en ;
-    skos:definition "The galileo (or Gal) is the unit of acceleration of free fall used extensively in the science of gravimetry. The galileo is defined as 1 cm/s². Unfortunately, the galileo is often denoted with the symbol Gal, not to be confused with the gallon that also uses the same symbol (gal)."@en ;
+    skos:definition "The galileo (or Gal) is the unit of acceleration of free fall used extensively in the science of gravimetry. The galileo is defined as 1 cm/s². Unfortunately, the galileo is often denoted with the symbol Gal, not to be confused with the gallon that also uses the same symbol (gal)."@en ;
     skos:historyNote "https://en.wikipedia.org/wiki/Gal_(unit)" ;
     skos:inScheme cs: ;
     skos:notation "Gal"^^<https://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
@@ -1586,7 +1586,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy <http://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
     skos:altLabel "gr_UK"@en ;
-    skos:definition "A grain is a unit of measurement of mass that is nominally based upon the mass of a single seed of a cereal. The grain is the only unit of mass measure common to the three traditional English mass and weight systems; the obsolete Tower grain was, by definition, exactly 1/64 of a troy grain. Since 1958, the grain or troy grain measure has been defined in terms of units of mass in the International System of Units (SI) as precisely 64.79891 mg. Thus, 1 gram ≈ 15.4323584 grains. There are precisely 7000 grains per avoirdupois pound in the imperial and US customary units, and 5760 grains in the troy pound."@en ;
+    skos:definition "A grain is a unit of measurement of mass that is nominally based upon the mass of a single seed of a cereal. The grain is the only unit of mass measure common to the three traditional English mass and weight systems; the obsolete Tower grain was, by definition, exactly 1/64 of a troy grain. Since 1958, the grain or troy grain measure has been defined in terms of units of mass in the International System of Units (SI) as precisely 64.79891 mg. Thus, 1 gram ≈ 15.4323584 grains. There are precisely 7000 grains per avoirdupois pound in the imperial and US customary units, and 5760 grains in the troy pound."@en ;
     skos:inScheme cs: ;
     skos:notation "gr{UK}"^^<https://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
     skos:prefLabel "grain"@en ;
@@ -1620,7 +1620,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <http://qudt.org/vocab/unit/GigaBYTE>
     a skos:Concept ;
     rdfs:isDefinedBy <http://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
-    skos:definition "The gigabyte is a multiple of the unit byte for digital information storage. The prefix giga means 10⁹ in the International System of Units (SI), therefore 1 GB is 1 000 000 000 B. The unit symbol for the gigabyte is GB or Gbyte, but not Gb (lowercase b) which is typically used for the gigabit. Historically, the term has also been used in some fields of computer science and information technology to denote the gibibyte, or 1073741824 B."@en ;
+    skos:definition "The gigabyte is a multiple of the unit byte for digital information storage. The prefix giga means 10⁹ in the International System of Units (SI), therefore 1 GB is 1 000 000 000 B. The unit symbol for the gigabyte is GB or Gbyte, but not Gb (lowercase b) which is typically used for the gigabit. Historically, the term has also been used in some fields of computer science and information technology to denote the gibibyte, or 1073741824 B."@en ;
     skos:inScheme cs: ;
     skos:notation "GB"^^<https://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
     skos:prefLabel "gigabyte"@en ;
@@ -1631,7 +1631,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <http://qudt.org/vocab/unit/GigaPA>
     a skos:Concept ;
     rdfs:isDefinedBy <http://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
-    skos:definition "1 000 000 000-fold of the International System of Units (SI) derived unit pascal."@en ;
+    skos:definition "1 000 000 000-fold of the International System of Units (SI) derived unit pascal."@en ;
     skos:inScheme cs: ;
     skos:notation "GPa"^^<https://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
     skos:prefLabel "gigapascal"@en ;
@@ -1679,7 +1679,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <http://qudt.org/vocab/unit/IN>
     a skos:Concept ;
     rdfs:isDefinedBy <http://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
-    skos:definition "An inch (in) is the name of a unit of length in a number of different systems, including imperial units, and US customary units. There are 36 in in a yard and 12 in in a foot, and 1 in equals 25.4 mm. The difference between a US customary inch and an imperial inch is insignificant for most applications (the accepted value of 25.4 mm is 1.7 millionths of an inch longer than the old imperial inch and 2 millionths of an inch shorter than the old US inch). Corresponding units of area and volume are the square inch and the cubic inch."@en ;
+    skos:definition "An inch (in) is the name of a unit of length in a number of different systems, including imperial units, and US customary units. There are 36 in in a yard and 12 in in a foot, and 1 in equals 25.4 mm. The difference between a US customary inch and an imperial inch is insignificant for most applications (the accepted value of 25.4 mm is 1.7 millionths of an inch longer than the old imperial inch and 2 millionths of an inch shorter than the old US inch). Corresponding units of area and volume are the square inch and the cubic inch."@en ;
     skos:inScheme cs: ;
     skos:notation "in"^^<https://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
     skos:prefLabel "inch"@en ;
@@ -1902,7 +1902,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <http://qudt.org/vocab/unit/KiloPA>
     a skos:Concept ;
     rdfs:isDefinedBy <http://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
-    skos:definition "Kilopascal (kPa) is a unit of pressure. 1 kPa is approximately the pressure exerted by a 10 g mass resting on a 1 cm² area. 101.3 kPa = 1 atm. There are 1000 Pa in 1 kPa."@en ;
+    skos:definition "Kilopascal (kPa) is a unit of pressure. 1 kPa is approximately the pressure exerted by a 10 g mass resting on a 1 cm² area. 101.3 kPa = 1 atm. There are 1000 Pa in 1 kPa."@en ;
     skos:inScheme cs: ;
     skos:notation "kPa"^^<https://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
     skos:prefLabel "kilopascal"@en ;
@@ -2116,7 +2116,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         "m/s²"@en ,
         "metre per second squared"@en ,
         "ms⁻²"@en ;
-    skos:definition "Metre per square second is the unit of acceleration in the International System of Units (SI). As a derived unit it is composed from the SI base units of length, the metre, and the standard unit of time, the second. Its symbol is written in several forms as m/s², or ms⁻². As acceleration, the unit is interpreted physically as change in velocity or speed per time interval, that is, metre per second per second."@en ;
+    skos:definition "Metre per square second is the unit of acceleration in the International System of Units (SI). As a derived unit it is composed from the SI base units of length, the metre, and the standard unit of time, the second. Its symbol is written in several forms as m/s², or ms⁻². As acceleration, the unit is interpreted physically as change in velocity or speed per time interval, that is, metre per second per second."@en ;
     skos:inScheme cs: ;
     skos:notation "m/s2"^^<https://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
     skos:prefLabel "metre per square second"@en ;
@@ -2130,7 +2130,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:altLabel
         "M2"@en ,
         "square meter"@en ;
-    skos:definition "The International System of Units (SI) unit of area is the square metre. A unit of area equal to that of a square of sides 1 m."@en ;
+    skos:definition "The International System of Units (SI) unit of area is the square metre. A unit of area equal to that of a square of sides 1 m."@en ;
     skos:inScheme cs: ;
     skos:notation "m²"^^<https://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
     skos:prefLabel "square metre"@en ;
@@ -2215,7 +2215,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         "MILE2"@en ,
         "sq mi"@en ,
         "square imperial mile"@en ;
-    skos:definition "The square mile is an imperial and US unit of measure for an area equal to the area of a square of one statute mile. It should not be confused with miles square, which refers to the number of miles on each side squared. For instance, 20 miles square (20 × 20 mi) is equal to 400 square miles. One square mile is equivalent to: 4 014 489 600 in², 27 878 400 ft², 3 097 600 yd², 640 acres, 258.9988110336 ha, 2560 roods, 25 899 881 103.36 cm², 2 589 988.110336 m², 2.589988110336 km². When applied to a portion of the Earth's surface, which is curved rather than flat, 'square mile' is an informal synonym for section."@en ;
+    skos:definition "The square mile is an imperial and US unit of measure for an area equal to the area of a square of one statute mile. It should not be confused with miles square, which refers to the number of miles on each side squared. For instance, 20 miles square (20 × 20 mi) is equal to 400 square miles. One square mile is equivalent to: 4 014 489 600 in², 27 878 400 ft², 3 097 600 yd², 640 acres, 258.9988110336 ha, 2560 roods, 25 899 881 103.36 cm², 2 589 988.110336 m², 2.589988110336 km². When applied to a portion of the Earth's surface, which is curved rather than flat, 'square mile' is an informal synonym for section."@en ;
     skos:inScheme cs: ;
     skos:notation "mi²"^^<https://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
     skos:prefLabel "square mile"@en ;
@@ -2285,7 +2285,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <http://qudt.org/vocab/unit/MegaJ>
     a skos:Concept ;
     rdfs:isDefinedBy <http://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
-    skos:definition "The megajoule (MJ) is a multiple of the unit joule (J), the unit of energy in the International System of Units (SI), equivalent to one million or 10⁶ joules. Also defined as 1 000 000-fold of the derived unit joule."@en ;
+    skos:definition "The megajoule (MJ) is a multiple of the unit joule (J), the unit of energy in the International System of Units (SI), equivalent to one million or 10⁶ joules. Also defined as 1 000 000-fold of the derived unit joule."@en ;
     skos:inScheme cs: ;
     skos:notation "MJ"^^<https://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
     skos:prefLabel "megajoule"@en ;
@@ -2321,7 +2321,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <http://qudt.org/vocab/unit/MegaPA>
     a skos:Concept ;
     rdfs:isDefinedBy <http://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
-    skos:definition "The megapascal (MPa) is a multiple of the pascal (Pa), the International System of Units (SI) unit of pressure. 1 MPa equals 1 000 000 or 10⁶ pascals. Also defined as 1 000 000-fold of the derived unit pascal."@en ;
+    skos:definition "The megapascal (MPa) is a multiple of the pascal (Pa), the International System of Units (SI) unit of pressure. 1 MPa equals 1 000 000 or 10⁶ pascals. Also defined as 1 000 000-fold of the derived unit pascal."@en ;
     skos:inScheme cs: ;
     skos:notation "MPa"^^<https://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
     skos:prefLabel "megapascal"@en ;
@@ -2539,7 +2539,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         "millimeters"@en ,
         "millimetres"@en ,
         "mmtr"@en ;
-    skos:definition "The millimetre (mm) is a unit of length in the metric system, equal to one thousandth of a metre, which is the International System of Units (SI) base unit of length. It is equal to 1000 µm or 1 000 000 nm. A millimetre is equal to exactly  5/127 (approximately 0.039370) of an inch."@en ;
+    skos:definition "The millimetre (mm) is a unit of length in the metric system, equal to one thousandth of a metre, which is the International System of Units (SI) base unit of length. It is equal to 1000 µm or 1 000 000 nm. A millimetre is equal to exactly  5/127 (approximately 0.039370) of an inch."@en ;
     skos:inScheme cs: ;
     skos:notation "mm"^^<https://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
     skos:prefLabel "millimetre"@en ;
@@ -2553,7 +2553,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:altLabel
         "MM2"@en ,
         "square millimeter"@en ;
-    skos:definition "A unit of area equal to that of a square of sides 1 mm."@en ;
+    skos:definition "A unit of area equal to that of a square of sides 1 mm."@en ;
     skos:inScheme cs: ;
     skos:notation "mm²"^^<https://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
     skos:prefLabel "square millimetre"@en ;
@@ -2726,7 +2726,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <http://qudt.org/vocab/unit/NanoSEC>
     a skos:Concept ;
     rdfs:isDefinedBy <http://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
-    skos:definition "A nanosecond is an International System of Units (SI) unit of time equal to one-billionth of one second (10⁻⁹ or 1/1 000 000 000 s). One nanosecond is to one second as one second is to 31.69 years."@en ;
+    skos:definition "A nanosecond is an International System of Units (SI) unit of time equal to one-billionth of one second (10⁻⁹ or 1/1 000 000 000 s). One nanosecond is to one second as one second is to 31.69 years."@en ;
     skos:inScheme cs: ;
     skos:notation "ns"^^<https://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
     skos:prefLabel "nanosecond"@en ;
@@ -2810,7 +2810,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:altLabel
         "OZ-TR"@en ,
         "oz{troy}"@en ,
-        "oz t"@en ;
+        "oz t"@en ;
     skos:definition "The troy ounce is an obsolete metric used in weighing precious metals. The troy ounce is 1/12th of a troy pound. Based on the international definition of a troy pound as 5760 grains, the troy ounce is exactly 480 grains, or 0.0311034768 kg (or 31.1034768 g)."@en ;
     skos:inScheme cs: ;
     skos:notation "oz{troy}"^^<https://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
@@ -2974,7 +2974,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <http://qudt.org/vocab/unit/PetaBYTE>
     a skos:Concept ;
     rdfs:isDefinedBy <http://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
-    skos:definition "A petabyte (PB) is a unit of information equal to one quadrillion bytes, or 10²⁴ TB. The prefix peta (P) indicates the fifth power to 1000: 1 PB = 1 000 000 000 000 000 B, 1 000 000 GB = 1000 TB. The pebibyte (PiB), using a binary prefix, is the corresponding power of 10²⁴, which is more than 12% greater (2⁵⁰ B = 1 125 899 906 842 624 B)."@en ;
+    skos:definition "A petabyte (PB) is a unit of information equal to one quadrillion bytes, or 10²⁴ TB. The prefix peta (P) indicates the fifth power to 1000: 1 PB = 1 000 000 000 000 000 B, 1 000 000 GB = 1000 TB. The pebibyte (PiB), using a binary prefix, is the corresponding power of 10²⁴, which is more than 12% greater (2⁵⁰ B = 1 125 899 906 842 624 B)."@en ;
     skos:inScheme cs: ;
     skos:notation "PB"^^<https://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
     skos:prefLabel "petabyte"@en ;
@@ -2985,7 +2985,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <http://qudt.org/vocab/unit/PetaJ>
     a skos:Concept ;
     rdfs:isDefinedBy <http://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
-    skos:definition "The petajoule (PJ) is equal to one quadrillion (10¹⁵) joules. 210 PJ is about 50 megatons of TNT (trinitrotoluene) which is the amount of energy released by the Tsar Bomba, the largest man-made explosion ever. Also defined as the 1 000 000 000 000 000-fold of the derived International System of Units (SI) unit joule."@en ;
+    skos:definition "The petajoule (PJ) is equal to one quadrillion (10¹⁵) joules. 210 PJ is about 50 megatons of TNT (trinitrotoluene) which is the amount of energy released by the Tsar Bomba, the largest man-made explosion ever. Also defined as the 1 000 000 000 000 000-fold of the derived International System of Units (SI) unit joule."@en ;
     skos:inScheme cs: ;
     skos:notation "PJ"^^<https://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
     skos:prefLabel "petajoule"@en ;
@@ -2996,7 +2996,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <http://qudt.org/vocab/unit/R>
     a skos:Concept ;
     rdfs:isDefinedBy <http://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
-    skos:definition "Not to be confused with roentgen equivalent man or roentgen equivalent physical. The roentgen (symbol R) is an obsolete unit of measurement for the kerma of X-rays and gamma rays up to 3 MeV."@en ;
+    skos:definition "Not to be confused with roentgen equivalent man or roentgen equivalent physical. The roentgen (symbol R) is an obsolete unit of measurement for the kerma of X-rays and gamma rays up to 3 MeV."@en ;
     skos:inScheme cs: ;
     skos:notation "R"^^<http://qudt.org/vocab/unit/R> ;
     skos:prefLabel "roentgen"@en ;
@@ -3020,7 +3020,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <http://qudt.org/vocab/unit/RAD_R>
     a skos:Concept ;
     rdfs:isDefinedBy <http://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
-    skos:definition "The rad is a deprecated unit of absorbed radiation dose, defined as 1 rad = 0.01 Gy = 0.01 J/kg. It was originally defined in CGS units in 1953 as the dose causing 100 ergs of energy to be absorbed by one gram of matter. It has been replaced by the gray in most of the world. A related unit, the roentgen, was formerly used to quantify the number of rad deposited into a target when it was exposed to radiation. The F-factor can used to convert between rad and roentgens. The material absorbing the radiation can be human tissue or silicon microchips or any other medium (for example, air, water, lead shielding, etc.)."@en ;
+    skos:definition "The rad is a deprecated unit of absorbed radiation dose, defined as 1 rad = 0.01 Gy = 0.01 J/kg. It was originally defined in CGS units in 1953 as the dose causing 100 ergs of energy to be absorbed by one gram of matter. It has been replaced by the gray in most of the world. A related unit, the roentgen, was formerly used to quantify the number of rad deposited into a target when it was exposed to radiation. The F-factor can used to convert between rad and roentgens. The material absorbing the radiation can be human tissue or silicon microchips or any other medium (for example, air, water, lead shielding, etc.)."@en ;
     skos:inScheme cs: ;
     skos:notation "RAD_R"^^<http://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
     skos:prefLabel "rad"@en ;
@@ -3031,7 +3031,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <http://qudt.org/vocab/unit/REM>
     a skos:Concept ;
     rdfs:isDefinedBy <http://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
-    skos:definition "A rem is a deprecated unit used to measure the biological effects of ionizing radiation. The rem is defined as equal to 0.01 sievert, which is the more commonly used unit outside of the United States. Equivalent dose, effective dose and committed dose can all be measured in units of rem. These quantities are products of the absorbed dose in rads and weighting factors. These factors must be selected for each exposure situation; there is no universally applicable conversion constant from rad to rem. A rem is a large dose of radiation, so the millirem (mrem), which is one thousandth of a rem, is often used for the dosages commonly encountered, such as the amount of radiation received from medical x-rays and background sources."@en ;
+    skos:definition "A rem is a deprecated unit used to measure the biological effects of ionizing radiation. The rem is defined as equal to 0.01 sievert, which is the more commonly used unit outside of the United States. Equivalent dose, effective dose and committed dose can all be measured in units of rem. These quantities are products of the absorbed dose in rads and weighting factors. These factors must be selected for each exposure situation; there is no universally applicable conversion constant from rad to rem. A rem is a large dose of radiation, so the millirem (mrem), which is one thousandth of a rem, is often used for the dosages commonly encountered, such as the amount of radiation received from medical x-rays and background sources."@en ;
     skos:inScheme cs: ;
     skos:notation "REM"^^<http://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
     skos:prefLabel "rem"@en ;
@@ -3119,7 +3119,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy <http://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
     skos:altLabel "toe"@en ;
-    skos:definition "The tonne of oil equivalent (toe) is a unit of energy: the amount of energy released by burning 1 t of crude oil, approximately 42 GJ (as different crude oils have different calorific values, the exact value of the toe is defined by convention; unfortunately there are several slightly different definitions). The toe is sometimes used for large amounts of energy, as it can be more intuitive to visualise, say, the energy released by burning 1000 t of oil than 42 000 billion joules (the International System of Units [SI] unit of energy)."@en ;
+    skos:definition "The tonne of oil equivalent (toe) is a unit of energy: the amount of energy released by burning 1 t of crude oil, approximately 42 GJ (as different crude oils have different calorific values, the exact value of the toe is defined by convention; unfortunately there are several slightly different definitions). The toe is sometimes used for large amounts of energy, as it can be more intuitive to visualise, say, the energy released by burning 1000 t of oil than 42 000 billion joules (the International System of Units [SI] unit of energy)."@en ;
     skos:inScheme cs: ;
     skos:notation "TOE"^^<https://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
     skos:prefLabel "tonne of oil equivalent"@en ;
@@ -3203,7 +3203,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy <http://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
     skos:altLabel "Tbyte"@en ;
-    skos:definition "The terabyte (TB) is a multiple of the unit byte for digital information. The prefix tera means 10¹² in the International System of Units (SI), and therefore 1 TB is 1 000 000 000 000 B (1 trillion bytes) or 1000 GB. 1 TB in binary prefixes is 0.9095 tebibytes, or 931.32 gibibytes. The unit symbol for the terabyte is TB or TByte, but not Tb (lowercase b) which refers to terabit."@en ;
+    skos:definition "The terabyte (TB) is a multiple of the unit byte for digital information. The prefix tera means 10¹² in the International System of Units (SI), and therefore 1 TB is 1 000 000 000 000 B (1 trillion bytes) or 1000 GB. 1 TB in binary prefixes is 0.9095 tebibytes, or 931.32 gibibytes. The unit symbol for the terabyte is TB or TByte, but not Tb (lowercase b) which refers to terabit."@en ;
     skos:inScheme cs: ;
     skos:notation "TB"^^<https://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
     skos:prefLabel "terabyte"@en ;
@@ -3214,7 +3214,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 <http://qudt.org/vocab/unit/TeraJ>
     a skos:Concept ;
     rdfs:isDefinedBy <http://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
-    skos:definition "The terajoule is a multiple of the unit joule, the unit of energy in the International System of Units (SI), equivalent to 1 000 000 000 000 or 10¹² J. Also defined as 1 000 000 000 000-fold of the SI derived unit joule."@en ;
+    skos:definition "The terajoule is a multiple of the unit joule, the unit of energy in the International System of Units (SI), equivalent to 1 000 000 000 000 or 10¹² J. Also defined as 1 000 000 000 000-fold of the SI derived unit joule."@en ;
     skos:inScheme cs: ;
     skos:notation "TJ"^^<https://www.qudt.org/doc/DOC_VOCAB-UNITS.html> ;
     skos:prefLabel "terajoule"@en ;
@@ -3579,7 +3579,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 :KiloCARAT
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
-    skos:definition "A multiple of the unit carat (ct). Equal to 1000 carats or 10³ carats, and with a mass of 200 g."@en ;
+    skos:definition "A multiple of the unit carat (ct). Equal to 1000 carats or 10³ carats, and with a mass of 200 g."@en ;
     skos:inScheme cs: ;
     skos:notation "kct"^^xsd:token ;
     skos:prefLabel "thousand carats"@en ;
@@ -3615,7 +3615,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:altLabel
         "KM2"@en ,
         "square kilometer"@en ;
-    skos:definition "A unit of area equal to that of a square of sides 1 km."@en ;
+    skos:definition "A unit of area equal to that of a square of sides 1 km."@en ;
     skos:inScheme cs: ;
     skos:notation "km²"^^xsd:token ;
     skos:prefLabel "square kilometre"@en ;
@@ -3650,7 +3650,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:altLabel "lambda"@en ;
-    skos:definition "Longitude degrees are the units of measurement for the angular distance of a place east or west of the International Reference Meridian (IRM, or prime meridian), a specially designated imaginary north–south line that passes through both geographic poles and Greenwich, London. The prime meridian defines 0° longitude. Longitude is measured in degrees, minutes and seconds or in decimal degrees, and corresponds to the amount of arc created by drawing first a line from Earth’s centre to the intersection of the Equator and the prime meridian and then another line from Earth’s centre to any point elsewhere on the Equator. Longitude is measured 180° both east and west of the prime meridian. Longitude angles are usually denoted by the Greek lowercase letter lambda (λ), One degree of latitude covers about 111 km (69 mi) and can be further divided into 60 minutes and 60 seconds. The distance per degree of longitude at the Equator is about 111.32 km (69.18 mi) and at the poles, 0."@en ;
+    skos:definition "Longitude degrees are the units of measurement for the angular distance of a place east or west of the International Reference Meridian (IRM, or prime meridian), a specially designated imaginary north–south line that passes through both geographic poles and Greenwich, London. The prime meridian defines 0° longitude. Longitude is measured in degrees, minutes and seconds or in decimal degrees, and corresponds to the amount of arc created by drawing first a line from Earth’s centre to the intersection of the Equator and the prime meridian and then another line from Earth’s centre to any point elsewhere on the Equator. Longitude is measured 180° both east and west of the prime meridian. Longitude angles are usually denoted by the Greek lowercase letter lambda (λ), One degree of latitude covers about 111 km (69 mi) and can be further divided into 60 minutes and 60 seconds. The distance per degree of longitude at the Equator is about 111.32 km (69.18 mi) and at the poles, 0."@en ;
     skos:inScheme cs: ;
     skos:notation "λ"^^xsd:token ;
     skos:prefLabel "longitude degree"@en ;
@@ -3678,7 +3678,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 :MegaCARAT
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
-    skos:definition "A multiple of the unit carat (ct). Equal to 1 000 000 (or 10⁶) carats, and with a mass of 200 kg."@en ;
+    skos:definition "A multiple of the unit carat (ct). Equal to 1 000 000 (or 10⁶) carats, and with a mass of 200 kg."@en ;
     skos:inScheme cs: ;
     skos:notation "Mct"^^xsd:token ;
     skos:prefLabel "million carats"@en ;
@@ -3720,7 +3720,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         "micrometre per second squared"@en ,
         "µm/s²"@en ,
         "µms⁻²"@en ;
-    skos:definition "The micrometre per square second (µm/s²) is a unit of acceleration and is often called the 'gravity unit'. As acceleration, the unit is interpreted physically as change in velocity or speed per time interval, that is, micrometre per second per second."@en ;
+    skos:definition "The micrometre per square second (µm/s²) is a unit of acceleration and is often called the 'gravity unit'. As acceleration, the unit is interpreted physically as change in velocity or speed per time interval, that is, micrometre per second per second."@en ;
     skos:inScheme cs: ;
     skos:notation "µm/s²"^^xsd:token ;
     skos:prefLabel "micrometre per square second"@en ;
@@ -3766,7 +3766,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         "dose rate"@en ,
         "dose units"@en ,
         "nGy_h"@en ;
-    skos:definition "A measure of radiation dose, expressed as nanograys per hour. The gray (Gy) is an International System of Units (SI) unit for the measurement of radiation exposure, equivalent to the energy 'deposited' in a kilogram of a substance by the radiation. Exposure is also referred to as absorbed dose. The important concept is that exposure is measured by what radiation does to substances, not anything particular about the radiation itself. The gray is a large unit and for normal radiation protection levels a series of prefixes are used: nanogray (nGy) is one billionth of a gray (1/1 000 000 000), microgray (µGy) is one millionth of a gray (1/1 000 000), milligray (mGy) is one thousandth of a gray (1/1000)."@en ;
+    skos:definition "A measure of radiation dose, expressed as nanograys per hour. The gray (Gy) is an International System of Units (SI) unit for the measurement of radiation exposure, equivalent to the energy 'deposited' in a kilogram of a substance by the radiation. Exposure is also referred to as absorbed dose. The important concept is that exposure is measured by what radiation does to substances, not anything particular about the radiation itself. The gray is a large unit and for normal radiation protection levels a series of prefixes are used: nanogray (nGy) is one billionth of a gray (1/1 000 000 000), microgray (µGy) is one millionth of a gray (1/1 000 000), milligray (mGy) is one thousandth of a gray (1/1000)."@en ;
     skos:inScheme cs: ;
     skos:notation "nGy/h"^^xsd:token ;
     skos:prefLabel "nanogray per hour"@en ;
@@ -3781,7 +3781,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         "OZ-TR/TL"@en ,
         "Troy Ounce Per Long Imperial Ton"@en ,
         "oz{troy}_ton"@en ,
-        "oz t/ton"@en ;
+        "oz t/ton"@en ;
     skos:definition "A measure of concentration. The number of troy ounces of a material of interest within the mass of 1 lt of total material."@en ;
     skos:inScheme cs: ;
     skos:notation "oz{troy}/ton"^^xsd:token ;
@@ -3796,7 +3796,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         "OZ-TR/TS"@en ,
         "Troy Ounce Per Short Imperial Ton"@en ,
         "oz{troy}_st"@en ,
-        "oz t/st"@en ;
+        "oz t/st"@en ;
     skos:definition "A measure of concentration. The number of troy ounces of a material of interest within the mass of 1 st of total material."@en ;
     skos:inScheme cs: ;
     skos:notation "oz{troy}/st"^^xsd:token ;
@@ -3824,7 +3824,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:altLabel "phi"@en ;
-    skos:definition "Latitude degrees are the units of measurement for the angular distance of a place north or south of the earth's equator. Lines of constant latitude run east and west, parallel to the equator, and range from 0 degrees at the equator to 90 degrees at the North or South poles. There are different kinds of latitude — geocentric, astronomical, and geographic (or geodetic) — but there are only minor differences between them. In most common references, geodetic latitude is implied. Geodetic latitude is the arc subtended by the equatorial plane and the normal line that can be drawn at a given point on Earth’s surface. It is measured in degrees, minutes and seconds or decimal degrees, north or south of the equator. Geodetic latitude angles are usually denoted by the Greek lowercase letter phi (ϕ or φ), with uppercase N or S to indicate whether the location is in the Northern or Southern hemisphere. One degree of latitude covers about 111 km (69 mi) and can be further divided into 60 minutes and 60 seconds."@en ;
+    skos:definition "Latitude degrees are the units of measurement for the angular distance of a place north or south of the earth's equator. Lines of constant latitude run east and west, parallel to the equator, and range from 0 degrees at the equator to 90 degrees at the North or South poles. There are different kinds of latitude — geocentric, astronomical, and geographic (or geodetic) — but there are only minor differences between them. In most common references, geodetic latitude is implied. Geodetic latitude is the arc subtended by the equatorial plane and the normal line that can be drawn at a given point on Earth’s surface. It is measured in degrees, minutes and seconds or decimal degrees, north or south of the equator. Geodetic latitude angles are usually denoted by the Greek lowercase letter phi (ϕ or φ), with uppercase N or S to indicate whether the location is in the Northern or Southern hemisphere. One degree of latitude covers about 111 km (69 mi) and can be further divided into 60 minutes and 60 seconds."@en ;
     skos:inScheme cs: ;
     skos:notation "ϕ"^^xsd:token ;
     skos:prefLabel "latitude degree"@en ;

--- a/vocabularies/Geoscience-units-of-measurement.ttl
+++ b/vocabularies/Geoscience-units-of-measurement.ttl
@@ -3903,10 +3903,10 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:topConceptOf cs: ;
 .
 
-<https://linked.data.g​ov.au/org/gswa>
+<https://linked.data.gov.au/org/gswa>
     a schema:Organization ;
-    schema:name "Gswa" ;
-    schema:url ""^^xsd:anyURI ;
+    schema:name "Geological Survey of Western Australia" ;
+    schema:url "https://dmp.wa.gov.au/Geological-Survey/Geological-Survey-262.aspx"^^xsd:anyURI ;
 .
 
 cs:
@@ -4233,9 +4233,9 @@ cs:
                     schema:url ""^^xsd:anyURI ;
                 ] ;
         ] ;
-    schema:creator <https://linked.data.g​ov.au/org/gswa> ;
+    schema:creator <https://linked.data.gov.au/org/gswa> ;
     schema:dateCreated "2023-11-01"^^xsd:date ;
     schema:dateModified "2024-04-15"^^xsd:date ;
-    schema:publisher <https://linked.data.g​ov.au/org/gswa> ;
+    schema:publisher <https://linked.data.gov.au/org/gswa> ;
     schema:version "1.2" ;
 .

--- a/vocabularies/borehole-configuration-vertical-depth.ttl
+++ b/vocabularies/borehole-configuration-vertical-depth.ttl
@@ -434,7 +434,7 @@ cs:
         :reduced-level ,
         :seismic-reference-datum ,
         <http://linked.data.gov.au/def/depth-reference/water-bottom> ;
-    skos:historyNote "Derived from [WAPIMS].[dbo].[WellPermanentDatumType], [WAPIMS].[dbo].[BoreholeVerticalReferenceType], and [WAPIMS].[dbo].[WellDepthReferenceType] with additions from the unpublished Geoscience Australia's Depth Reference Type vocabulary. Also refers to Geological Survey of Queensland's Depth Reference vocabulary (https://vocabs.gsq.digital/object?uri=http://linked.data.gov.au/def/depth-reference), with considerably expanded definitions."@en ;
+    skos:historyNote "Derived from [WAPIMS].[dbo].[WellPermanentDatumType], [WAPIMS].[dbo].[BoreholeVerticalReferenceType], and [WAPIMS].[dbo].[WellDepthReferenceType] with additions from the unpublished Geoscience Australia's Depth Reference Type vocabulary. Also refers to Geological Survey of Queensland's Depth Reference vocabulary (http://linked.data.gov.au/def/depth-reference), with considerably expanded definitions."@en ;
     skos:prefLabel "Vertical/depth reference systems"@en ;
     prov:qualifiedAttribution
         [

--- a/vocabularies/borehole-drilling-method.ttl
+++ b/vocabularies/borehole-drilling-method.ttl
@@ -27,7 +27,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:altLabel "Caldwell bucket drilling"@en ;
-    skos:definition "A proprietary drilling method commonly used in opal mining, and more recently potash mining, involving a large rotating bucket on the end of a drillstem. Used for large diameter open holes up to 3 m wide. Also known as Calweld bucket drilling. The name originates from the California Welding Company that originally produced the rigs."@en ;
+    skos:definition "A proprietary drilling method commonly used in opal mining, and more recently potash mining, involving a large rotating bucket on the end of a drillstem. Used for large diameter open holes up to 3 m wide. Also known as Calweld bucket drilling. The name originates from the California Welding Company that originally produced the rigs."@en ;
     skos:inScheme cs: ;
     skos:prefLabel "Calweld"@en ;
     schema:citation "https://www.opalquest.com/blogs/news/mining-methods-equipment"^^xsd:anyURI ;
@@ -53,7 +53,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     a skos:Concept ;
     rdfs:isDefinedBy cs: ;
     skos:altLabel "bucket auger"@en ;
-    skos:definition "The bucket rig is a form of the rotary drill rig. It uses mechanical or hydraulic drive to rotate a kelly (i.e. a steel bar with a hole drilled through the middle for a fluid path) which is attached to the bucket. This type of rig normally utilizes a square friction type or round locking type kelly with three or four telescoping sections which can extend to 30 m or more. Bucket rigs may be equipped to drill holes from 25.4 cm to 152.4 cm in diameter. Bucket drilling uses a cylindrical bucket with cutting blades or teeth mounted on a hinged bottom to repeatedly cut and lift sediments from the borehole. To drill, the bucket is rotated to allow the bottom of the cutting teeth to fill the bucket. When the bucket is full, it is raised by cable."@en ;
+    skos:definition "The bucket rig is a form of the rotary drill rig. It uses mechanical or hydraulic drive to rotate a kelly (i.e. a steel bar with a hole drilled through the middle for a fluid path) which is attached to the bucket. This type of rig normally utilizes a square friction type or round locking type kelly with three or four telescoping sections which can extend to 30 m or more. Bucket rigs may be equipped to drill holes from 25.4 cm to 152.4 cm in diameter. Bucket drilling uses a cylindrical bucket with cutting blades or teeth mounted on a hinged bottom to repeatedly cut and lift sediments from the borehole. To drill, the bucket is rotated to allow the bottom of the cutting teeth to fill the bucket. When the bucket is full, it is raised by cable."@en ;
     skos:inScheme cs: ;
     skos:narrower
         :Bauer-bucket ,
@@ -222,7 +222,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         "RC"@en ,
         "RC hammer drilling"@en ,
         "reverse circulation drilling"@en ;
-    skos:definition "The drilling mechanism for reverse circulation (RC) drilling is a pneumatic reciprocating piston known as a 'hammer' driving a tungsten-steel drillbit. Compressed air passes down to the drillbit along the annular space between an outer and inner drill rod to return to the surface inside the rods carrying drill cuttings. This is the reverse of the air path employed in normal ‘open hole’ rotary percussion drilling (including RAB drilling). At the top of the hole, the air and drill cuttings are passed through a cyclone to collect the cuttings for sampling. The RC drilling technique prevents the upcoming sample from being contaminated with material from the wall of the hole above the sampling depth. RC drilling utilizes much larger rigs and machinery and comparatively higher air pressure. Depths of up to 500 m are routinely achieved."@en ;
+    skos:definition "The drilling mechanism for reverse circulation (RC) drilling is a pneumatic reciprocating piston known as a 'hammer' driving a tungsten-steel drillbit. Compressed air passes down to the drillbit along the annular space between an outer and inner drill rod to return to the surface inside the rods carrying drill cuttings. This is the reverse of the air path employed in normal ‘open hole’ rotary percussion drilling (including RAB drilling). At the top of the hole, the air and drill cuttings are passed through a cyclone to collect the cuttings for sampling. The RC drilling technique prevents the upcoming sample from being contaminated with material from the wall of the hole above the sampling depth. RC drilling utilizes much larger rigs and machinery and comparatively higher air pressure. Depths of up to 500 m are routinely achieved."@en ;
     skos:exactMatch cgibdm:reverse_circulation_drilling ;
     skos:inScheme cs: ;
     skos:notation "RC"^^xsd:token ;
@@ -311,7 +311,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:altLabel
         "VAC"@en ,
         "vacuum drilling"@en ;
-    skos:definition "Vacuum drilling is principally designed for mineral exploration drilling to provide a low-cost, efficient recovery of uncontaminated drill samples. Vacuum drilling uses a tungsten carbide tipped blade bit to make the hole. The cuttings are then ‘sucked’ up the drillpipe using an industrial vacuum pump. The sample is separated from the air flow through a sealed cyclone into a transparent collection (vacuum) flask. Any remaining fine material is removed by a secondary filter before the air passes through the vacuum pump and vented to the atmosphere. In softer material, drilling with this method is a fast, accurate and economical method of obtaining samples. Although hole depths of 50 m or more have been recorded, most are less than 10 m."@en ;
+    skos:definition "Vacuum drilling is principally designed for mineral exploration drilling to provide a low-cost, efficient recovery of uncontaminated drill samples. Vacuum drilling uses a tungsten carbide tipped blade bit to make the hole. The cuttings are then ‘sucked’ up the drillpipe using an industrial vacuum pump. The sample is separated from the air flow through a sealed cyclone into a transparent collection (vacuum) flask. Any remaining fine material is removed by a secondary filter before the air passes through the vacuum pump and vented to the atmosphere. In softer material, drilling with this method is a fast, accurate and economical method of obtaining samples. Although hole depths of 50 m or more have been recorded, most are less than 10 m."@en ;
     skos:exactMatch cgibdm:vacuum ;
     skos:historyNote "Australian Drilling Industry Association 2018, Chapter 3, The Drilling Manual, Sixth edition: Australian Drilling Industry Association, p. 214." ;
     skos:inScheme cs: ;
@@ -396,7 +396,7 @@ cgibdm:delft_sampler
     rdfs:isDefinedBy <http://resource.geosciml.org/classifierscheme/cgi/2016.01/boreholedrillingmethod> ;
     skos:altLabel "Delft continuous sampler"@en ;
     skos:definition "The Delft continuous sampler, developed by GeoDelft, is used for obtaining high quality samples within very soft cohesive soils. The sampling system is available in two sizes to take continuous samples, 29 or 66 mm in diameter, normally with a maximum penetration of about 18 m. A steel outer tube is pushed into the ground using standard CPT (cone penetrometer test) equipment and the soil sample core is fed into a thin-walled plastic inner tube as the sampler advances. After extraction, the samples are cut into 1 m lengths and placed in purpose-made cases, being retained in the plastic tubes."@en ;
-    skos:historyNote "Begemann, HKSP 1974, The delft continuous soilsampler: Bulletin of the International Association of Engineering Geology, v. 10, p. 35–37, doi:10.1007/BF02634629." ;
+    skos:historyNote "Begemann, HKSP 1974, The delft continuous soilsampler: Bulletin of the International Association of Engineering Geology, v. 10, p. 35–37, doi:10.1007/BF02634629." ;
     skos:inScheme cs: ;
     skos:prefLabel "Delft sampler"@en ;
     schema:citation
@@ -426,7 +426,7 @@ cgibdm:diamond_core
 cgibdm:direct_push
     a skos:Concept ;
     rdfs:isDefinedBy <http://resource.geosciml.org/classifierscheme/cgi/2016.01/boreholedrillingmethod> ;
-    skos:definition "Direct push technology includes several types of drilling rigs and drilling equipment that advance a drillstring by pushing or hammering without rotating the drillstring. Direct push rigs include both cone penetration testing rigs and direct push sampling rigs such as a PowerProbe or Geoprobe. Direct push rigs typically are limited to drilling in unconsolidated soil materials and very soft rock. Direct push drilling rigs use hydraulic cylinders and a hydraulic hammer in advancing a hollow core sampler, typically no longer than 2 m, to gather soil and groundwater samples. The core pipe has a valve on top that is used to create a vacuum at the top of the core when pulling the core out of the sediment. The method can be used in up to 5 m of water."@en ;
+    skos:definition "Direct push technology includes several types of drilling rigs and drilling equipment that advance a drillstring by pushing or hammering without rotating the drillstring. Direct push rigs include both cone penetration testing rigs and direct push sampling rigs such as a PowerProbe or Geoprobe. Direct push rigs typically are limited to drilling in unconsolidated soil materials and very soft rock. Direct push drilling rigs use hydraulic cylinders and a hydraulic hammer in advancing a hollow core sampler, typically no longer than 2 m, to gather soil and groundwater samples. The core pipe has a valve on top that is used to create a vacuum at the top of the core when pulling the core out of the sediment. The method can be used in up to 5 m of water."@en ;
     skos:historyNote "CGI Borehole drilling method vocabulary" ;
     skos:inScheme cs: ;
     skos:narrower
@@ -472,7 +472,7 @@ cgibdm:hand_auger
 cgibdm:kasten_core
     a skos:Concept ;
     rdfs:isDefinedBy <http://resource.geosciml.org/classifierscheme/cgi/2016.01/boreholedrillingmethod> ;
-    skos:definition "Large volume, relatively undisturbed sediment core (~3 m long) from a Kasten Corer. The corer is constructed of stainless steel and is square in cross-section. A weight of several hundred kilograms on top of the corer pushes it 2 to 3 m into the seabed."@en ;
+    skos:definition "Large volume, relatively undisturbed sediment core (~3 m long) from a Kasten Corer. The corer is constructed of stainless steel and is square in cross-section. A weight of several hundred kilograms on top of the corer pushes it 2 to 3 m into the seabed."@en ;
     skos:historyNote "CGI Borehole drilling method vocabulary" ;
     skos:inScheme cs: ;
     skos:prefLabel "Kasten core"@en ;
@@ -482,7 +482,7 @@ cgibdm:kasten_core
 cgibdm:mackereth_core
     a skos:Concept ;
     rdfs:isDefinedBy <http://resource.geosciml.org/classifierscheme/cgi/2016.01/boreholedrillingmethod> ;
-    skos:definition "The Mackereth corer (Mackereth, 1958; Smith, 1959) is a pneumatic device that consists of a cylindrical aluminium chamber about 1.2 m long and 0.5 m in diameter. The apparatus is lowered to the lake floor on a rope, and air hoses connect the chamber to the vessel at the water surface. Compressed air is used to pump the water out of the chamber and then to force the inner core barrel downward through the chamber and into the sediment. The method can recover single-drive moderate (up to 12 m) cores from lakes of diverse depths. Mackereth cores can be deployed on virtually any small craft and can be used in water depths up to 100 m."@en ;
+    skos:definition "The Mackereth corer (Mackereth, 1958; Smith, 1959) is a pneumatic device that consists of a cylindrical aluminium chamber about 1.2 m long and 0.5 m in diameter. The apparatus is lowered to the lake floor on a rope, and air hoses connect the chamber to the vessel at the water surface. Compressed air is used to pump the water out of the chamber and then to force the inner core barrel downward through the chamber and into the sediment. The method can recover single-drive moderate (up to 12 m) cores from lakes of diverse depths. Mackereth cores can be deployed on virtually any small craft and can be used in water depths up to 100 m."@en ;
     skos:historyNote "CGI Borehole drilling method vocabulary" ;
     skos:inScheme cs: ;
     skos:prefLabel "Mackereth core"@en ;
@@ -492,7 +492,7 @@ cgibdm:mackereth_core
 cgibdm:mackintosh_probe
     a skos:Concept ;
     rdfs:isDefinedBy <http://resource.geosciml.org/classifierscheme/cgi/2016.01/boreholedrillingmethod> ;
-    skos:definition "The Mackintosh tool consists of rods that can be threaded together with barrel connectors and which are normally fitted with a driving point at their base, and a light hand-operated driving hammer at their top. The tool provides a very economical method of determining the thickness of soft deposits such as peat. The driving point is streamlined in longitudinal section with a maximum diameter of 27 mm. The drive hammer has a total weight of about 4 kg. The rods are 1.2 m long and 12 mm diameter. The device is often used to provide a depth profile by driving the point and rods into the ground with equal blows of the full drop height available from the hammer: the number of blows for each 150 mm of penetration is recorded."@en ;
+    skos:definition "The Mackintosh tool consists of rods that can be threaded together with barrel connectors and which are normally fitted with a driving point at their base, and a light hand-operated driving hammer at their top. The tool provides a very economical method of determining the thickness of soft deposits such as peat. The driving point is streamlined in longitudinal section with a maximum diameter of 27 mm. The drive hammer has a total weight of about 4 kg. The rods are 1.2 m long and 12 mm diameter. The device is often used to provide a depth profile by driving the point and rods into the ground with equal blows of the full drop height available from the hammer: the number of blows for each 150 mm of penetration is recorded."@en ;
     skos:historyNote "Clayton, CRI, Matthews, MC, and Simons, NE 1995, Site investigation: A Handbook for engineers: Blackwell Science, Oxford, 584p." ;
     skos:inScheme cs: ;
     skos:prefLabel "Mackintosh probe"@en ;
@@ -519,7 +519,7 @@ cgibdm:sonic
         "SON"@en ,
         "sonic drilling"@en ,
         "vibratory"@en ;
-    skos:definition "A sonic or vibratory drillhead works by sending high-frequency resonant vibrations down the drillstring to the drillbit, while the operator controls these frequencies to suit the specific conditions of the soil/rock geology. Vibrations may also be generated within the drillhead. The frequency is generally between 50 and 180 Hz (cycles per second) and can be varied by the operator. Resonance magnifies the amplitude of the drillbit, which fluidizes the soil particles at the bit face, allowing for fast and easy penetration through most geological formations. An internal spring system isolates these vibrational forces from the rest of the drill rig."@en ;
+    skos:definition "A sonic or vibratory drillhead works by sending high-frequency resonant vibrations down the drillstring to the drillbit, while the operator controls these frequencies to suit the specific conditions of the soil/rock geology. Vibrations may also be generated within the drillhead. The frequency is generally between 50 and 180 Hz (cycles per second) and can be varied by the operator. Resonance magnifies the amplitude of the drillbit, which fluidizes the soil particles at the bit face, allowing for fast and easy penetration through most geological formations. An internal spring system isolates these vibrational forces from the rest of the drill rig."@en ;
     skos:historyNote "Powersd, JP, Corwin, AB, Schmall, PC and Kaeck, WE 2007, Construction dewatering and groundwater control: New Methods and Applications, Third edition: John Wyley and Sons Inc., 624p." ;
     skos:inScheme cs: ;
     skos:notation "SON"^^xsd:token ;

--- a/vocabularies/location-method.ttl
+++ b/vocabularies/location-method.ttl
@@ -311,7 +311,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 :google-earth
     a skos:Concept ;
     skos:definition "Geographical location determined from Google Earth, a virtual model of Earth which uses the World Geodetic System 1984 (WGS-84) as its coordinate system. Typically accurate to 50 m."@en ;
-    skos:historyNote "Used by GSWA to capture locations of geological observations or exploration/mining/infrastructure sites. Google Earth is a computer program that renders a 3D representation of Earth based primarily on satellite imagery. The program maps the Earth by superimposing satellite images, aerial photography, and GIS data onto a 3D globe, allowing users to see cities and landscapes from various angles." ;
+    skos:historyNote "Used by GSWA to capture locations of geological observations or exploration/mining/infrastructure sites. Google Earth is a computer program that renders a 3D representation of Earth based primarily on satellite imagery. The program maps the Earth by superimposing satellite images, aerial photography, and GIS data onto a 3D globe, allowing users to see cities and landscapes from various angles." ;
     skos:inScheme cs: ;
     skos:prefLabel "Google Earth (WGS-84)"@en ;
     skos:topConceptOf cs: ;
@@ -337,7 +337,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 :gps-wgs84-gda94
     a skos:Concept ;
-    skos:definition "Geographical location derived by a measurement of location and time via Global Positioning System (GPS) — it uses multilateration to connect a receiver to a network of satellites to determine the position coordinates of the receiver. The default coordinate system for GPS is the World Geodetic System 1984; in Australia the Geocentric Datum of Australia 1994 (or 2020) is also used. Modern GPS receivers can be accurate to 10 m."@en ;
+    skos:definition "Geographical location derived by a measurement of location and time via Global Positioning System (GPS) — it uses multilateration to connect a receiver to a network of satellites to determine the position coordinates of the receiver. The default coordinate system for GPS is the World Geodetic System 1984; in Australia the Geocentric Datum of Australia 1994 (or 2020) is also used. Modern GPS receivers can be accurate to 10 m."@en ;
     skos:historyNote "Used by GSWA to capture locations of geological observations or exploration/mining/infrastructure sites." ;
     skos:inScheme cs: ;
     skos:narrower :gps-wgs84-gda94-legacy ;
@@ -346,7 +346,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 :gps-wgs84-gda94-legacy
     a skos:Concept ;
-    skos:definition "Used to identify the location method for legacy points whose coordinates were captured via Global Positioning System (GPS) prior to May 1, 2000. Due to improvements in the accuracy of GPS devices over time, accuracy is estimated to vary between 100 and 200 m."@en ;
+    skos:definition "Used to identify the location method for legacy points whose coordinates were captured via Global Positioning System (GPS) prior to May 1, 2000. Due to improvements in the accuracy of GPS devices over time, accuracy is estimated to vary between 100 and 200 m."@en ;
     skos:historyNote "Used by GSWA to capture locations of legacy geological observations or exploration/mining/infrastructure sites." ;
     skos:inScheme cs: ;
     skos:prefLabel "GPS observation (WGS-84/GDA-94) - legacy"@en ;
@@ -354,7 +354,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 :landsatTM-mga
     a skos:Concept ;
-    skos:definition "Geographical location captured by using georeferenced imagery acquired by NASA's Landsat Thematic Mapper (TM) satellites. Accuracy is estimated to be within 100 m."@en ;
+    skos:definition "Geographical location captured by using georeferenced imagery acquired by NASA's Landsat Thematic Mapper (TM) satellites. Accuracy is estimated to be within 100 m."@en ;
     skos:historyNote "Used by GSWA to capture locations of legacy geological observations or exploration/mining/infrastructure sites. The Thematic Mapper is an advanced sensor carried aboard NASA Landsat satellites, used to collect high-resolution imagery in the visible, near infrared and short-wave infrared spectra of light." ;
     skos:inScheme cs: ;
     skos:prefLabel "Landsat TM (MGA)"@en ;
@@ -367,7 +367,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         "LADAR"@en ,
         "LIDAR"@en ,
         "Lidar"@en ;
-    skos:definition "Geographical location obtained using the 'laser imaging detection and ranging' (LiDAR) method, whereby the coordinates of a point are measured from ground control points using a laser to measure the time it takes for the reflected light to return to the receiver). Typically, a Global Navigation Satellite System receiver configured over a georeferenced control point is used to link the data in with the WGS (World Geodetic System). Horizontal and vertical accuracies vary, but can be as low as 1 cm or less."@en ;
+    skos:definition "Geographical location obtained using the 'laser imaging detection and ranging' (LiDAR) method, whereby the coordinates of a point are measured from ground control points using a laser to measure the time it takes for the reflected light to return to the receiver). Typically, a Global Navigation Satellite System receiver configured over a georeferenced control point is used to link the data in with the WGS (World Geodetic System). Horizontal and vertical accuracies vary, but can be as low as 1 cm or less."@en ;
     skos:historyNote "LiDAR is a ground or airborne surveying technology that uses laser pulses to create high-resolution models of ground elevation or underground workings." ;
     skos:inScheme cs: ;
     skos:prefLabel "LiDAR"@en ;
@@ -385,7 +385,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 :non-standard-geological-map-mga
     a skos:Concept ;
-    skos:definition "Geographical location determined from a geological map that uses a different scale, projection, or set of symbols from standard geological maps. Accuracy is estimated at 100 m. Non-standard geological maps are usually produced for specific areas or at specific sizes/scales, usually to highlight the geology of a defined area or geological region, or to present specific sets of features."@en ;
+    skos:definition "Geographical location determined from a geological map that uses a different scale, projection, or set of symbols from standard geological maps. Accuracy is estimated at 100 m. Non-standard geological maps are usually produced for specific areas or at specific sizes/scales, usually to highlight the geology of a defined area or geological region, or to present specific sets of features."@en ;
     skos:historyNote "Used by GSWA to capture locations of legacy geological observations or exploration/mining/infrastructure sites." ;
     skos:inScheme cs: ;
     skos:prefLabel "non-standard geological map (MGA)"@en ;
@@ -393,7 +393,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 :non-standard-topographic-map-mga
     a skos:Concept ;
-    skos:definition "Geographical location determined from a topographic map that uses a different scale, projection, or set of symbols from standard topographic maps. Accuracy is estimated at 100 m. Non-standard topographic maps are usually produced for specific areas or at specific sizes/scales, usually to highlight the topography of a defined area or region, or to present specific sets of features."@en ;
+    skos:definition "Geographical location determined from a topographic map that uses a different scale, projection, or set of symbols from standard topographic maps. Accuracy is estimated at 100 m. Non-standard topographic maps are usually produced for specific areas or at specific sizes/scales, usually to highlight the topography of a defined area or region, or to present specific sets of features."@en ;
     skos:historyNote "Used by GSWA to capture locations of legacy geological observations or exploration/mining/infrastructure sites." ;
     skos:inScheme cs: ;
     skos:prefLabel "non-standard topographic map (MGA)"@en ;
@@ -401,7 +401,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 :orthophoto-mga
     a skos:Concept ;
-    skos:definition "Geographical location captured by using orthophotographs, i.e. aerial photos taken with a high-resolution camera that have been geometrically corrected to give a uniform scale. Captured as Map Grid of Australia (MGA) 1994 coordinates. Accuracy is typically within 5 m."@en ;
+    skos:definition "Geographical location captured by using orthophotographs, i.e. aerial photos taken with a high-resolution camera that have been geometrically corrected to give a uniform scale. Captured as Map Grid of Australia (MGA) 1994 coordinates. Accuracy is typically within 5 m."@en ;
     skos:historyNote "Used by GSWA to capture locations of geological observations or exploration/mining/infrastructure sites." ;
     skos:inScheme cs: ;
     skos:narrower :panoramic-image-mga ;
@@ -412,7 +412,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 :panoramic-image-mga
     a skos:Concept ;
-    skos:definition "Geographical location of points marked on panoramic photographs using georeferenced orthophotographs, i.e. aerial photos taken with a high resolution camera that have been geometrically corrected to give a uniform scale. Typically used to position the location of specific geological features on cliff/scarp that cannot be accessed directly during mapping. Captured as Map Grid of Australia (MGA) 1994 coordinates. Accuracy is typically within 25 m."@en ;
+    skos:definition "Geographical location of points marked on panoramic photographs using georeferenced orthophotographs, i.e. aerial photos taken with a high resolution camera that have been geometrically corrected to give a uniform scale. Typically used to position the location of specific geological features on cliff/scarp that cannot be accessed directly during mapping. Captured as Map Grid of Australia (MGA) 1994 coordinates. Accuracy is typically within 25 m."@en ;
     skos:historyNote "Used by GSWA to capture locations of legacy geological observations or exploration/mining/infrastructure sites." ;
     skos:inScheme cs: ;
     skos:prefLabel "capture from panoramic image using orthophotograph (MGA)"@en ;
@@ -420,7 +420,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 :published-report
     a skos:Concept ;
-    skos:definition "Geographical location retrieved from a map, image, or text within a published document, e.g. an article in a journal, published thesis, etc. Accuracy estimated to be within 100 m."@en ;
+    skos:definition "Geographical location retrieved from a map, image, or text within a published document, e.g. an article in a journal, published thesis, etc. Accuracy estimated to be within 100 m."@en ;
     skos:historyNote "Used by GSWA to capture locations of geological observations or exploration/mining/infrastructure sites." ;
     skos:inScheme cs: ;
     skos:prefLabel "published report (MGA/WGS/GDA)"@en ;
@@ -437,7 +437,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 :rtk
     a skos:Concept ;
     skos:altLabel "RTK"@en ;
-    skos:definition "This method involves surveying of an area to correct for common errors in Global Navigation Satellite Systems (GNSS) in real time. It uses measurements of the phase of the signal's carrier wave in addition to the information content of the signal, and relies on a single reference station or interpolated virtual station to provide real-time corrections. Typically the accuracy of this method is within 1 or 2 cm, horizontally and vertically."@en ;
+    skos:definition "This method involves surveying of an area to correct for common errors in Global Navigation Satellite Systems (GNSS) in real time. It uses measurements of the phase of the signal's carrier wave in addition to the information content of the signal, and relies on a single reference station or interpolated virtual station to provide real-time corrections. Typically the accuracy of this method is within 1 or 2 cm, horizontally and vertically."@en ;
     skos:historyNote "Used in the mineral resources exploration and mining industry, and captured by GSWA via mineral exploration reports." ;
     skos:inScheme cs: ;
     skos:prefLabel "real time kinematic"@en ;
@@ -448,7 +448,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 :satellite
     a skos:Concept ;
     rdfs:isDefinedBy <https://en.wikipedia.org/wiki/Satellite_imagery> ;
-    skos:definition "Geographic location captured by using satellite images (also Earth observation imagery, spaceborne photography, or simply satellite photo) are images of Earth collected by imaging satellites operated by governments and businesses around the world."@en ;
+    skos:definition "Geographic location captured by using satellite images (also Earth observation imagery, spaceborne photography, or simply satellite photo) are images of Earth collected by imaging satellites operated by governments and businesses around the world."@en ;
     skos:historyNote "Used by GSWA to capture locations of legacy geological observations or exploration/mining/infrastructure sites." ;
     skos:inScheme cs: ;
     skos:narrower
@@ -471,7 +471,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 :spot-p
     a skos:Concept ;
-    skos:definition "Geographical location captured using georeferenced imagery acquired by Satellite Pour l'Observation de la Terre (SPOT P, a commercial satellite imaging system which uses a Panchromatic sensor to capture highly detailed black and white images). Accuracy is estimated to be within 20 m."@en ;
+    skos:definition "Geographical location captured using georeferenced imagery acquired by Satellite Pour l'Observation de la Terre (SPOT P, a commercial satellite imaging system which uses a Panchromatic sensor to capture highly detailed black and white images). Accuracy is estimated to be within 20 m."@en ;
     skos:historyNote "Used by GSWA to capture locations of geological observations or exploration/mining/infrastructure sites." ;
     skos:inScheme cs: ;
     skos:prefLabel "SPOT P (MGA)"@en ;
@@ -491,7 +491,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 :surveyed-ground-control
     a skos:Concept ;
-    skos:definition "Geographical location measured from ground control points, i.e. points whose coordinates were accurately determined by surveyors. Accuracy is typically within 1 m."@en ;
+    skos:definition "Geographical location measured from ground control points, i.e. points whose coordinates were accurately determined by surveyors. Accuracy is typically within 1 m."@en ;
     skos:historyNote "Used by GSWA to capture locations of geological observations or exploration/mining/infrastructure sites." ;
     skos:inScheme cs: ;
     skos:prefLabel "surveyed from ground control (WGS-84/GDA-94)"@en ;
@@ -550,7 +550,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 :unpublished-report
     a skos:Concept ;
-    skos:definition "Geographical location retrieved from a map, image, or text within a written, unpublished document, e.g. an internal report, unpublished thesis, etc. Accuracy estimated to be within 100 m."@en ;
+    skos:definition "Geographical location retrieved from a map, image, or text within a written, unpublished document, e.g. an internal report, unpublished thesis, etc. Accuracy estimated to be within 100 m."@en ;
     skos:historyNote "Used by GSWA to capture locations of geological observations or exploration/mining/infrastructure sites." ;
     skos:inScheme cs: ;
     skos:prefLabel "unpublished report (MGA/WGS/GDA)"@en ;


### PR DESCRIPTION
Fix two odd characters in text in several vocabs:

* https://linked.data.g​ov.au/org/gswa - has a non-visible character between 'g' & 'o' in 'gov'
    * this is a result of Excel use
    * removed
* NBSP (non-breaking Space) character, from word etc, in descriptive text
    * goes to just a space