### PR TITLE
PID updates due to all-PID validation

### DIFF
--- a/vocabularies/borehole-drilling-method.ttl
+++ b/vocabularies/borehole-drilling-method.ttl
@@ -1,6 +1,6 @@
-PREFIX : <https://linked.data.gov.au/def/borehole-drilling-method-western-australia/>
+PREFIX : <https://linked.data.gov.au/def/borehole-drilling-method-wa/>
 PREFIX cgibdm: <http://resource.geosciml.org/classifier/cgi/boreholedrillingmethod/>
-PREFIX cs: <https://linked.data.gov.au/def/borehole-drilling-method-western-australia>
+PREFIX cs: <https://linked.data.gov.au/def/borehole-drilling-method-wa>
 PREFIX dcat: <http://www.w3.org/ns/dcat#>
 PREFIX dataroles: <https://linked.data.gov.au/def/data-roles/>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
@@ -563,10 +563,12 @@ cgibdm:window_sampler
     schema:url "https://www.dmp.wa.gov.au/Geological-Survey/Geological-Survey-262.aspx"^^xsd:anyURI ;
 .
 
+:1.0 schema:name "1.0" .
+
 cs:
     a skos:ConceptScheme ;
     reg:status <https://linked.data.gov.au/def/reg-statuses/accepted> ;
-    owl:versionIRI <http://draft.com/borehole-drilling-method-western-australia/1.0> ;
+    owl:versionIRI :1.0 ;
     skos:definition "A list of drilling methods routinely used by the mineral and energy resource industries. The drilling methods are grouped into three main categories based on the dominant motion of the drillstem (i.e. the string of pipe that transmits power from the surface down to the drillbit) and drillbit (the part of the bottom-hole assembly that cuts, grinds or breaks the bottom-hole formation to make the hole). Specifically, the presence/absence of rotation in either or both is used as the main distinguishing factor, hence the main grouping into rotary, non-rotary and hybrid. Most drilling used by the mineral and energy resource industries falls into the rotary drilling category. Note that alternative classification schemes can use parameters such as the hole-making method in combination with the hole-clearing and stabilizing method and/or the type of sample produced (e.g. core versus chips). These methods can cross over between the main categories used here; for example, percussion drilling can be used in conjunction with rotary, non-rotary and hybrid methods and the term is not always qualified in company reports. In addition, many drilling rigs are multipurpose and hence can use a combination of drilling methods, including in the same borehole; for example, reverse circulation drilling can be followed by diamond drilling — however, these are both rotary drilling methods. Definitions are compiled from a variety of sources, including the Australian Drilling Industry Association's Drilling Manual (2018, Sixth edition), existing published vocabularies, drilling company webpages, Wikipedia, and a variety reports/publications."@en ;
     skos:hasTopConcept
         :hybrid-drilling ,
@@ -574,7 +576,7 @@ cs:
         :rotary-drilling ,
         :unknown ;
     skos:historyNote "This vocabulary stems from and restructures the CGI's Borehole Drilling Method vocabulary, taking into account the common methods and terminology usage in the mineral and energy resource industry in Western Australia. IRIs are shared only when no changes were introduced to definitions. Notations largely stem from those used in GSWA's Drillhole database  ([DRILLHOLES].[Interfaces].[LookupHoleType])."@en ;
-    skos:prefLabel "Borehole drilling method"@en ;
+    skos:prefLabel "Borehole drilling method WA"@en ;
     schema:keywords theme:resources ;
     prov:qualifiedAttribution
         [


### PR DESCRIPTION
the PID for the Borehole Drilling Method vocab sould end `-wa`, not `-western-australia`, as per other WA PIDs.

Yes, merging this PR will require updated to any systems referencing the PIDs from this vocab.

I will update the PID redirects once this PR is merged.