### PR TITLE
update ChronoStrat Chart

### DIFF
--- a/vocabularies/ChronostratChart.ttl
+++ b/vocabularies/ChronostratChart.ttl
@@ -1,4 +1,3 @@
-PREFIX agldwgstatus: <https://linked.data.gov.au/def/reg-statuses/>
 PREFIX cs: <http://resource.geosciml.org/classifier/ics/ischart>
 PREFIX dcterms: <http://purl.org/dc/terms/>
 PREFIX gts: <http://resource.geosciml.org/ontology/timescale/gts#>
@@ -7,15 +6,12 @@ PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX rank: <http://resource.geosciml.org/ontology/timescale/rank/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-PREFIX reg: <http://purl.org/linked-data/registry#>
-PREFIX schema: <https://schema.org/>
+PREFIX sdo: <https://schema.org/>
 PREFIX sh: <http://www.w3.org/ns/shacl#>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX time: <http://www.w3.org/2006/time#>
 PREFIX ts: <http://resource.geosciml.org/vocabulary/timescale/>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-PREFIX theme: <https://linked.data.gov.au/def/gswa-vocabulary-themes/>
-
 
 ischart:Ages
     a skos:Collection ;
@@ -246,12 +242,12 @@ ischart:Periods
 ischart:RGBHex
     a owl:Datatype ;
     rdfs:label "CMYK colour notation" ;
-    rdfs:comment """An 8-bit per channel, hexidecimal representation of RGB colours.
-
+    rdfs:comment """An 8-bit per channel, hexidecimal representation of RGB colours.\r
+\r
 This datatype uses a microformat of "#{R}{G}{B}" with hexidecimal value for {R}, {G} & {B} between 00 and FF."""@en ;
 .
 
-ischart:SubPeriods
+ischart:SubPeriod
     a skos:Collection ;
     rdfs:isDefinedBy cs: ;
     skos:definition "A sub-period an informal geochronologic time unit that is only defined for the Carboniferous Period. the two instances are tens of millions of years in length"@en ;
@@ -260,7 +256,7 @@ ischart:SubPeriods
     skos:member
         ischart:Mississippian ,
         ischart:Pennsylvanian ;
-    skos:prefLabel "Sub-Periods"@en ;
+    skos:prefLabel "Sub Periods"@en ;
 .
 
 ischart:SuperEons
@@ -282,6 +278,7 @@ ischart:inMYA
 ischart:Aalenian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "пален"@bg ,
@@ -311,20 +308,21 @@ ischart:Aalenian
     skos:prefLabel "Aalenian"@en ;
     time:hasBeginning [
             ischart:inMYA 174.7 ;
-            schema:marginOfError 0.8
+            sdo:marginOfError 0.8
         ] ;
     time:hasEnd [
             ischart:inMYA 170.9 ;
-            schema:marginOfError 0.8
+            sdo:marginOfError 0.8
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 58 ;
-    schema:color "#9AD9DD"^^ischart:RGBHex ;
+    sdo:color "#9AD9DD"^^ischart:RGBHex ;
 .
 
 ischart:Aeronian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "перон"@bg ,
@@ -354,20 +352,21 @@ ischart:Aeronian
     skos:prefLabel "Aeronian"@en ;
     time:hasBeginning [
             ischart:inMYA 440.8 ;
-            schema:marginOfError 1.2
+            sdo:marginOfError 1.2
         ] ;
     time:hasEnd [
             ischart:inMYA 438.5 ;
-            schema:marginOfError 1.1
+            sdo:marginOfError 1.1
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 127 ;
-    schema:color "#B3E1C2"^^ischart:RGBHex ;
+    sdo:color "#B3E1C2"^^ischart:RGBHex ;
 .
 
 ischart:Albian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "плб"@bg ,
@@ -404,7 +403,7 @@ ischart:Albian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 43 ;
-    schema:color "#CCEA97"^^ischart:RGBHex ;
+    sdo:color "#CCEA97"^^ischart:RGBHex ;
 .
 
 ischart:Anisian
@@ -446,7 +445,7 @@ ischart:Anisian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 71 ;
-    schema:color "#BC75B7"^^ischart:RGBHex ;
+    sdo:color "#BC75B7"^^ischart:RGBHex ;
 .
 
 ischart:Aptian
@@ -489,12 +488,13 @@ ischart:Aptian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 44 ;
-    schema:color "#BFE48A"^^ischart:RGBHex ;
+    sdo:color "#BFE48A"^^ischart:RGBHex ;
 .
 
 ischart:Aquitanian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "пквитан"@bg ,
@@ -530,12 +530,13 @@ ischart:Aquitanian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 19 ;
-    schema:color "#FFFF33"^^ischart:RGBHex ;
+    sdo:color "#FFFF33"^^ischart:RGBHex ;
 .
 
 ischart:Artinskian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "пртин"@bg ,
@@ -565,20 +566,21 @@ ischart:Artinskian
     skos:prefLabel "Artinskian"@en ;
     time:hasBeginning [
             ischart:inMYA 290.1 ;
-            schema:marginOfError 0.26
+            sdo:marginOfError 0.26
         ] ;
     time:hasEnd [
             ischart:inMYA 283.5 ;
-            schema:marginOfError 0.6
+            sdo:marginOfError 0.6
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 87 ;
-    schema:color "#E37B68"^^ischart:RGBHex ;
+    sdo:color "#E37B68"^^ischart:RGBHex ;
 .
 
 ischart:Asselian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "пѿел"@bg ,
@@ -608,20 +610,21 @@ ischart:Asselian
     skos:prefLabel "Asselian"@en ;
     time:hasBeginning [
             ischart:inMYA 298.9 ;
-            schema:marginOfError 0.15
+            sdo:marginOfError 0.15
         ] ;
     time:hasEnd [
             ischart:inMYA 293.51 ;
-            schema:marginOfError 0.17
+            sdo:marginOfError 0.17
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 89 ;
-    schema:color "#E36350"^^ischart:RGBHex ;
+    sdo:color "#E36350"^^ischart:RGBHex ;
 .
 
 ischart:Bajocian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Байоѿ"@bg ,
@@ -651,20 +654,21 @@ ischart:Bajocian
     skos:prefLabel "Bajocian"@en ;
     time:hasBeginning [
             ischart:inMYA 170.9 ;
-            schema:marginOfError 0.8
+            sdo:marginOfError 0.8
         ] ;
     time:hasEnd [
             ischart:inMYA 168.2 ;
-            schema:marginOfError 1.2
+            sdo:marginOfError 1.2
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 57 ;
-    schema:color "#A6DDE0"^^ischart:RGBHex ;
+    sdo:color "#A6DDE0"^^ischart:RGBHex ;
 .
 
 ischart:Barremian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Барем"@bg ,
@@ -701,7 +705,7 @@ ischart:Barremian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 45 ;
-    schema:color "#B3DF7F"^^ischart:RGBHex ;
+    sdo:color "#B3DF7F"^^ischart:RGBHex ;
 .
 
 ischart:Bartonian
@@ -742,12 +746,13 @@ ischart:Bartonian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 26 ;
-    schema:color "#FDC091"^^ischart:RGBHex ;
+    sdo:color "#FDC091"^^ischart:RGBHex ;
 .
 
 ischart:Bashkirian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Башкир"@bg ,
@@ -777,20 +782,21 @@ ischart:Bashkirian
     skos:prefLabel "Bashkirian"@en ;
     time:hasBeginning [
             ischart:inMYA 323.2 ;
-            schema:marginOfError 0.4
+            sdo:marginOfError 0.4
         ] ;
     time:hasEnd [
             ischart:inMYA 315.2 ;
-            schema:marginOfError 0.2
+            sdo:marginOfError 0.2
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 97 ;
-    schema:color "#99C2B5"^^ischart:RGBHex ;
+    sdo:color "#99C2B5"^^ischart:RGBHex ;
 .
 
 ischart:Bathonian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Бат"@bg ,
@@ -820,15 +826,15 @@ ischart:Bathonian
     skos:prefLabel "Bathonian"@en ;
     time:hasBeginning [
             ischart:inMYA 168.2 ;
-            schema:marginOfError 1.2
+            sdo:marginOfError 1.2
         ] ;
     time:hasEnd [
             ischart:inMYA 165.3 ;
-            schema:marginOfError 1.1
+            sdo:marginOfError 1.1
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 56 ;
-    schema:color "#B3E2E3"^^ischart:RGBHex ;
+    sdo:color "#B3E2E3"^^ischart:RGBHex ;
 .
 
 ischart:Berriasian
@@ -871,7 +877,7 @@ ischart:Berriasian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 48 ;
-    schema:color "#8CCD60"^^ischart:RGBHex ;
+    sdo:color "#8CCD60"^^ischart:RGBHex ;
 .
 
 ischart:Burdigalian
@@ -912,12 +918,13 @@ ischart:Burdigalian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 18 ;
-    schema:color "#FFFF41"^^ischart:RGBHex ;
+    sdo:color "#FFFF41"^^ischart:RGBHex ;
 .
 
 ischart:Calabrian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Калабрий"@bg ,
@@ -953,7 +960,7 @@ ischart:Calabrian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 7 ;
-    schema:color "#FFF2BA"^^ischart:RGBHex ;
+    sdo:color "#FFF2BA"^^ischart:RGBHex ;
 .
 
 ischart:Callovian
@@ -988,20 +995,21 @@ ischart:Callovian
     skos:prefLabel "Callovian"@en ;
     time:hasBeginning [
             ischart:inMYA 165.3 ;
-            schema:marginOfError 1.1
+            sdo:marginOfError 1.1
         ] ;
     time:hasEnd [
             ischart:inMYA 161.5 ;
-            schema:marginOfError 1.0
+            sdo:marginOfError 1.0
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 55 ;
-    schema:color "#BFE7E5"^^ischart:RGBHex ;
+    sdo:color "#BFE7E5"^^ischart:RGBHex ;
 .
 
 ischart:Calymmian
     a skos:Concept ;
     gts:rank rank:Period ;
+    gts:ratifiedGSSA true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Калим"@bg ,
@@ -1037,7 +1045,7 @@ ischart:Calymmian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 164 ;
-    schema:color "#FDC07A"^^ischart:RGBHex ;
+    sdo:color "#FDC07A"^^ischart:RGBHex ;
 .
 
 ischart:CambrianStage10
@@ -1076,11 +1084,11 @@ ischart:CambrianStage10
         ] ;
     time:hasEnd [
             ischart:inMYA 485.4 ;
-            schema:marginOfError 1.9
+            sdo:marginOfError 1.9
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 142 ;
-    schema:color "#E6F5C9"^^ischart:RGBHex ;
+    sdo:color "#E6F5C9"^^ischart:RGBHex ;
 .
 
 ischart:CambrianStage2
@@ -1123,7 +1131,7 @@ ischart:CambrianStage2
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 152 ;
-    schema:color "#A6BA80"^^ischart:RGBHex ;
+    sdo:color "#A6BA80"^^ischart:RGBHex ;
 .
 
 ischart:CambrianStage3
@@ -1166,7 +1174,7 @@ ischart:CambrianStage3
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 153 ;
-    schema:color "#A6C583"^^ischart:RGBHex ;
+    sdo:color "#A6C583"^^ischart:RGBHex ;
 .
 
 ischart:CambrianStage4
@@ -1209,12 +1217,13 @@ ischart:CambrianStage4
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 150 ;
-    schema:color "#B3CA8E"^^ischart:RGBHex ;
+    sdo:color "#B3CA8E"^^ischart:RGBHex ;
 .
 
 ischart:Campanian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Кампан"@bg ,
@@ -1244,20 +1253,21 @@ ischart:Campanian
     skos:prefLabel "Campanian"@en ;
     time:hasBeginning [
             ischart:inMYA 83.6 ;
-            schema:marginOfError 0.2
+            sdo:marginOfError 0.2
         ] ;
     time:hasEnd [
             ischart:inMYA 72.1 ;
-            schema:marginOfError 0.2
+            sdo:marginOfError 0.2
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 37 ;
-    schema:color "#E6F47F"^^ischart:RGBHex ;
+    sdo:color "#E6F47F"^^ischart:RGBHex ;
 .
 
 ischart:Capitanian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Капитан"@bg ,
@@ -1287,20 +1297,21 @@ ischart:Capitanian
     skos:prefLabel "Capitanian"@en ;
     time:hasBeginning [
             ischart:inMYA 264.28 ;
-            schema:marginOfError 0.16
+            sdo:marginOfError 0.16
         ] ;
     time:hasEnd [
             ischart:inMYA 259.51 ;
-            schema:marginOfError 0.21
+            sdo:marginOfError 0.21
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 82 ;
-    schema:color "#FB9A85"^^ischart:RGBHex ;
+    sdo:color "#FB9A85"^^ischart:RGBHex ;
 .
 
 ischart:Carnian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Карн"@bg ,
@@ -1338,12 +1349,13 @@ ischart:Carnian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 68 ;
-    schema:color "#C99BCB"^^ischart:RGBHex ;
+    sdo:color "#C99BCB"^^ischart:RGBHex ;
 .
 
 ischart:Cenomanian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Ценоман"@bg ,
@@ -1379,12 +1391,13 @@ ischart:Cenomanian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 41 ;
-    schema:color "#B3DE53"^^ischart:RGBHex ;
+    sdo:color "#B3DE53"^^ischart:RGBHex ;
 .
 
 ischart:Changhsingian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Чангшинг"@bg ,
@@ -1414,20 +1427,21 @@ ischart:Changhsingian
     skos:prefLabel "Changhsingian"@en ;
     time:hasBeginning [
             ischart:inMYA 254.14 ;
-            schema:marginOfError 0.07
+            sdo:marginOfError 0.07
         ] ;
     time:hasEnd [
             ischart:inMYA 251.902 ;
-            schema:marginOfError 0.024
+            sdo:marginOfError 0.024
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 79 ;
-    schema:color "#FCC0B2"^^ischart:RGBHex ;
+    sdo:color "#FCC0B2"^^ischart:RGBHex ;
 .
 
 ischart:Chattian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Хат"@bg ,
@@ -1463,12 +1477,13 @@ ischart:Chattian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 22 ;
-    schema:color "#FEE6AA"^^ischart:RGBHex ;
+    sdo:color "#FEE6AA"^^ischart:RGBHex ;
 .
 
 ischart:Chibanian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:broader ischart:Pleistocene ;
     skos:definition "A time period from 0.774 to 0.129 million years ago" ;
@@ -1483,12 +1498,13 @@ ischart:Chibanian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 6 ;
-    schema:color "#FFF2C7"^^ischart:RGBHex ;
+    sdo:color "#FFF2C7"^^ischart:RGBHex ;
 .
 
 ischart:Coniacian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Кониак"@bg ,
@@ -1518,15 +1534,15 @@ ischart:Coniacian
     skos:prefLabel "Coniacian"@en ;
     time:hasBeginning [
             ischart:inMYA 89.8 ;
-            schema:marginOfError 0.3
+            sdo:marginOfError 0.3
         ] ;
     time:hasEnd [
             ischart:inMYA 86.3 ;
-            schema:marginOfError 0.5
+            sdo:marginOfError 0.5
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 39 ;
-    schema:color "#CCE968"^^ischart:RGBHex ;
+    sdo:color "#CCE968"^^ischart:RGBHex ;
 .
 
 ischart:Cryogenian
@@ -1569,12 +1585,13 @@ ischart:Cryogenian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 159 ;
-    schema:color "#FECC5C"^^ischart:RGBHex ;
+    sdo:color "#FECC5C"^^ischart:RGBHex ;
 .
 
 ischart:Danian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Дан"@bg ,
@@ -1610,12 +1627,13 @@ ischart:Danian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 33 ;
-    schema:color "#FDB462"^^ischart:RGBHex ;
+    sdo:color "#FDB462"^^ischart:RGBHex ;
 .
 
 ischart:Dapingian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Дапинг"@bg ,
@@ -1645,20 +1663,21 @@ ischart:Dapingian
     skos:prefLabel "Dapingian"@en ;
     time:hasBeginning [
             ischart:inMYA 470.0 ;
-            schema:marginOfError 1.4
+            sdo:marginOfError 1.4
         ] ;
     time:hasEnd [
             ischart:inMYA 467.3 ;
-            schema:marginOfError 1.1
+            sdo:marginOfError 1.1
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 136 ;
-    schema:color "#66C092"^^ischart:RGBHex ;
+    sdo:color "#66C092"^^ischart:RGBHex ;
 .
 
 ischart:Darriwilian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Даривил"@bg ,
@@ -1688,20 +1707,21 @@ ischart:Darriwilian
     skos:prefLabel "Darriwilian"@en ;
     time:hasBeginning [
             ischart:inMYA 467.3 ;
-            schema:marginOfError 1.1
+            sdo:marginOfError 1.1
         ] ;
     time:hasEnd [
             ischart:inMYA 458.4 ;
-            schema:marginOfError 0.9
+            sdo:marginOfError 0.9
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 135 ;
-    schema:color "#74C69C"^^ischart:RGBHex ;
+    sdo:color "#74C69C"^^ischart:RGBHex ;
 .
 
 ischart:Drumian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Друм"@bg ,
@@ -1739,12 +1759,13 @@ ischart:Drumian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 147 ;
-    schema:color "#BFD99D"^^ischart:RGBHex ;
+    sdo:color "#BFD99D"^^ischart:RGBHex ;
 .
 
 ischart:Ectasian
     a skos:Concept ;
     gts:rank rank:Period ;
+    gts:ratifiedGSSA true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Ектаз"@bg ,
@@ -1780,12 +1801,13 @@ ischart:Ectasian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 163 ;
-    schema:color "#FDCC8A"^^ischart:RGBHex ;
+    sdo:color "#FDCC8A"^^ischart:RGBHex ;
 .
 
 ischart:Ediacaran
     a skos:Concept ;
     gts:rank rank:Period ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Едиакар"@bg ,
@@ -1819,16 +1841,17 @@ ischart:Ediacaran
         ] ;
     time:hasEnd [
             ischart:inMYA 538.8 ;
-            schema:marginOfError 0.2
+            sdo:marginOfError 0.2
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 158 ;
-    schema:color "#FED96A"^^ischart:RGBHex ;
+    sdo:color "#FED96A"^^ischart:RGBHex ;
 .
 
 ischart:Eifelian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "пйфел"@bg ,
@@ -1858,20 +1881,21 @@ ischart:Eifelian
     skos:prefLabel "Eifelian"@en ;
     time:hasBeginning [
             ischart:inMYA 393.3 ;
-            schema:marginOfError 1.2
+            sdo:marginOfError 1.2
         ] ;
     time:hasEnd [
             ischart:inMYA 387.7 ;
-            schema:marginOfError 0.8
+            sdo:marginOfError 0.8
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 112 ;
-    schema:color "#F1D576"^^ischart:RGBHex ;
+    sdo:color "#F1D576"^^ischart:RGBHex ;
 .
 
 ischart:Emsian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Емѿ"@bg ,
@@ -1901,20 +1925,21 @@ ischart:Emsian
     skos:prefLabel "Emsian"@en ;
     time:hasBeginning [
             ischart:inMYA 407.6 ;
-            schema:marginOfError 2.6
+            sdo:marginOfError 2.6
         ] ;
     time:hasEnd [
             ischart:inMYA 393.3 ;
-            schema:marginOfError 1.2
+            sdo:marginOfError 1.2
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 114 ;
-    schema:color "#E5D075"^^ischart:RGBHex ;
+    sdo:color "#E5D075"^^ischart:RGBHex ;
 .
 
 ischart:Eoarchean
     a skos:Concept ;
     gts:rank rank:Era ;
+    gts:ratifiedGSSA true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Еоархай"@bg ,
@@ -1946,19 +1971,20 @@ ischart:Eoarchean
     skos:prefLabel "Eoarchean"@en ;
     time:hasBeginning [
             ischart:inMYA 4031 ;
-            schema:marginOfError 3
+            sdo:marginOfError 3
         ] ;
     time:hasEnd [
             ischart:inMYA 3600
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 176 ;
-    schema:color "#DA037F"^^ischart:RGBHex ;
+    sdo:color "#DA037F"^^ischart:RGBHex ;
 .
 
 ischart:Famennian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Фамен"@bg ,
@@ -1988,20 +2014,21 @@ ischart:Famennian
     skos:prefLabel "Famennian"@en ;
     time:hasBeginning [
             ischart:inMYA 372.2 ;
-            schema:marginOfError 1.6
+            sdo:marginOfError 1.6
         ] ;
     time:hasEnd [
             ischart:inMYA 358.9 ;
-            schema:marginOfError 0.4
+            sdo:marginOfError 0.4
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 108 ;
-    schema:color "#F2EDB3"^^ischart:RGBHex ;
+    sdo:color "#F2EDB3"^^ischart:RGBHex ;
 .
 
 ischart:Floian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Flo"@cs ,
@@ -2030,20 +2057,21 @@ ischart:Floian
     skos:prefLabel "Floian"@en ;
     time:hasBeginning [
             ischart:inMYA 477.7 ;
-            schema:marginOfError 1.4
+            sdo:marginOfError 1.4
         ] ;
     time:hasEnd [
             ischart:inMYA 470.0 ;
-            schema:marginOfError 1.4
+            sdo:marginOfError 1.4
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 138 ;
-    schema:color "#41B087"^^ischart:RGBHex ;
+    sdo:color "#41B087"^^ischart:RGBHex ;
 .
 
 ischart:Fortunian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Фортун"@bg ,
@@ -2073,7 +2101,7 @@ ischart:Fortunian
     skos:prefLabel "Fortunian"@en ;
     time:hasBeginning [
             ischart:inMYA 538.8 ;
-            schema:marginOfError 0.2
+            sdo:marginOfError 0.2
         ] ;
     time:hasEnd [
             ischart:inMYA 529 ;
@@ -2081,12 +2109,13 @@ ischart:Fortunian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 155 ;
-    schema:color "#99B575"^^ischart:RGBHex ;
+    sdo:color "#99B575"^^ischart:RGBHex ;
 .
 
 ischart:Frasnian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Фран"@bg ,
@@ -2116,20 +2145,21 @@ ischart:Frasnian
     skos:prefLabel "Frasnian"@en ;
     time:hasBeginning [
             ischart:inMYA 382.7 ;
-            schema:marginOfError 1.6
+            sdo:marginOfError 1.6
         ] ;
     time:hasEnd [
             ischart:inMYA 372.2 ;
-            schema:marginOfError 1.6
+            sdo:marginOfError 1.6
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 109 ;
-    schema:color "#F2EDAD"^^ischart:RGBHex ;
+    sdo:color "#F2EDAD"^^ischart:RGBHex ;
 .
 
 ischart:Gelasian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Gelas"@cs ,
@@ -2164,12 +2194,13 @@ ischart:Gelasian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 8 ;
-    schema:color "#FFEDB3"^^ischart:RGBHex ;
+    sdo:color "#FFEDB3"^^ischart:RGBHex ;
 .
 
 ischart:Givetian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Живет"@bg ,
@@ -2199,20 +2230,21 @@ ischart:Givetian
     skos:prefLabel "Givetian"@en ;
     time:hasBeginning [
             ischart:inMYA 387.7 ;
-            schema:marginOfError 0.8
+            sdo:marginOfError 0.8
         ] ;
     time:hasEnd [
             ischart:inMYA 382.7 ;
-            schema:marginOfError 1.6
+            sdo:marginOfError 1.6
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 111 ;
-    schema:color "#F1E185"^^ischart:RGBHex ;
+    sdo:color "#F1E185"^^ischart:RGBHex ;
 .
 
 ischart:Gorstian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Горѿт"@bg ,
@@ -2242,20 +2274,21 @@ ischart:Gorstian
     skos:prefLabel "Gorstian"@en ;
     time:hasBeginning [
             ischart:inMYA 427.4 ;
-            schema:marginOfError 0.5
+            sdo:marginOfError 0.5
         ] ;
     time:hasEnd [
             ischart:inMYA 425.6 ;
-            schema:marginOfError 0.9
+            sdo:marginOfError 0.9
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 121 ;
-    schema:color "#CCECDD"^^ischart:RGBHex ;
+    sdo:color "#CCECDD"^^ischart:RGBHex ;
 .
 
 ischart:Greenlandian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:broader ischart:Holocene ;
     skos:definition "A time period from 0.0117 to 0.0082 million years ago" ;
@@ -2270,12 +2303,13 @@ ischart:Greenlandian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 3 ;
-    schema:color "#FEECDB"^^ischart:RGBHex ;
+    sdo:color "#FEECDB"^^ischart:RGBHex ;
 .
 
 ischart:Guzhangian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Жужанг"@bg ,
@@ -2313,7 +2347,7 @@ ischart:Guzhangian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 146 ;
-    schema:color "#CCDFAA"^^ischart:RGBHex ;
+    sdo:color "#CCDFAA"^^ischart:RGBHex ;
 .
 
 ischart:Gzhelian
@@ -2348,20 +2382,21 @@ ischart:Gzhelian
     skos:prefLabel "Gzhelian"@en ;
     time:hasBeginning [
             ischart:inMYA 303.7 ;
-            schema:marginOfError 0.1
+            sdo:marginOfError 0.1
         ] ;
     time:hasEnd [
             ischart:inMYA 298.9 ;
-            schema:marginOfError 0.15
+            sdo:marginOfError 0.15
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 92 ;
-    schema:color "#CCD4C7"^^ischart:RGBHex ;
+    sdo:color "#CCD4C7"^^ischart:RGBHex ;
 .
 
 ischart:Hadean
     a skos:Concept ;
     gts:rank rank:Eon ;
+    gts:ratifiedGSSA true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Hád (spodní hranice není definována)"@cs ,
@@ -2393,16 +2428,17 @@ ischart:Hadean
         ] ;
     time:hasEnd [
             ischart:inMYA 4031 ;
-            schema:marginOfError 3
+            sdo:marginOfError 3
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 177 ;
-    schema:color "#AE027E"^^ischart:RGBHex ;
+    sdo:color "#AE027E"^^ischart:RGBHex ;
 .
 
 ischart:Hauterivian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Хотрив"@bg ,
@@ -2439,12 +2475,13 @@ ischart:Hauterivian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 46 ;
-    schema:color "#A6D975"^^ischart:RGBHex ;
+    sdo:color "#A6D975"^^ischart:RGBHex ;
 .
 
 ischart:Hettangian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Хетанж"@bg ,
@@ -2474,20 +2511,21 @@ ischart:Hettangian
     skos:prefLabel "Hettangian"@en ;
     time:hasBeginning [
             ischart:inMYA 201.4 ;
-            schema:marginOfError 0.2
+            sdo:marginOfError 0.2
         ] ;
     time:hasEnd [
             ischart:inMYA 199.5 ;
-            schema:marginOfError 0.3
+            sdo:marginOfError 0.3
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 63 ;
-    schema:color "#4EB3D3"^^ischart:RGBHex ;
+    sdo:color "#4EB3D3"^^ischart:RGBHex ;
 .
 
 ischart:Hirnantian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Хирнант"@bg ,
@@ -2517,20 +2555,21 @@ ischart:Hirnantian
     skos:prefLabel "Hirnantian"@en ;
     time:hasBeginning [
             ischart:inMYA 445.2 ;
-            schema:marginOfError 1.4
+            sdo:marginOfError 1.4
         ] ;
     time:hasEnd [
             ischart:inMYA 443.8 ;
-            schema:marginOfError 1.5
+            sdo:marginOfError 1.5
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 131 ;
-    schema:color "#A6DBAB"^^ischart:RGBHex ;
+    sdo:color "#A6DBAB"^^ischart:RGBHex ;
 .
 
 ischart:Homerian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Хомер"@bg ,
@@ -2560,20 +2599,21 @@ ischart:Homerian
     skos:prefLabel "Homerian"@en ;
     time:hasBeginning [
             ischart:inMYA 430.5 ;
-            schema:marginOfError 0.7
+            sdo:marginOfError 0.7
         ] ;
     time:hasEnd [
             ischart:inMYA 427.4 ;
-            schema:marginOfError 0.5
+            sdo:marginOfError 0.5
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 123 ;
-    schema:color "#CCEBD1"^^ischart:RGBHex ;
+    sdo:color "#CCEBD1"^^ischart:RGBHex ;
 .
 
 ischart:Induan
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Инд"@bg ,
@@ -2603,19 +2643,20 @@ ischart:Induan
     skos:prefLabel "Induan"@en ;
     time:hasBeginning [
             ischart:inMYA 251.902 ;
-            schema:marginOfError 0.024
+            sdo:marginOfError 0.024
         ] ;
     time:hasEnd [
             ischart:inMYA 251.2
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 74 ;
-    schema:color "#A4469F"^^ischart:RGBHex ;
+    sdo:color "#A4469F"^^ischart:RGBHex ;
 .
 
 ischart:Jiangshanian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel "江山期"@zh ;
     skos:broader ischart:Furongian ;
@@ -2633,7 +2674,7 @@ ischart:Jiangshanian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 143 ;
-    schema:color "#D9F0BB"^^ischart:RGBHex ;
+    sdo:color "#D9F0BB"^^ischart:RGBHex ;
 .
 
 ischart:Kasimovian
@@ -2668,20 +2709,21 @@ ischart:Kasimovian
     skos:prefLabel "Kasimovian"@en ;
     time:hasBeginning [
             ischart:inMYA 307.0 ;
-            schema:marginOfError 0.1
+            sdo:marginOfError 0.1
         ] ;
     time:hasEnd [
             ischart:inMYA 303.7 ;
-            schema:marginOfError 0.1
+            sdo:marginOfError 0.1
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 93 ;
-    schema:color "#BFD0C5"^^ischart:RGBHex ;
+    sdo:color "#BFD0C5"^^ischart:RGBHex ;
 .
 
 ischart:Katian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Кат"@bg ,
@@ -2711,20 +2753,21 @@ ischart:Katian
     skos:prefLabel "Katian"@en ;
     time:hasBeginning [
             ischart:inMYA 453.0 ;
-            schema:marginOfError 0.7
+            sdo:marginOfError 0.7
         ] ;
     time:hasEnd [
             ischart:inMYA 445.2 ;
-            schema:marginOfError 1.4
+            sdo:marginOfError 1.4
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 132 ;
-    schema:color "#99D69F"^^ischart:RGBHex ;
+    sdo:color "#99D69F"^^ischart:RGBHex ;
 .
 
 ischart:Kimmeridgian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Кимеридж"@bg ,
@@ -2754,15 +2797,15 @@ ischart:Kimmeridgian
     skos:prefLabel "Kimmeridgian"@en ;
     time:hasBeginning [
             ischart:inMYA 154.8 ;
-            schema:marginOfError 0.8
+            sdo:marginOfError 0.8
         ] ;
     time:hasEnd [
             ischart:inMYA 149.2 ;
-            schema:marginOfError 0.7
+            sdo:marginOfError 0.7
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 52 ;
-    schema:color "#CCECF4"^^ischart:RGBHex ;
+    sdo:color "#CCECF4"^^ischart:RGBHex ;
 .
 
 ischart:Kungurian
@@ -2797,20 +2840,21 @@ ischart:Kungurian
     skos:prefLabel "Kungurian"@en ;
     time:hasBeginning [
             ischart:inMYA 283.5 ;
-            schema:marginOfError 0.6
+            sdo:marginOfError 0.6
         ] ;
     time:hasEnd [
             ischart:inMYA 273.01 ;
-            schema:marginOfError 0.14
+            sdo:marginOfError 0.14
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 86 ;
-    schema:color "#E38776"^^ischart:RGBHex ;
+    sdo:color "#E38776"^^ischart:RGBHex ;
 .
 
 ischart:Ladinian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Ладин"@bg ,
@@ -2848,12 +2892,13 @@ ischart:Ladinian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 70 ;
-    schema:color "#C983BF"^^ischart:RGBHex ;
+    sdo:color "#C983BF"^^ischart:RGBHex ;
 .
 
 ischart:Langhian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Ланг"@bg ,
@@ -2889,12 +2934,13 @@ ischart:Langhian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 17 ;
-    schema:color "#FFFF4D"^^ischart:RGBHex ;
+    sdo:color "#FFFF4D"^^ischart:RGBHex ;
 .
 
 ischart:Lochkovian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Ложков"@bg ,
@@ -2924,20 +2970,21 @@ ischart:Lochkovian
     skos:prefLabel "Lochkovian"@en ;
     time:hasBeginning [
             ischart:inMYA 419.2 ;
-            schema:marginOfError 3.2
+            sdo:marginOfError 3.2
         ] ;
     time:hasEnd [
             ischart:inMYA 410.8 ;
-            schema:marginOfError 2.8
+            sdo:marginOfError 2.8
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 117 ;
-    schema:color "#E5B75A"^^ischart:RGBHex ;
+    sdo:color "#E5B75A"^^ischart:RGBHex ;
 .
 
 ischart:Ludfordian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Лудфорд"@bg ,
@@ -2967,20 +3014,21 @@ ischart:Ludfordian
     skos:prefLabel "Ludfordian"@en ;
     time:hasBeginning [
             ischart:inMYA 425.6 ;
-            schema:marginOfError 0.9
+            sdo:marginOfError 0.9
         ] ;
     time:hasEnd [
             ischart:inMYA 423.0 ;
-            schema:marginOfError 2.3
+            sdo:marginOfError 2.3
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 120 ;
-    schema:color "#D9F0DF"^^ischart:RGBHex ;
+    sdo:color "#D9F0DF"^^ischart:RGBHex ;
 .
 
 ischart:Lutetian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Лютеѿ"@bg ,
@@ -3016,12 +3064,13 @@ ischart:Lutetian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 27 ;
-    schema:color "#FDB482"^^ischart:RGBHex ;
+    sdo:color "#FDB482"^^ischart:RGBHex ;
 .
 
 ischart:Maastrichtian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Маѿтрихт"@bg ,
@@ -3051,19 +3100,20 @@ ischart:Maastrichtian
     skos:prefLabel "Maastrichtian"@en ;
     time:hasBeginning [
             ischart:inMYA 72.1 ;
-            schema:marginOfError 0.2
+            sdo:marginOfError 0.2
         ] ;
     time:hasEnd [
             ischart:inMYA 66.0
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 36 ;
-    schema:color "#F2FA8C"^^ischart:RGBHex ;
+    sdo:color "#F2FA8C"^^ischart:RGBHex ;
 .
 
 ischart:Meghalayan
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:broader ischart:Holocene ;
     skos:definition "A time period from 0.0042 million years ago to the present" ;
@@ -3078,12 +3128,13 @@ ischart:Meghalayan
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 1 ;
-    schema:color "#FDEDEC"^^ischart:RGBHex ;
+    sdo:color "#FDEDEC"^^ischart:RGBHex ;
 .
 
 ischart:Mesoarchean
     a skos:Concept ;
     gts:rank rank:Era ;
+    gts:ratifiedGSSA true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Мезоархай"@bg ,
@@ -3121,12 +3172,13 @@ ischart:Mesoarchean
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 173 ;
-    schema:color "#F768A9"^^ischart:RGBHex ;
+    sdo:color "#F768A9"^^ischart:RGBHex ;
 .
 
 ischart:Messinian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Меѿин"@bg ,
@@ -3162,7 +3214,7 @@ ischart:Messinian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 14 ;
-    schema:color "#FFFF73"^^ischart:RGBHex ;
+    sdo:color "#FFFF73"^^ischart:RGBHex ;
 .
 
 ischart:Moscovian
@@ -3197,20 +3249,21 @@ ischart:Moscovian
     skos:prefLabel "Moscovian"@en ;
     time:hasBeginning [
             ischart:inMYA 315.2 ;
-            schema:marginOfError 0.2
+            sdo:marginOfError 0.2
         ] ;
     time:hasEnd [
             ischart:inMYA 307.0 ;
-            schema:marginOfError 0.1
+            sdo:marginOfError 0.1
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 96 ;
-    schema:color "#B3CBB9"^^ischart:RGBHex ;
+    sdo:color "#B3CBB9"^^ischart:RGBHex ;
 .
 
 ischart:Neoarchean
     a skos:Concept ;
     gts:rank rank:Era ;
+    gts:ratifiedGSSA true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "пеоархай"@bg ,
@@ -3248,7 +3301,7 @@ ischart:Neoarchean
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 172 ;
-    schema:color "#F99BC1"^^ischart:RGBHex ;
+    sdo:color "#F99BC1"^^ischart:RGBHex ;
 .
 
 ischart:Norian
@@ -3291,12 +3344,13 @@ ischart:Norian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 67 ;
-    schema:color "#D6AAD3"^^ischart:RGBHex ;
+    sdo:color "#D6AAD3"^^ischart:RGBHex ;
 .
 
 ischart:Northgrippian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:broader ischart:Holocene ;
     skos:definition "A time period from 0.0082 to 0.0042 million years ago" ;
@@ -3311,7 +3365,7 @@ ischart:Northgrippian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 2 ;
-    schema:color "#FDECE4"^^ischart:RGBHex ;
+    sdo:color "#FDECE4"^^ischart:RGBHex ;
 .
 
 ischart:Olenekian
@@ -3345,19 +3399,20 @@ ischart:Olenekian
     skos:notation "t2"^^ischart:ccgmShortCode ;
     skos:prefLabel "Olenekian"@en ;
     time:hasBeginning [
-            ischart:inMYA 247.2
+            ischart:inMYA 251.2
         ] ;
     time:hasEnd [
-            ischart:inMYA 251.2
+            ischart:inMYA 247.2
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 73 ;
-    schema:color "#B051A5"^^ischart:RGBHex ;
+    sdo:color "#B051A5"^^ischart:RGBHex ;
 .
 
 ischart:Orosirian
     a skos:Concept ;
     gts:rank rank:Period ;
+    gts:ratifiedGSSA true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Ороѿир"@bg ,
@@ -3393,7 +3448,7 @@ ischart:Orosirian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 167 ;
-    schema:color "#F76898"^^ischart:RGBHex ;
+    sdo:color "#F76898"^^ischart:RGBHex ;
 .
 
 ischart:Oxfordian
@@ -3428,20 +3483,21 @@ ischart:Oxfordian
     skos:prefLabel "Oxfordian"@en ;
     time:hasBeginning [
             ischart:inMYA 161.5 ;
-            schema:marginOfError 1.0
+            sdo:marginOfError 1.0
         ] ;
     time:hasEnd [
             ischart:inMYA 154.8 ;
-            schema:marginOfError 0.8
+            sdo:marginOfError 0.8
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 53 ;
-    schema:color "#BFE7F1"^^ischart:RGBHex ;
+    sdo:color "#BFE7F1"^^ischart:RGBHex ;
 .
 
 ischart:Paibian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Паиб"@bg ,
@@ -3479,12 +3535,13 @@ ischart:Paibian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 145 ;
-    schema:color "#CCEBAE"^^ischart:RGBHex ;
+    sdo:color "#CCEBAE"^^ischart:RGBHex ;
 .
 
 ischart:Paleoarchean
     a skos:Concept ;
     gts:rank rank:Era ;
+    gts:ratifiedGSSA true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Палеоархай"@bg ,
@@ -3522,12 +3579,13 @@ ischart:Paleoarchean
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 174 ;
-    schema:color "#F4449F"^^ischart:RGBHex ;
+    sdo:color "#F4449F"^^ischart:RGBHex ;
 .
 
 ischart:Piacenzian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Пиачен"@bg ,
@@ -3563,12 +3621,13 @@ ischart:Piacenzian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 11 ;
-    schema:color "#FFFFBF"^^ischart:RGBHex ;
+    sdo:color "#FFFFBF"^^ischart:RGBHex ;
 .
 
 ischart:Pliensbachian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Плиинѿбах"@bg ,
@@ -3598,20 +3657,21 @@ ischart:Pliensbachian
     skos:prefLabel "Pliensbachian"@en ;
     time:hasBeginning [
             ischart:inMYA 192.9 ;
-            schema:marginOfError 0.3
+            sdo:marginOfError 0.3
         ] ;
     time:hasEnd [
             ischart:inMYA 184.2 ;
-            schema:marginOfError 0.3
+            sdo:marginOfError 0.3
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 61 ;
-    schema:color "#80C5DD"^^ischart:RGBHex ;
+    sdo:color "#80C5DD"^^ischart:RGBHex ;
 .
 
 ischart:Pragian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Праг"@bg ,
@@ -3641,20 +3701,21 @@ ischart:Pragian
     skos:prefLabel "Pragian"@en ;
     time:hasBeginning [
             ischart:inMYA 410.8 ;
-            schema:marginOfError 2.8
+            sdo:marginOfError 2.8
         ] ;
     time:hasEnd [
             ischart:inMYA 407.6 ;
-            schema:marginOfError 2.6
+            sdo:marginOfError 2.6
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 115 ;
-    schema:color "#E5C468"^^ischart:RGBHex ;
+    sdo:color "#E5C468"^^ischart:RGBHex ;
 .
 
 ischart:Priabonian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Приабон"@bg ,
@@ -3690,7 +3751,7 @@ ischart:Priabonian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 25 ;
-    schema:color "#FDCDA1"^^ischart:RGBHex ;
+    sdo:color "#FDCDA1"^^ischart:RGBHex ;
 .
 
 ischart:Rhaetian
@@ -3729,16 +3790,17 @@ ischart:Rhaetian
         ] ;
     time:hasEnd [
             ischart:inMYA 201.4 ;
-            schema:marginOfError 0.2
+            sdo:marginOfError 0.2
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 66 ;
-    schema:color "#E3B9DB"^^ischart:RGBHex ;
+    sdo:color "#E3B9DB"^^ischart:RGBHex ;
 .
 
 ischart:Rhuddanian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Рудан"@bg ,
@@ -3768,20 +3830,21 @@ ischart:Rhuddanian
     skos:prefLabel "Rhuddanian"@en ;
     time:hasBeginning [
             ischart:inMYA 443.8 ;
-            schema:marginOfError 1.5
+            sdo:marginOfError 1.5
         ] ;
     time:hasEnd [
             ischart:inMYA 440.8 ;
-            schema:marginOfError 1.2
+            sdo:marginOfError 1.2
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 129 ;
-    schema:color "#A6DCB5"^^ischart:RGBHex ;
+    sdo:color "#A6DCB5"^^ischart:RGBHex ;
 .
 
 ischart:Rhyacian
     a skos:Concept ;
     gts:rank rank:Period ;
+    gts:ratifiedGSSA true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Риац"@bg ,
@@ -3817,12 +3880,13 @@ ischart:Rhyacian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 168 ;
-    schema:color "#F75B89"^^ischart:RGBHex ;
+    sdo:color "#F75B89"^^ischart:RGBHex ;
 .
 
 ischart:Roadian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Роад"@bg ,
@@ -3852,20 +3916,21 @@ ischart:Roadian
     skos:prefLabel "Roadian"@en ;
     time:hasBeginning [
             ischart:inMYA 273.01 ;
-            schema:marginOfError 0.14
+            sdo:marginOfError 0.14
         ] ;
     time:hasEnd [
             ischart:inMYA 266.9 ;
-            schema:marginOfError 0.4
+            sdo:marginOfError 0.4
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 85 ;
-    schema:color "#FB8069"^^ischart:RGBHex ;
+    sdo:color "#FB8069"^^ischart:RGBHex ;
 .
 
 ischart:Rupelian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Рупел"@bg ,
@@ -3901,12 +3966,13 @@ ischart:Rupelian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 24 ;
-    schema:color "#FED99A"^^ischart:RGBHex ;
+    sdo:color "#FED99A"^^ischart:RGBHex ;
 .
 
 ischart:Sakmarian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Сакмар"@bg ,
@@ -3936,20 +4002,21 @@ ischart:Sakmarian
     skos:prefLabel "Sakmarian"@en ;
     time:hasBeginning [
             ischart:inMYA 293.51 ;
-            schema:marginOfError 0.17
+            sdo:marginOfError 0.17
         ] ;
     time:hasEnd [
             ischart:inMYA 290.1 ;
-            schema:marginOfError 0.26
+            sdo:marginOfError 0.26
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 88 ;
-    schema:color "#E36F5C"^^ischart:RGBHex ;
+    sdo:color "#E36F5C"^^ischart:RGBHex ;
 .
 
 ischart:Sandbian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Сандб"@bg ,
@@ -3979,20 +4046,21 @@ ischart:Sandbian
     skos:prefLabel "Sandbian"@en ;
     time:hasBeginning [
             ischart:inMYA 458.4 ;
-            schema:marginOfError 0.9
+            sdo:marginOfError 0.9
         ] ;
     time:hasEnd [
             ischart:inMYA 453.0 ;
-            schema:marginOfError 0.7
+            sdo:marginOfError 0.7
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 133 ;
-    schema:color "#8CD094"^^ischart:RGBHex ;
+    sdo:color "#8CD094"^^ischart:RGBHex ;
 .
 
 ischart:Santonian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Сантон"@bg ,
@@ -4022,20 +4090,21 @@ ischart:Santonian
     skos:prefLabel "Santonian"@en ;
     time:hasBeginning [
             ischart:inMYA 86.3 ;
-            schema:marginOfError 0.5
+            sdo:marginOfError 0.5
         ] ;
     time:hasEnd [
             ischart:inMYA 83.6 ;
-            schema:marginOfError 0.2
+            sdo:marginOfError 0.2
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 38 ;
-    schema:color "#D9EF74"^^ischart:RGBHex ;
+    sdo:color "#D9EF74"^^ischart:RGBHex ;
 .
 
 ischart:Selandian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Селанд"@bg ,
@@ -4071,7 +4140,7 @@ ischart:Selandian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 31 ;
-    schema:color "#FEBF65"^^ischart:RGBHex ;
+    sdo:color "#FEBF65"^^ischart:RGBHex ;
 .
 
 ischart:Serpukhovian
@@ -4106,20 +4175,21 @@ ischart:Serpukhovian
     skos:prefLabel "Serpukhovian"@en ;
     time:hasBeginning [
             ischart:inMYA 330.9 ;
-            schema:marginOfError 0.2
+            sdo:marginOfError 0.2
         ] ;
     time:hasEnd [
             ischart:inMYA 323.2 ;
-            schema:marginOfError 0.4
+            sdo:marginOfError 0.4
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 100 ;
-    schema:color "#BFC26B"^^ischart:RGBHex ;
+    sdo:color "#BFC26B"^^ischart:RGBHex ;
 .
 
 ischart:Serravallian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Саравал"@bg ,
@@ -4155,12 +4225,13 @@ ischart:Serravallian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 16 ;
-    schema:color "#FFFF59"^^ischart:RGBHex ;
+    sdo:color "#FFFF59"^^ischart:RGBHex ;
 .
 
 ischart:Sheinwoodian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Шейнуд"@bg ,
@@ -4190,20 +4261,21 @@ ischart:Sheinwoodian
     skos:prefLabel "Sheinwoodian"@en ;
     time:hasBeginning [
             ischart:inMYA 433.4 ;
-            schema:marginOfError 0.8
+            sdo:marginOfError 0.8
         ] ;
     time:hasEnd [
             ischart:inMYA 430.5 ;
-            schema:marginOfError 0.7
+            sdo:marginOfError 0.7
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 124 ;
-    schema:color "#BFE6C3"^^ischart:RGBHex ;
+    sdo:color "#BFE6C3"^^ischart:RGBHex ;
 .
 
 ischart:Siderian
     a skos:Concept ;
     gts:rank rank:Period ;
+    gts:ratifiedGSSA true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Сидер"@bg ,
@@ -4239,12 +4311,13 @@ ischart:Siderian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 171 ;
-    schema:color "#F74F7C"^^ischart:RGBHex ;
+    sdo:color "#F74F7C"^^ischart:RGBHex ;
 .
 
 ischart:Sinemurian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Синемур"@bg ,
@@ -4274,20 +4347,21 @@ ischart:Sinemurian
     skos:prefLabel "Sinemurian"@en ;
     time:hasBeginning [
             ischart:inMYA 199.5 ;
-            schema:marginOfError 0.3
+            sdo:marginOfError 0.3
         ] ;
     time:hasEnd [
             ischart:inMYA 192.9 ;
-            schema:marginOfError 0.3
+            sdo:marginOfError 0.3
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 62 ;
-    schema:color "#67BCD8"^^ischart:RGBHex ;
+    sdo:color "#67BCD8"^^ischart:RGBHex ;
 .
 
 ischart:Statherian
     a skos:Concept ;
     gts:rank rank:Period ;
+    gts:ratifiedGSSA true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Статер"@bg ,
@@ -4323,12 +4397,13 @@ ischart:Statherian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 166 ;
-    schema:color "#F875A7"^^ischart:RGBHex ;
+    sdo:color "#F875A7"^^ischart:RGBHex ;
 .
 
 ischart:Stenian
     a skos:Concept ;
     gts:rank rank:Period ;
+    gts:ratifiedGSSA true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Стен"@bg ,
@@ -4364,12 +4439,13 @@ ischart:Stenian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 162 ;
-    schema:color "#FED99A"^^ischart:RGBHex ;
+    sdo:color "#FED99A"^^ischart:RGBHex ;
 .
 
 ischart:Telychian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Телич"@bg ,
@@ -4399,20 +4475,21 @@ ischart:Telychian
     skos:prefLabel "Telychian"@en ;
     time:hasBeginning [
             ischart:inMYA 438.5 ;
-            schema:marginOfError 1.1
+            sdo:marginOfError 1.1
         ] ;
     time:hasEnd [
             ischart:inMYA 433.4 ;
-            schema:marginOfError 0.8
+            sdo:marginOfError 0.8
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 126 ;
-    schema:color "#BFE6CF"^^ischart:RGBHex ;
+    sdo:color "#BFE6CF"^^ischart:RGBHex ;
 .
 
 ischart:Thanetian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Танет"@bg ,
@@ -4448,7 +4525,7 @@ ischart:Thanetian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 30 ;
-    schema:color "#FDBF6F"^^ischart:RGBHex ;
+    sdo:color "#FDBF6F"^^ischart:RGBHex ;
 .
 
 ischart:Tithonian
@@ -4483,7 +4560,7 @@ ischart:Tithonian
     skos:prefLabel "Tithonian"@en ;
     time:hasBeginning [
             ischart:inMYA 149.2 ;
-            schema:marginOfError 0.7
+            sdo:marginOfError 0.7
         ] ;
     time:hasEnd [
             ischart:inMYA 145 ;
@@ -4491,12 +4568,13 @@ ischart:Tithonian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 51 ;
-    schema:color "#D9F1F7"^^ischart:RGBHex ;
+    sdo:color "#D9F1F7"^^ischart:RGBHex ;
 .
 
 ischart:Toarcian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Тоар"@bg ,
@@ -4526,20 +4604,21 @@ ischart:Toarcian
     skos:prefLabel "Toarcian"@en ;
     time:hasBeginning [
             ischart:inMYA 184.2 ;
-            schema:marginOfError 0.3
+            sdo:marginOfError 0.3
         ] ;
     time:hasEnd [
             ischart:inMYA 174.7 ;
-            schema:marginOfError 0.8
+            sdo:marginOfError 0.8
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 60 ;
-    schema:color "#99CEE3"^^ischart:RGBHex ;
+    sdo:color "#99CEE3"^^ischart:RGBHex ;
 .
 
 ischart:Tonian
     a skos:Concept ;
     gts:rank rank:Period ;
+    gts:ratifiedGSSA true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Тон"@bg ,
@@ -4576,12 +4655,13 @@ ischart:Tonian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 161 ;
-    schema:color "#FEBF4E"^^ischart:RGBHex ;
+    sdo:color "#FEBF4E"^^ischart:RGBHex ;
 .
 
 ischart:Tortonian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Тортон"@bg ,
@@ -4617,12 +4697,13 @@ ischart:Tortonian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 15 ;
-    schema:color "#FFFF66"^^ischart:RGBHex ;
+    sdo:color "#FFFF66"^^ischart:RGBHex ;
 .
 
 ischart:Tournaisian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Турней"@bg ,
@@ -4652,20 +4733,21 @@ ischart:Tournaisian
     skos:prefLabel "Tournaisian"@en ;
     time:hasBeginning [
             ischart:inMYA 358.9 ;
-            schema:marginOfError 0.4
+            sdo:marginOfError 0.4
         ] ;
     time:hasEnd [
             ischart:inMYA 346.7 ;
-            schema:marginOfError 0.4
+            sdo:marginOfError 0.4
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 107 ;
-    schema:color "#8CB06C"^^ischart:RGBHex ;
+    sdo:color "#8CB06C"^^ischart:RGBHex ;
 .
 
 ischart:Tremadocian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Тремадок"@bg ,
@@ -4695,20 +4777,21 @@ ischart:Tremadocian
     skos:prefLabel "Tremadocian"@en ;
     time:hasBeginning [
             ischart:inMYA 485.4 ;
-            schema:marginOfError 1.9
+            sdo:marginOfError 1.9
         ] ;
     time:hasEnd [
             ischart:inMYA 477.7 ;
-            schema:marginOfError 1.4
+            sdo:marginOfError 1.4
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 141 ;
-    schema:color "#33A97E"^^ischart:RGBHex ;
+    sdo:color "#33A97E"^^ischart:RGBHex ;
 .
 
 ischart:Turonian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Турон"@bg ,
@@ -4741,11 +4824,11 @@ ischart:Turonian
         ] ;
     time:hasEnd [
             ischart:inMYA 89.8 ;
-            schema:marginOfError 0.3
+            sdo:marginOfError 0.3
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 40 ;
-    schema:color "#BFE35D"^^ischart:RGBHex ;
+    sdo:color "#BFE35D"^^ischart:RGBHex ;
 .
 
 ischart:UpperPleistocene
@@ -4782,12 +4865,13 @@ ischart:UpperPleistocene
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 5 ;
-    schema:color "#FFF2D3"^^ischart:RGBHex ;
+    sdo:color "#FFF2D3"^^ischart:RGBHex ;
 .
 
 ischart:Valanginian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Валанжин"@bg ,
@@ -4816,21 +4900,22 @@ ischart:Valanginian
     skos:notation "b2"^^ischart:ccgmShortCode ;
     skos:prefLabel "Valanginian"@en ;
     time:hasBeginning [
-            ischart:inMYA 132.6 ;
-            skos:note "uncertain"
+            ischart:inMYA 137.05 ;
+            sdo:marginOfError 0.2 ;
         ] ;
     time:hasEnd [
-            ischart:inMYA 139.8 ;
+            ischart:inMYA 132.6 ;
             skos:note "uncertain"
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 47 ;
-    schema:color "#99D36A"^^ischart:RGBHex ;
+    sdo:color "#99D36A"^^ischart:RGBHex ;
 .
 
 ischart:Visean
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Визей"@bg ,
@@ -4860,20 +4945,21 @@ ischart:Visean
     skos:prefLabel "Visean"@en ;
     time:hasBeginning [
             ischart:inMYA 346.7 ;
-            schema:marginOfError 0.4
+            sdo:marginOfError 0.4
         ] ;
     time:hasEnd [
             ischart:inMYA 330.9 ;
-            schema:marginOfError 0.2
+            sdo:marginOfError 0.2
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 103 ;
-    schema:color "#A6B96C"^^ischart:RGBHex ;
+    sdo:color "#A6B96C"^^ischart:RGBHex ;
 .
 
 ischart:Wordian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Уорд"@bg ,
@@ -4903,20 +4989,21 @@ ischart:Wordian
     skos:prefLabel "Wordian"@en ;
     time:hasBeginning [
             ischart:inMYA 266.9 ;
-            schema:marginOfError 0.4
+            sdo:marginOfError 0.4
         ] ;
     time:hasEnd [
             ischart:inMYA 264.28 ;
-            schema:marginOfError 0.16
+            sdo:marginOfError 0.16
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 83 ;
-    schema:color "#FB8D76"^^ischart:RGBHex ;
+    sdo:color "#FB8D76"^^ischart:RGBHex ;
 .
 
 ischart:Wuchiapingian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Вучиапинг"@bg ,
@@ -4946,20 +5033,21 @@ ischart:Wuchiapingian
     skos:prefLabel "Wuchiapingian"@en ;
     time:hasBeginning [
             ischart:inMYA 259.51 ;
-            schema:marginOfError 0.21
+            sdo:marginOfError 0.21
         ] ;
     time:hasEnd [
             ischart:inMYA 254.14 ;
-            schema:marginOfError 0.07
+            sdo:marginOfError 0.07
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 81 ;
-    schema:color "#FCB4A2"^^ischart:RGBHex ;
+    sdo:color "#FCB4A2"^^ischart:RGBHex ;
 .
 
 ischart:Wuliuan
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:broader ischart:Miaolingian ;
     skos:definition "A time period from 509 to 504.5 million years ago" ;
@@ -4976,12 +5064,13 @@ ischart:Wuliuan
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 149 ;
-    schema:color "#B3D492"^^ischart:RGBHex ;
+    sdo:color "#B3D492"^^ischart:RGBHex ;
 .
 
 ischart:Ypresian
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Ипреѿ"@bg ,
@@ -5017,12 +5106,13 @@ ischart:Ypresian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 29 ;
-    schema:color "#FCA773"^^ischart:RGBHex ;
+    sdo:color "#FCA773"^^ischart:RGBHex ;
 .
 
 ischart:Zanclean
     a skos:Concept ;
     gts:rank rank:Age ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Занклѿки"@bg ,
@@ -5058,12 +5148,13 @@ ischart:Zanclean
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 13 ;
-    schema:color "#FFFFB3"^^ischart:RGBHex ;
+    sdo:color "#FFFFB3"^^ischart:RGBHex ;
 .
 
 ischart:LowerMississippian
     a skos:Concept ;
     gts:rank rank:Epoch ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "前期ミシシッピアン紀"@ja ,
@@ -5076,20 +5167,21 @@ ischart:LowerMississippian
     skos:prefLabel "Early Mississippian"@en ;
     time:hasBeginning [
             ischart:inMYA 358.9 ;
-            schema:marginOfError 0.4
+            sdo:marginOfError 0.4
         ] ;
     time:hasEnd [
             ischart:inMYA 346.7 ;
-            schema:marginOfError 0.4
+            sdo:marginOfError 0.4
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 105 ;
-    schema:color "#80AB6C"^^ischart:RGBHex ;
+    sdo:color "#80AB6C"^^ischart:RGBHex ;
 .
 
 ischart:LowerPennsylvanian
     a skos:Concept ;
     gts:rank rank:Epoch ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "前期ペンシルバニア紀"@ja ,
@@ -5102,20 +5194,21 @@ ischart:LowerPennsylvanian
     skos:prefLabel "Early Pennsylvanian"@en ;
     time:hasBeginning [
             ischart:inMYA 323.2 ;
-            schema:marginOfError 0.4
+            sdo:marginOfError 0.4
         ] ;
     time:hasEnd [
             ischart:inMYA 315.2 ;
-            schema:marginOfError 0.2
+            sdo:marginOfError 0.2
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 98 ;
-    schema:color "#8CBEB4"^^ischart:RGBHex ;
+    sdo:color "#8CBEB4"^^ischart:RGBHex ;
 .
 
 ischart:MiddleMississippian
     a skos:Concept ;
     gts:rank rank:Epoch ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "中期ミシシッピアン紀"@ja ,
@@ -5128,15 +5221,15 @@ ischart:MiddleMississippian
     skos:prefLabel "Middle Mississippian"@en ;
     time:hasBeginning [
             ischart:inMYA 346.7 ;
-            schema:marginOfError 0.4
+            sdo:marginOfError 0.4
         ] ;
     time:hasEnd [
             ischart:inMYA 330.9 ;
-            schema:marginOfError 0.2
+            sdo:marginOfError 0.2
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 102 ;
-    schema:color "#99B46C"^^ischart:RGBHex ;
+    sdo:color "#99B46C"^^ischart:RGBHex ;
 .
 
 ischart:MiddlePennsylvanian
@@ -5154,15 +5247,15 @@ ischart:MiddlePennsylvanian
     skos:prefLabel "Middle Pennsylvanian"@en ;
     time:hasBeginning [
             ischart:inMYA 315.2 ;
-            schema:marginOfError 0.2
+            sdo:marginOfError 0.2
         ] ;
     time:hasEnd [
             ischart:inMYA 307.0 ;
-            schema:marginOfError 0.1
+            sdo:marginOfError 0.1
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 95 ;
-    schema:color "#A6C7B7"^^ischart:RGBHex ;
+    sdo:color "#A6C7B7"^^ischart:RGBHex ;
 .
 
 ischart:Pridoli
@@ -5170,6 +5263,7 @@ ischart:Pridoli
     gts:rank
         rank:Age ,
         rank:Epoch ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Пржидол"@bg ,
@@ -5199,15 +5293,15 @@ ischart:Pridoli
     skos:prefLabel "Pridoli"@en ;
     time:hasBeginning [
             ischart:inMYA 423.0 ;
-            schema:marginOfError 2.3
+            sdo:marginOfError 2.3
         ] ;
     time:hasEnd [
             ischart:inMYA 419.2 ;
-            schema:marginOfError 3.2
+            sdo:marginOfError 3.2
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 119 ;
-    schema:color "#E6F5E1"^^ischart:RGBHex ;
+    sdo:color "#E6F5E1"^^ischart:RGBHex ;
 .
 
 ischart:UpperMississippian
@@ -5225,21 +5319,15 @@ ischart:UpperMississippian
     skos:prefLabel "Late Mississippian"@en ;
     time:hasBeginning [
             ischart:inMYA 330.9 ;
-            schema:marginOfError 0.2
+            sdo:marginOfError 0.2
         ] ;
     time:hasEnd [
             ischart:inMYA 323.2 ;
-            schema:marginOfError 0.4
+            sdo:marginOfError 0.4
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 101 ;
-    schema:color "#B3BE6C"^^ischart:RGBHex ;
-.
-
-<https://linked.data.gov.au/org/ics>
-    a schema:Organization ;
-    schema:name "International Commission on Stratigraphy" ;
-    schema:url "https://stratigraphy.org"^^xsd:anyURI ;
+    sdo:color "#B3BE6C"^^ischart:RGBHex ;
 .
 
 ischart:CambrianSeries2
@@ -5285,12 +5373,13 @@ ischart:CambrianSeries2
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 151 ;
-    schema:color "#99C078"^^ischart:RGBHex ;
+    sdo:color "#99C078"^^ischart:RGBHex ;
 .
 
 ischart:Carboniferous
     a skos:Concept ;
     gts:rank rank:Period ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Карбон"@bg ,
@@ -5323,15 +5412,15 @@ ischart:Carboniferous
     skos:prefLabel "Carboniferous"@en ;
     time:hasBeginning [
             ischart:inMYA 358.9 ;
-            schema:marginOfError 0.4
+            sdo:marginOfError 0.4
         ] ;
     time:hasEnd [
             ischart:inMYA 298.9 ;
-            schema:marginOfError 0.15
+            sdo:marginOfError 0.15
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 104 ;
-    schema:color "#67A599"^^ischart:RGBHex ;
+    sdo:color "#67A599"^^ischart:RGBHex ;
 .
 
 ischart:Cretaceous
@@ -5376,12 +5465,13 @@ ischart:Cretaceous
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 49 ;
-    schema:color "#7FC64E"^^ischart:RGBHex ;
+    sdo:color "#7FC64E"^^ischart:RGBHex ;
 .
 
 ischart:Lopingian
     a skos:Concept ;
     gts:rank rank:Epoch ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Лопинг"@bg ,
@@ -5414,20 +5504,21 @@ ischart:Lopingian
     skos:prefLabel "Lopingian"@en ;
     time:hasBeginning [
             ischart:inMYA 259.51 ;
-            schema:marginOfError 0.21
+            sdo:marginOfError 0.21
         ] ;
     time:hasEnd [
             ischart:inMYA 251.902 ;
-            schema:marginOfError 0.024
+            sdo:marginOfError 0.024
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 80 ;
-    schema:color "#FBA794"^^ischart:RGBHex ;
+    sdo:color "#FBA794"^^ischart:RGBHex ;
 .
 
 ischart:LowerOrdovician
     a skos:Concept ;
     gts:rank rank:Epoch ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Ранен Ордовик"@bg ,
@@ -5460,20 +5551,21 @@ ischart:LowerOrdovician
     skos:prefLabel "Early Ordovician"@en ;
     time:hasBeginning [
             ischart:inMYA 485.4 ;
-            schema:marginOfError 1.9
+            sdo:marginOfError 1.9
         ] ;
     time:hasEnd [
             ischart:inMYA 470.0 ;
-            schema:marginOfError 1.4
+            sdo:marginOfError 1.4
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 139 ;
-    schema:color "#1A9D6F"^^ischart:RGBHex ;
+    sdo:color "#1A9D6F"^^ischart:RGBHex ;
 .
 
 ischart:LowerTriassic
     a skos:Concept ;
     gts:rank rank:Epoch ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Раннен Триаѿ"@bg ,
@@ -5506,19 +5598,20 @@ ischart:LowerTriassic
     skos:prefLabel "Early Triassic"@en ;
     time:hasBeginning [
             ischart:inMYA 251.902 ;
-            schema:marginOfError 0.024
+            sdo:marginOfError 0.024
         ] ;
     time:hasEnd [
             ischart:inMYA 247.2
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 75 ;
-    schema:color "#983999"^^ischart:RGBHex ;
+    sdo:color "#983999"^^ischart:RGBHex ;
 .
 
 ischart:Ludlow
     a skos:Concept ;
     gts:rank rank:Epoch ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Лудлоу"@bg ,
@@ -5551,20 +5644,21 @@ ischart:Ludlow
     skos:prefLabel "Ludlow"@en ;
     time:hasBeginning [
             ischart:inMYA 427.4 ;
-            schema:marginOfError 0.5
+            sdo:marginOfError 0.5
         ] ;
     time:hasEnd [
             ischart:inMYA 419.2 ;
-            schema:marginOfError 3.2
+            sdo:marginOfError 3.2
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 122 ;
-    schema:color "#BFE6CF"^^ischart:RGBHex ;
+    sdo:color "#BFE6CF"^^ischart:RGBHex ;
 .
 
 ischart:MiddleDevonian
     a skos:Concept ;
     gts:rank rank:Epoch ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Среден Девон"@bg ,
@@ -5597,20 +5691,21 @@ ischart:MiddleDevonian
     skos:prefLabel "Middle Devonian"@en ;
     time:hasBeginning [
             ischart:inMYA 393.3 ;
-            schema:marginOfError 1.2
+            sdo:marginOfError 1.2
         ] ;
     time:hasEnd [
             ischart:inMYA 382.7 ;
-            schema:marginOfError 1.6
+            sdo:marginOfError 1.6
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 113 ;
-    schema:color "#F1C868"^^ischart:RGBHex ;
+    sdo:color "#F1C868"^^ischart:RGBHex ;
 .
 
 ischart:MiddleOrdovician
     a skos:Concept ;
     gts:rank rank:Epoch ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Среден Ордовик"@bg ,
@@ -5643,15 +5738,15 @@ ischart:MiddleOrdovician
     skos:prefLabel "Middle Ordovician"@en ;
     time:hasBeginning [
             ischart:inMYA 470.0 ;
-            schema:marginOfError 1.4
+            sdo:marginOfError 1.4
         ] ;
     time:hasEnd [
             ischart:inMYA 458.4 ;
-            schema:marginOfError 0.9
+            sdo:marginOfError 0.9
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 137 ;
-    schema:color "#4DB47E"^^ischart:RGBHex ;
+    sdo:color "#4DB47E"^^ischart:RGBHex ;
 .
 
 ischart:MiddleTriassic
@@ -5696,12 +5791,13 @@ ischart:MiddleTriassic
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 72 ;
-    schema:color "#B168B1"^^ischart:RGBHex ;
+    sdo:color "#B168B1"^^ischart:RGBHex ;
 .
 
 ischart:Neogene
     a skos:Concept ;
     gts:rank rank:Period ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "пеоген"@bg ,
@@ -5740,12 +5836,13 @@ ischart:Neogene
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 21 ;
-    schema:color "#FFE619"^^ischart:RGBHex ;
+    sdo:color "#FFE619"^^ischart:RGBHex ;
 .
 
 ischart:Oligocene
     a skos:Concept ;
     gts:rank rank:Epoch ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Олигоцен"@bg ,
@@ -5784,12 +5881,13 @@ ischart:Oligocene
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 23 ;
-    schema:color "#FEC07A"^^ischart:RGBHex ;
+    sdo:color "#FEC07A"^^ischart:RGBHex ;
 .
 
 ischart:Pliocene
     a skos:Concept ;
     gts:rank rank:Epoch ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Плиоцен"@bg ,
@@ -5828,12 +5926,13 @@ ischart:Pliocene
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 12 ;
-    schema:color "#FFFF99"^^ischart:RGBHex ;
+    sdo:color "#FFFF99"^^ischart:RGBHex ;
 .
 
 ischart:Quaternary
     a skos:Concept ;
     gts:rank rank:Period ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Кватернер"@bg ,
@@ -5872,12 +5971,13 @@ ischart:Quaternary
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 10 ;
-    schema:color "#F9F97F"^^ischart:RGBHex ;
+    sdo:color "#F9F97F"^^ischart:RGBHex ;
 .
 
 ischart:Terreneuvian
     a skos:Concept ;
     gts:rank rank:Epoch ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Теренеув"@bg ,
@@ -5910,7 +6010,7 @@ ischart:Terreneuvian
     skos:prefLabel "Terreneuvian"@en ;
     time:hasBeginning [
             ischart:inMYA 538.8 ;
-            schema:marginOfError 0.2
+            sdo:marginOfError 0.2
         ] ;
     time:hasEnd [
             ischart:inMYA 521 ;
@@ -5918,12 +6018,13 @@ ischart:Terreneuvian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 157 ;
-    schema:color "#8CB06C"^^ischart:RGBHex ;
+    sdo:color "#8CB06C"^^ischart:RGBHex ;
 .
 
 ischart:UpperDevonian
     a skos:Concept ;
     gts:rank rank:Epoch ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Къѿен Девон"@bg ,
@@ -5952,15 +6053,15 @@ ischart:UpperDevonian
     skos:prefLabel "Late Devonian"@en ;
     time:hasBeginning [
             ischart:inMYA 382.7 ;
-            schema:marginOfError 1.6
+            sdo:marginOfError 1.6
         ] ;
     time:hasEnd [
             ischart:inMYA 358.9 ;
-            schema:marginOfError 0.4
+            sdo:marginOfError 0.4
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 110 ;
-    schema:color "#F1E19D"^^ischart:RGBHex ;
+    sdo:color "#F1E19D"^^ischart:RGBHex ;
 .
 
 ischart:UpperPennsylvanian
@@ -5994,20 +6095,21 @@ ischart:UpperPennsylvanian
     skos:prefLabel "Late Pennsylvanian"@en ;
     time:hasBeginning [
             ischart:inMYA 307.0 ;
-            schema:marginOfError 0.1
+            sdo:marginOfError 0.1
         ] ;
     time:hasEnd [
             ischart:inMYA 298.9 ;
-            schema:marginOfError 0.15
+            sdo:marginOfError 0.15
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 94 ;
-    schema:color "#BFD0BA"^^ischart:RGBHex ;
+    sdo:color "#BFD0BA"^^ischart:RGBHex ;
 .
 
 ischart:Wenlock
     a skos:Concept ;
     gts:rank rank:Epoch ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Венлок"@bg ,
@@ -6040,20 +6142,21 @@ ischart:Wenlock
     skos:prefLabel "Wenlock"@en ;
     time:hasBeginning [
             ischart:inMYA 433.4 ;
-            schema:marginOfError 0.8
+            sdo:marginOfError 0.8
         ] ;
     time:hasEnd [
             ischart:inMYA 427.4 ;
-            schema:marginOfError 0.5
+            sdo:marginOfError 0.5
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 125 ;
-    schema:color "#B3E1C2"^^ischart:RGBHex ;
+    sdo:color "#B3E1C2"^^ischart:RGBHex ;
 .
 
 ischart:Cenozoic
     a skos:Concept ;
     gts:rank rank:Era ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "пеозой"@bg ,
@@ -6095,12 +6198,13 @@ ischart:Cenozoic
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 32 ;
-    schema:color "#F2F91D"^^ischart:RGBHex ;
+    sdo:color "#F2F91D"^^ischart:RGBHex ;
 .
 
 ischart:Devonian
     a skos:Concept ;
     gts:rank rank:Period ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Девон"@bg ,
@@ -6134,20 +6238,21 @@ ischart:Devonian
     skos:prefLabel "Devonian"@en ;
     time:hasBeginning [
             ischart:inMYA 419.2 ;
-            schema:marginOfError 3.2
+            sdo:marginOfError 3.2
         ] ;
     time:hasEnd [
             ischart:inMYA 358.9 ;
-            schema:marginOfError 0.4
+            sdo:marginOfError 0.4
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 116 ;
-    schema:color "#CB8C37"^^ischart:RGBHex ;
+    sdo:color "#CB8C37"^^ischart:RGBHex ;
 .
 
 ischart:Furongian
     a skos:Concept ;
     gts:rank rank:Epoch ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Фуронг"@bg ,
@@ -6185,16 +6290,17 @@ ischart:Furongian
         ] ;
     time:hasEnd [
             ischart:inMYA 485.4 ;
-            schema:marginOfError 1.9
+            sdo:marginOfError 1.9
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 144 ;
-    schema:color "#B3E095"^^ischart:RGBHex ;
+    sdo:color "#B3E095"^^ischart:RGBHex ;
 .
 
 ischart:Guadalupian
     a skos:Concept ;
     gts:rank rank:Epoch ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Гуадалуп"@bg ,
@@ -6228,20 +6334,21 @@ ischart:Guadalupian
     skos:prefLabel "Guadalupian"@en ;
     time:hasBeginning [
             ischart:inMYA 273.01 ;
-            schema:marginOfError 0.14
+            sdo:marginOfError 0.14
         ] ;
     time:hasEnd [
             ischart:inMYA 259.51 ;
-            schema:marginOfError 0.21
+            sdo:marginOfError 0.21
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 84 ;
-    schema:color "#FB745C"^^ischart:RGBHex ;
+    sdo:color "#FB745C"^^ischart:RGBHex ;
 .
 
 ischart:Holocene
     a skos:Concept ;
     gts:rank rank:Epoch ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Холоцен"@bg ,
@@ -6281,12 +6388,13 @@ ischart:Holocene
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 4 ;
-    schema:color "#FEEBD2"^^ischart:RGBHex ;
+    sdo:color "#FEEBD2"^^ischart:RGBHex ;
 .
 
 ischart:Jurassic
     a skos:Concept ;
     gts:rank rank:Period ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Юра"@bg ,
@@ -6320,7 +6428,7 @@ ischart:Jurassic
     skos:prefLabel "Jurassic"@en ;
     time:hasBeginning [
             ischart:inMYA 201.4 ;
-            schema:marginOfError 0.2
+            sdo:marginOfError 0.2
         ] ;
     time:hasEnd [
             ischart:inMYA 145.0 ;
@@ -6328,12 +6436,13 @@ ischart:Jurassic
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 64 ;
-    schema:color "#34B2C9"^^ischart:RGBHex ;
+    sdo:color "#34B2C9"^^ischart:RGBHex ;
 .
 
 ischart:Llandovery
     a skos:Concept ;
     gts:rank rank:Epoch ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Лиандовери"@bg ,
@@ -6367,20 +6476,21 @@ ischart:Llandovery
     skos:prefLabel "Llandovery"@en ;
     time:hasBeginning [
             ischart:inMYA 443.8 ;
-            schema:marginOfError 1.5
+            sdo:marginOfError 1.5
         ] ;
     time:hasEnd [
             ischart:inMYA 433.4 ;
-            schema:marginOfError 0.8
+            sdo:marginOfError 0.8
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 128 ;
-    schema:color "#99D7B3"^^ischart:RGBHex ;
+    sdo:color "#99D7B3"^^ischart:RGBHex ;
 .
 
 ischart:LowerDevonian
     a skos:Concept ;
     gts:rank rank:Epoch ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Ранен Девон"@bg ,
@@ -6414,20 +6524,21 @@ ischart:LowerDevonian
     skos:prefLabel "Early Devonian"@en ;
     time:hasBeginning [
             ischart:inMYA 419.2 ;
-            schema:marginOfError 3.2
+            sdo:marginOfError 3.2
         ] ;
     time:hasEnd [
             ischart:inMYA 393.3 ;
-            schema:marginOfError 1.2
+            sdo:marginOfError 1.2
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 118 ;
-    schema:color "#E5AC4D"^^ischart:RGBHex ;
+    sdo:color "#E5AC4D"^^ischart:RGBHex ;
 .
 
 ischart:Mesoproterozoic
     a skos:Concept ;
     gts:rank rank:Era ;
+    gts:ratifiedGSSA true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Мезопротерозой"@bg ,
@@ -6467,12 +6578,13 @@ ischart:Mesoproterozoic
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 165 ;
-    schema:color "#FDB462"^^ischart:RGBHex ;
+    sdo:color "#FDB462"^^ischart:RGBHex ;
 .
 
 ischart:Mesozoic
     a skos:Concept ;
     gts:rank rank:Era ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Мезозой"@bg ,
@@ -6506,19 +6618,20 @@ ischart:Mesozoic
     skos:prefLabel "Mesozoic"@en ;
     time:hasBeginning [
             ischart:inMYA 251.902 ;
-            schema:marginOfError 0.024
+            sdo:marginOfError 0.024
         ] ;
     time:hasEnd [
             ischart:inMYA 66.0
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 76 ;
-    schema:color "#67C5CA"^^ischart:RGBHex ;
+    sdo:color "#67C5CA"^^ischart:RGBHex ;
 .
 
 ischart:Miaolingian
     a skos:Concept ;
     gts:rank rank:Epoch ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:broader ischart:Cambrian ;
     skos:definition "A time period from 509 to 497 million years ago" ;
@@ -6539,12 +6652,13 @@ ischart:Miaolingian
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 148 ;
-    schema:color "#A6CF86"^^ischart:RGBHex ;
+    sdo:color "#A6CF86"^^ischart:RGBHex ;
 .
 
 ischart:Mississippian
     a skos:Concept ;
     gts:rank rank:Sub-Period ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Миѿиѿип"@bg ,
@@ -6578,20 +6692,22 @@ ischart:Mississippian
     skos:prefLabel "Mississippian"@en ;
     time:hasBeginning [
             ischart:inMYA 358.9 ;
-            schema:marginOfError 0.4
+            sdo:marginOfError 0.4
         ] ;
     time:hasEnd [
             ischart:inMYA 323.2 ;
-            schema:marginOfError 0.4
+            sdo:marginOfError 0.4
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 106 ;
-    schema:color "#678F66"^^ischart:RGBHex ;
+    sdo:color "#678F66"^^ischart:RGBHex ;
 .
 
 ischart:Neoproterozoic
     a skos:Concept ;
     gts:rank rank:Era ;
+    gts:ratifiedGSSA true ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "пеопротерозой"@bg ,
@@ -6628,16 +6744,17 @@ ischart:Neoproterozoic
         ] ;
     time:hasEnd [
             ischart:inMYA 538.8 ;
-            schema:marginOfError 0.2
+            sdo:marginOfError 0.2
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 160 ;
-    schema:color "#FEB342"^^ischart:RGBHex ;
+    sdo:color "#FEB342"^^ischart:RGBHex ;
 .
 
 ischart:Ordovician
     a skos:Concept ;
     gts:rank rank:Period ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Ордовик"@bg ,
@@ -6671,20 +6788,21 @@ ischart:Ordovician
     skos:prefLabel "Ordovician"@en ;
     time:hasBeginning [
             ischart:inMYA 485.4 ;
-            schema:marginOfError 1.9
+            sdo:marginOfError 1.9
         ] ;
     time:hasEnd [
             ischart:inMYA 443.8 ;
-            schema:marginOfError 1.5
+            sdo:marginOfError 1.5
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 140 ;
-    schema:color "#009270"^^ischart:RGBHex ;
+    sdo:color "#009270"^^ischart:RGBHex ;
 .
 
 ischart:Paleocene
     a skos:Concept ;
     gts:rank rank:Epoch ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Палеоцен"@bg ,
@@ -6726,12 +6844,13 @@ ischart:Paleocene
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 34 ;
-    schema:color "#FDA75F"^^ischart:RGBHex ;
+    sdo:color "#FDA75F"^^ischart:RGBHex ;
 .
 
 ischart:Paleogene
     a skos:Concept ;
     gts:rank rank:Period ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Палеоген"@bg ,
@@ -6773,12 +6892,13 @@ ischart:Paleogene
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 35 ;
-    schema:color "#FD9A52"^^ischart:RGBHex ;
+    sdo:color "#FD9A52"^^ischart:RGBHex ;
 .
 
 ischart:Pennsylvanian
     a skos:Concept ;
     gts:rank rank:Sub-Period ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Пенѿилван"@bg ,
@@ -6812,20 +6932,21 @@ ischart:Pennsylvanian
     skos:prefLabel "Pennsylvanian"@en ;
     time:hasBeginning [
             ischart:inMYA 323.2 ;
-            schema:marginOfError 0.4
+            sdo:marginOfError 0.4
         ] ;
     time:hasEnd [
             ischart:inMYA 298.9 ;
-            schema:marginOfError 0.15
+            sdo:marginOfError 0.15
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 99 ;
-    schema:color "#7EBCC6"^^ischart:RGBHex ;
+    sdo:color "#7EBCC6"^^ischart:RGBHex ;
 .
 
 ischart:Permian
     a skos:Concept ;
     gts:rank rank:Period ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Перм"@bg ,
@@ -6859,20 +6980,21 @@ ischart:Permian
     skos:prefLabel "Permian"@en ;
     time:hasBeginning [
             ischart:inMYA 298.9 ;
-            schema:marginOfError 0.15
+            sdo:marginOfError 0.15
         ] ;
     time:hasEnd [
             ischart:inMYA 251.902 ;
-            schema:marginOfError 0.024
+            sdo:marginOfError 0.024
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 91 ;
-    schema:color "#F04028"^^ischart:RGBHex ;
+    sdo:color "#F04028"^^ischart:RGBHex ;
 .
 
 ischart:Phanerozoic
     a skos:Concept ;
     gts:rank rank:Eon ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Фанерозой"@bg ,
@@ -6905,19 +7027,20 @@ ischart:Phanerozoic
     skos:prefLabel "Phanerozoic"@en ;
     time:hasBeginning [
             ischart:inMYA 538.8 ;
-            schema:marginOfError 0.2
+            sdo:marginOfError 0.2
         ] ;
     time:hasEnd [
             ischart:inMYA 0
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 156 ;
-    schema:color "#9AD9DD"^^ischart:RGBHex ;
+    sdo:color "#9AD9DD"^^ischart:RGBHex ;
 .
 
 ischart:Precambrian
     a skos:Concept ;
     gts:rank rank:Super-Eon ;
+    gts:ratifiedGSSA true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Прекамбрий"@bg ,
@@ -6953,16 +7076,17 @@ ischart:Precambrian
         ] ;
     time:hasEnd [
             ischart:inMYA 538.8 ;
-            schema:marginOfError 0.2
+            sdo:marginOfError 0.2
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 178 ;
-    schema:color "#F74370"^^ischart:RGBHex ;
+    sdo:color "#F74370"^^ischart:RGBHex ;
 .
 
 ischart:Proterozoic
     a skos:Concept ;
     gts:rank rank:Eon ;
+    gts:ratifiedGSSA true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Протерозой"@bg ,
@@ -6999,16 +7123,17 @@ ischart:Proterozoic
         ] ;
     time:hasEnd [
             ischart:inMYA 538.8 ;
-            schema:marginOfError 0.2
+            sdo:marginOfError 0.2
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 170 ;
-    schema:color "#F73563"^^ischart:RGBHex ;
+    sdo:color "#F73563"^^ischart:RGBHex ;
 .
 
 ischart:Triassic
     a skos:Concept ;
     gts:rank rank:Period ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Триаѿ"@bg ,
@@ -7042,15 +7167,15 @@ ischart:Triassic
     skos:prefLabel "Triassic"@en ;
     time:hasBeginning [
             ischart:inMYA 251.902 ;
-            schema:marginOfError 0.024
+            sdo:marginOfError 0.024
         ] ;
     time:hasEnd [
             ischart:inMYA 201.4 ;
-            schema:marginOfError 0.2
+            sdo:marginOfError 0.2
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 78 ;
-    schema:color "#812B92"^^ischart:RGBHex ;
+    sdo:color "#812B92"^^ischart:RGBHex ;
 .
 
 ischart:UpperJurassic
@@ -7085,7 +7210,7 @@ ischart:UpperJurassic
     skos:prefLabel "Late Jurassic"@en ;
     time:hasBeginning [
             ischart:inMYA 161.5 ;
-            schema:marginOfError 1.0
+            sdo:marginOfError 1.0
         ] ;
     time:hasEnd [
             ischart:inMYA 145 ;
@@ -7093,12 +7218,13 @@ ischart:UpperJurassic
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 54 ;
-    schema:color "#B3E3EE"^^ischart:RGBHex ;
+    sdo:color "#B3E3EE"^^ischart:RGBHex ;
 .
 
 ischart:UpperOrdovician
     a skos:Concept ;
     gts:rank rank:Epoch ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Къѿен Ордовик"@bg ,
@@ -7128,20 +7254,21 @@ ischart:UpperOrdovician
     skos:prefLabel "Late Ordovician"@en ;
     time:hasBeginning [
             ischart:inMYA 458.4 ;
-            schema:marginOfError 0.9
+            sdo:marginOfError 0.9
         ] ;
     time:hasEnd [
             ischart:inMYA 443.8 ;
-            schema:marginOfError 1.5
+            sdo:marginOfError 1.5
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 134 ;
-    schema:color "#7FCA93"^^ischart:RGBHex ;
+    sdo:color "#7FCA93"^^ischart:RGBHex ;
 .
 
 ischart:UpperTriassic
     a skos:Concept ;
     gts:rank rank:Epoch ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Къѿен Триаѿ"@bg ,
@@ -7175,16 +7302,17 @@ ischart:UpperTriassic
         ] ;
     time:hasEnd [
             ischart:inMYA 201.4 ;
-            schema:marginOfError 0.2
+            sdo:marginOfError 0.2
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 69 ;
-    schema:color "#BD8CC3"^^ischart:RGBHex ;
+    sdo:color "#BD8CC3"^^ischart:RGBHex ;
 .
 
 ischart:Archean
     a skos:Concept ;
     gts:rank rank:Eon ;
+    gts:ratifiedGSSA true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "прхай"@bg ,
@@ -7221,19 +7349,20 @@ ischart:Archean
     skos:prefLabel "Archean"@en ;
     time:hasBeginning [
             ischart:inMYA 4031 ;
-            schema:marginOfError 3
+            sdo:marginOfError 3
         ] ;
     time:hasEnd [
             ischart:inMYA 2500
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 175 ;
-    schema:color "#F0047F"^^ischart:RGBHex ;
+    sdo:color "#F0047F"^^ischart:RGBHex ;
 .
 
 ischart:Cambrian
     a skos:Concept ;
     gts:rank rank:Period ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Камбрий"@bg ,
@@ -7268,20 +7397,21 @@ ischart:Cambrian
     skos:prefLabel "Cambrian"@en ;
     time:hasBeginning [
             ischart:inMYA 538.8 ;
-            schema:marginOfError 0.2
+            sdo:marginOfError 0.2
         ] ;
     time:hasEnd [
             ischart:inMYA 485.4 ;
-            schema:marginOfError 1.9
+            sdo:marginOfError 1.9
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 154 ;
-    schema:color "#7FA056"^^ischart:RGBHex ;
+    sdo:color "#7FA056"^^ischart:RGBHex ;
 .
 
 ischart:Cisuralian
     a skos:Concept ;
     gts:rank rank:Epoch ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Циѿурал"@bg ,
@@ -7316,20 +7446,21 @@ ischart:Cisuralian
     skos:prefLabel "Cisuralian"@en ;
     time:hasBeginning [
             ischart:inMYA 298.9 ;
-            schema:marginOfError 0.15
+            sdo:marginOfError 0.15
         ] ;
     time:hasEnd [
             ischart:inMYA 273.01 ;
-            schema:marginOfError 0.14
+            sdo:marginOfError 0.14
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 90 ;
-    schema:color "#EF5845"^^ischart:RGBHex ;
+    sdo:color "#EF5845"^^ischart:RGBHex ;
 .
 
 ischart:Eocene
     a skos:Concept ;
     gts:rank rank:Epoch ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Еоцен"@bg ,
@@ -7370,12 +7501,13 @@ ischart:Eocene
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 28 ;
-    schema:color "#FDB46C"^^ischart:RGBHex ;
+    sdo:color "#FDB46C"^^ischart:RGBHex ;
 .
 
 ischart:LowerJurassic
     a skos:Concept ;
     gts:rank rank:Epoch ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Ранна Юра"@bg ,
@@ -7410,20 +7542,21 @@ ischart:LowerJurassic
     skos:prefLabel "Early Jurassic"@en ;
     time:hasBeginning [
             ischart:inMYA 201.4 ;
-            schema:marginOfError 0.2
+            sdo:marginOfError 0.2
         ] ;
     time:hasEnd [
             ischart:inMYA 174.7 ;
-            schema:marginOfError 0.8
+            sdo:marginOfError 0.8
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 65 ;
-    schema:color "#42AED0"^^ischart:RGBHex ;
+    sdo:color "#42AED0"^^ischart:RGBHex ;
 .
 
 ischart:MiddleJurassic
     a skos:Concept ;
     gts:rank rank:Epoch ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Средна Юра"@bg ,
@@ -7458,20 +7591,21 @@ ischart:MiddleJurassic
     skos:prefLabel "Middle Jurassic"@en ;
     time:hasBeginning [
             ischart:inMYA 174.7 ;
-            schema:marginOfError 0.8
+            sdo:marginOfError 0.8
         ] ;
     time:hasEnd [
             ischart:inMYA 161.5 ;
-            schema:marginOfError 1.0
+            sdo:marginOfError 1.0
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 59 ;
-    schema:color "#80CFD8"^^ischart:RGBHex ;
+    sdo:color "#80CFD8"^^ischart:RGBHex ;
 .
 
 ischart:Paleoproterozoic
     a skos:Concept ;
     gts:rank rank:Era ;
+    gts:ratifiedGSSA true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Палеопротерозой"@bg ,
@@ -7514,12 +7648,13 @@ ischart:Paleoproterozoic
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 169 ;
-    schema:color "#F74370"^^ischart:RGBHex ;
+    sdo:color "#F74370"^^ischart:RGBHex ;
 .
 
 ischart:Pleistocene
     a skos:Concept ;
     gts:rank rank:Epoch ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Плейѿтоцен"@bg ,
@@ -7560,12 +7695,13 @@ ischart:Pleistocene
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 9 ;
-    schema:color "#FFEFAF"^^ischart:RGBHex ;
+    sdo:color "#FFEFAF"^^ischart:RGBHex ;
 .
 
 ischart:Silurian
     a skos:Concept ;
     gts:rank rank:Period ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Силур"@bg ,
@@ -7600,15 +7736,15 @@ ischart:Silurian
     skos:prefLabel "Silurian"@en ;
     time:hasBeginning [
             ischart:inMYA 443.8 ;
-            schema:marginOfError 1.5
+            sdo:marginOfError 1.5
         ] ;
     time:hasEnd [
             ischart:inMYA 419.2 ;
-            schema:marginOfError 3.2
+            sdo:marginOfError 3.2
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 130 ;
-    schema:color "#B3E1B6"^^ischart:RGBHex ;
+    sdo:color "#B3E1B6"^^ischart:RGBHex ;
 .
 
 ischart:LowerCretaceous
@@ -7655,12 +7791,13 @@ ischart:LowerCretaceous
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 50 ;
-    schema:color "#8CCD57"^^ischart:RGBHex ;
+    sdo:color "#8CCD57"^^ischart:RGBHex ;
 .
 
 ischart:Miocene
     a skos:Concept ;
     gts:rank rank:Epoch ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Миоцен"@bg ,
@@ -7703,12 +7840,13 @@ ischart:Miocene
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 20 ;
-    schema:color "#FFFF00"^^ischart:RGBHex ;
+    sdo:color "#FFFF00"^^ischart:RGBHex ;
 .
 
 ischart:Paleozoic
     a skos:Concept ;
     gts:rank rank:Era ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Палеозой"@bg ,
@@ -7746,21 +7884,22 @@ ischart:Paleozoic
     skos:notation "PZ"^^ischart:ccgmShortCode ;
     skos:prefLabel "Paleozoic"@en ;
     time:hasBeginning [
-            ischart:inMYA 251.902 ;
-            schema:marginOfError 0.024
+            ischart:inMYA 538.8 ;
+            sdo:marginOfError 0.2
         ] ;
     time:hasEnd [
-            ischart:inMYA 538.8 ;
-            schema:marginOfError 0.2
+            ischart:inMYA 251.902 ;
+            sdo:marginOfError 0.024
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 77 ;
-    schema:color "#99C08D"^^ischart:RGBHex ;
+    sdo:color "#99C08D"^^ischart:RGBHex ;
 .
 
 ischart:UpperCretaceous
     a skos:Concept ;
     gts:rank rank:Epoch ;
+    gts:ratifiedGSSP true ;
     rdfs:isDefinedBy ts:gts2020 ;
     skos:altLabel
         "Къѿна Креда"@bg ,
@@ -7799,30 +7938,338 @@ ischart:UpperCretaceous
         ] ;
     prov:wasDerivedFrom ts:gts2020 ;
     sh:order 42 ;
-    schema:color "#A6D84A"^^ischart:RGBHex ;
+    sdo:color "#A6D84A"^^ischart:RGBHex ;
 .
 
 cs:
     a skos:ConceptScheme ;
     dcterms:conformsTo <https://w3id.org/profile/vocpub/4.6> ;
-    dcterms:created "2023-11-05"^^xsd:date ;
+    dcterms:created "2024-11-26"^^xsd:date ;
     dcterms:creator <https://linked.data.gov.au/org/ics> ;
-    dcterms:modified "2023-11-16"^^xsd:date ;
+    dcterms:modified "2024-11-22"^^xsd:date ;
     dcterms:publisher <https://linked.data.gov.au/org/ics> ;
-    owl:versionIRI <https://w3id.org/profile/gts-skos/2023-09> ;
-    owl:versionInfo "2023-09" ;
-    reg:status agldwgstatus:experimental ;
-    skos:definition """This is a SKOS vocabulary presentation of the time units of the International Chronostratigraphic Chart represented as SKOS Concepts. Beginning and End ages are given for each unit in units of Millions of Years Ago (MYA)."""@en ;
+    owl:versionIRI ischart:2024-12 ;
+    owl:versionInfo "2024-12" ;
+    skos:altLabel
+        "TAULA CRONOESTRATIGRÀFICA INTERNACIONAL"@ca ,
+        "MEZINÁRODNÍ CHRONOSTRATIGRAFICKÁ TABULKA"@cs ,
+        "INTERNATIONALE CHRONOSTRATIGRAPHISCHE TABELLE"@de ,
+        "TABLA CRONOESTRATIGRÁFICA INTERNACIONAL"@es ,
+        "NAZIOARTEKO TAULA KRONOESTRATIGRAFIKOA"@eu ,
+        "KANSAINVÄLINEN KRONOSTRATIGRAFINEN TAULU"@fi ,
+        "CHARTE CHRONOSTRATIGRAPHIQUE INTERNATIONALE"@fr ,
+        "NEMZETKÖZI IDŐRÉTEGTANI TÁBLÁZAT"@hu ,
+        "SCALA CRONOSTRATIGRAFICA INTERNAZIONALE"@it ,
+        "国際年代層序表"@ja ,
+        "국 제 지 질 연 대 층 서 표"@ko ,
+        "TARPTAUTINĖ CHRONOSTRATIGRAFIJOS SKALĖ"@lt ,
+        "INTERNATIONALE CHRONOSTRATIGRAFISCHE TABEL"@nl ,
+        "INTERNASJONAL KRONOSTRATIGRAFISK TABELL"@no ,
+        "TABELA CRONOESTRATIGRÁFICA INTERNACIONAL"@pt ,
+        "МЕЖДУНАРОДНАЯ ХРОНОСТРАТИГРАФИЧЕСКАЯ ШКАЛА"@ru ,
+        "MEDZINÁRODNÁ CHRONOSTRATIGRAFICKÁ TABUĽKA"@sk ,
+        "ULUSLARARASI KRONOSTRATİGRAFİK ÇİZELGE"@tr ,
+        "国 际 年 代 地 层 表"@zh ;
+    skos:definition "This is a SKOS vocabulary presentation of the time units of the International Chronostratigraphic Chart represented as SKOS Concepts. Beginning and End ages are given for each unit in units of Millions of Years Ago (MYA)."@en ;
     skos:hasTopConcept
         ischart:Phanerozoic ,
         ischart:Precambrian ;
-    skos:historyNote "This vocabulary uses IRIs created for the Geologic Timescale (2020) data (see http://resource.geosciml.org/vocabulary/timescale/) with dates updated from the 2023-09 Chart (see https://stratigraphy.org/chart)" ;
+    skos:historyNote "This vocabulary uses IRIs originally created for the Geologic Timescale (2020) data (see http://resource.geosciml.org/vocabulary/timescale/)" ;
     skos:prefLabel "International Chronostratigraphic Chart"@en ;
     prov:wasDerivedFrom ts:gts2020 ;
-    schema:citation "https://stratigraphy.org/chart"^^xsd:anyURI ;
-    schema:copyrightHolder <https://linked.data.gov.au/org/ics> ;
-    schema:copyrightNotice "(c) International Commission on Stratigraphy, 2023"@en ;
-    schema:license <https://creativecommons.org/licenses/by/4.0/> ;
-    schema:keywords
-        theme:geology-framework ;
+    sdo:citation "https://stratigraphy.org/chart"^^xsd:anyURI ;
+    sdo:copyrightHolder <https://linked.data.gov.au/org/ics> ;
+    sdo:copyrightNotice "(c) International Commission on Stratigraphy, 2024"@en ;
+    sdo:license <https://creativecommons.org/licenses/by/4.0/> ;
+    skos:versionInfo """2024-12: Updated Chart to include:
+
+* ratification of the Valanginian GSSP
+* numeric age of Valanginian updated to 137.05 +/- 0.2
+
+2023-09: updated form of the Geologic Timescale (2020) (see http://resource.geosciml.org/vocabulary/timescale/) to match the 2023-09 Chart, as released at https://stratigraphy.org/chart in late 2023.""" ;
+    skos:scopeNote
+        """Units of all ranks are in the process of being defined by Global Boundary Stratotype Section and Points (GSSP) for their lower boundaries, including those of the Archean and Proterozoic, long defined by Global Standard Stratigraphic Ages (GSSA). Italic fonts indicate informal units and placeholders for unnamed units. Versioned charts and detailed information on ratified GSSPs are available at the website http://www.stratigraphy.org. The URL to this chart is found below.
+
+Numerical ages are subject to revision and do not define units in the Phanerozoic and the Ediacaran; only GSSPs do. For boundaries in the Phanerozoic without ratified GSSPs or without constrained numerical ages, an approximate numerical age (~) is provided.
+
+Ratified Subseries/Subepochs are abbreviated as U/L (Upper/Late), M (Middle) and L/E (Lower/Early). Numerical ages for all systems except Quaternary, upper Paleogene, Cretaceous, Jurassic, Triassic, Permian, Cambrian and Precambrian are taken from ‘A Geologic Time Scale 2012’ by Gradstein et al. (2012), those for the Quaternary, upper Paleogene, Cretaceous, Jurassic, Triassic, Permian, Cambrian and Precambrian were provided by the relevant ICS subcommissions.
+
+Colouring follows the Commission for the Geological Map of the World <www.ccgm.org>.
+
+Chart drafted by K.M. Cohen, D.A.T. Harper, P.L. Gibbard, N. Car
+
+(c) International Commission on Stratigraphy, September 2024.
+
+To cite: Cohen, K.M., Finney, S.C., Gibbard, P.L. & Fan, J.-X. (2013; updated), _The ICS International Chronostratigraphic Chart_. Episodes 36: 199-204"""@en ,
+
+    """Els límits inferiors de les unitats de tots els rangs es troben actualment en procés de ser definits com a Estratotips Globals de Límit (GSSP - Global Boundary Stratotype Section and Point), incloses les de l'Arqueà i el Proterozoic que, per convenció, havien estat definits cronomètricament segons edats numèriques absolutes (GSSA-Global Standard Stratigraphic Ages). Hom pot trobar la taula original i la informació detallada sobre els GSSP ratificats a http://www.stratigraphy.org.
+
+Les edats numèriques (Ma) estan subjectes a revisió i no defineixen unitats en el Fanerozoic ni en I’Ediacarià. Això només ho fan els GSSP. Pel que fa als límits d'aquelles unitats del Fanerozoic que encara no tenen un GSSP ratificat, o dels quals no es disposa d'una edat numèrica acotada, la taula dona una edat numèrica aproximada (~).
+
+Les Subsèries/Subèpoques ratificades s’abrevien com S/T (Superior/Tardà), M (Mitjà) i I/P (Inferior/Primerenc). Les edats numèriques de tots els sistemes, excepte el Quaternari, el Paleogen superior, el Cretaci, el Juràssic, el Triàsic, el Permià i el Precambrià provenen de “A Geologic Time Scale 2012” de Gradstein et al. (2012). Les del Quaternari, Paleogen superior, Cretaci, Juràssic, Triàsic, Permià, Cambrià i Precambrià són aportacions originals de les subcomissions respectives de la ICS (Int. Commission on Stratigraphy).
+
+Taula dissenyada per K.M. Cohen, D.A.T. Harper, P.L. Gibbard, N. Car
+
+(c) Comissió Internacional d’Estratigrafia (IUGS), Setembre 2024.
+
+Citacio: Cohen, K.M., Finney, S.C., Gibbard, P.L., y Fan, J.-X. (2013; actualilzat) The ICS Intemational Chronostratigraphic Chart. Episodes 36: 199-204.
+
+Traducció al català per iniciativa de Juan Carlos Gutiérrez-Marco (CSIC)."""@ca ,
+
+    """Postupně se pracuje na tom, aby všechny jednotky byly definovány svými spodními hranicemi na globálních stratotypech (GSSP - Global Boundary Stratotype Section and Point). To platí i pro jednotky archaika a proterozoika, dosud definované globálním standardním stratigrafickým stářím (GSSA - Global Standard Stratigraphic Age). Neformální jednotky a jednotky doposud nepojmenované jsou psány kurzívou. Další verze tabulky a detailní informace o ratifikovaných GSSP jsou dostupné na webu http://www.stratigraphy.org. URL této tabulky je uveden níže.
+
+Absolutní stáří jsou průběžně revidována a nedefinují jednotky ve fanerozoiku a ediakaru, kde jsou rozhodující pouze GSSP. Pro absolutního stáří hranic fanerozoických jednotek bez ratifikovaného GSSP nebo bez přesného absolutního datování je použit symbol (~).
+
+Označení schválených pododdělení/podepoch jsou v tabulce zkrácena na sp/sta (spodní/starší), stř (střední) a sv/ml (svrchní/mladší). Absolutní stáří jednotek jsou převzata z Gradstein et al. (2012) ‘A Geologic Time Scale 2012’, s výjimkou kvartéru, svrchního paleogénu, křídy, jurský, triasu, permu a prekambria, pro něž byla data poskytnuta příslušnými ICS subkomisemi.
+
+Barvy jednotek převzaty podle Komise pro geologickou mapu světa (Commission for the Geological Map of the World; www.ccgm.org).
+
+Návrh originální tabulky v angličtině: K.M. Cohen, D.A.T. Harper, P.L. Gibbard, N. Car
+
+(c) Mezinárodní stratigrafická komise, září 2023
+
+Způsob citace původní tabulky: Cohen, K.M., Finney, S.C., Gibbard, P.L. & Fan, J.-X. (2013; updated) The ICS International Chronostratigraphic Chart. Episodes 36:199-204"""@cs ,
+
+    """Globale stratigraphische Einheiten werden mit ihrer Basis definiert an Globalen Stratotyp Profilen und Punkten (GSSP, Global Stratotyp Section and Point). Dagegen sind Einheiten ≥ 1000 Ma definiert mit Globalen Stratigraphischen Standardaltern (GSSA). Mehr Informationen dazu unter: http://www.stratigraphy.org. Bis 09/2023 ratifizierte Grenzen sind mit einem Goldenen Nagel markiert.
+
+Die numerischen Alter stammen aus der Global Time Scale 2012 (GTS 2012, Gradstein et al. 2012), die Alter für das untere Pleistozän, das Chattium, die untere Kreide, die Jura, die Trias, das Perm und das Kryogenium von den zuständigen ICS-Subkommissionen. Das Zeichen ~ steht vor relativ unsicheren Altern.
+
+Farben: Commission for the Geological Map of the World (CGMW, http://www.ccgm.org).
+
+Zitierweize: Cohen, K.M., Finney, S.C., Gibbard, P.L. & Fan, J.-X. (2013;aktualisiert) The ICS International Chronostratigraphic Chart. Episodes 36:199-204. URL: http://www.stratigraphy.org/ICSchart/ChronostratChart2022-02.pdf
+
+Version in Deutsch: Deutsche Stratigraphische Kommission (DSK, M. Menning) Österreichische Stratigraphische Kommission (ASC, W. Piller)"""@de ,
+
+    """odas las unidades de esta Tabla, cualquiera que sea su rango, se definen por el Estratotipo Global de Límite (GSSP - Global Boundary Stratotype Section and Point) referido siempre a su límite inferior. Este proceso se halla todavía inacabado e incluirá las unidades del Arcaico y Proterozoico, cuyas divisiones se convinieron inicialmente mediante edades absolutas (GSSA - Global Standard Stratigraphic Ages). La posición de los GSSP oficiales se indica en la tabla mediante el símbolo del “Clavo Dorado” (Golden Spike), que los materializa en el terreno. El original de la tabla en distintos idiomas y formatos, junto con los detalles de los estratotipos globales de límite (criterio de definición de cada uno, localización geográfica y geológica, correlación, etc.), están disponibles en la web www.stratigraphy.org.
+
+Las edades absolutas, expresadas en millones de años (Ma), son sólo orientativas, pues tanto el Ediacárico como las unidades del Fanerozoico se definen formalmente por sus correspondientes GSSP, en vez de por edades numéricas. No obstante, para aquellas divisiones que no cuentan aún con un estratotipo global o con edades bien establecidas, se indican las dataciones aproximadas (~ Ma) de sus límites. Las edades numéricas han sido tomadas de Gradstein et al. (A Geologic Time Scale 2012), con excepción de las correspondientes al Cuaternario, Paleógeno superior, Cretácico, Jurásico, Triásico, Pérmico, Cámbrico y Precámbrico, que fueron aportadas por las subcomisiones respectivas de la ICS-IUGS.
+
+Tabla diseñada por K.M. Cohen, D.A.T. Harper, P.L. Gibbard y N. Car
+
+(c) International Commission on Stratigraphy (IUGS), Septiembre 2024.
+
+Citar como: Cohen, K.M., Finney, S.C., Gibbard, P.L. & Fan, J.-X. (2013; actualizada). The ICS International Chronostratigraphic Chart. Episodes 36: 199-204"""@es ,
+
+    """Kategoria guztietako unitateak definitzeko prozesuan daude beren beheko mugen muga-estratotipo globaleko ebaki eta puntuen bidez (GSSP-Global Boundary Stratotype Section and Point); baita Arkearrekoak eta Proterozoikokoak ere, denbora luzean adin estratigrafiko estandar globalez (GSSA-Global Standard Startigraphic Ages) definituak izan direnak. Taulak eta onetsitako GSSPen informazio xehea ondorengo web orrian eskuragarri daude: http://www.stratigraphy.org. Taula honen URLa behean adierazita dago.
+
+Adin numerikoak berrikusi egin daitezke eta ez dute unitaterik definitzen Fanerozoikoan eta Ediacararrean; soilik GSSPek definitzen dituzte unitateak. GSSPrik onetsita edo adin numeriko mugaturik ez duten mugentzako gutxi gorabeharko adin numeriko bat (~) eman da.
+
+Sistema guztien adin numerikoak, Behe Pleistozeno, Permiar, Triasiko, Kretazeo eta Kanbriarraurrekoak izan ezik, “A Geological Time Scale 2012” (Gradstein et al., 2012) argitalpenetik hartuak dira; Behe Pleistozeno, Permiar, Triasiko eta Kretazeokoak dagozkien ICSko azpibatzordeek emanak dira.
+
+Taula hau K.M. Cohen, S.C. Finney eta P.L. Gibbard-ek diseinatu dute
+
+(c) International Commission on Stratigraphy (IUGS), 2024 eko urtarrila.
+
+Aipamena egiteko: Cohen, K.M., Finney, S.C., Gibbard, P.L. eta Fan, J.-X. (2013; eguneratua) The ICS International Chronostratigraphic Chart. Episodes 36: 199-204"""@eu ,
+
+    """Kaikkien stratigrafisten tasojen yksiköille määritetään alarajoja Global Boundary Stratotype Section and Points (GSSP) -periaatteen mukaisesti. Tämä koskee myös arkeeisten ja proterotsooisten yksiköiden rajoja, jotka on aikaisemmin määritetty Global Standard Stratigraphic Ages (GSSA) -periaatteen mukaan. Epäviralliset yksiköt on kirjoitettu kursiivilla. Aiemmat versiot ja yksityiskohtaiset tiedot ratifioitujen globaalien stratotyyppileikkausten alakontaktien maantieteellisistä sijainneista (GSSP-kohteista) on saatavana verkkosivustolla http://www.stratigraphy.org. Kaavion verkkosivun URL-osoite on annettu alla.
+
+Numeeriset iät saattavat muuttua eikä niillä määritetä fanerotsooisia eikä ediakaran yksiköitä; ne rajautuvat yksinomaan globaalien stratotyyppileikkausten alakontaktien (GSSP:t) perusteella. Fanerotsooisille yksikkörajoille annetaan ikäarvio (~), mikäli rajoilla ei ole ratifioitua GSSP:tä tai vahvistettua numeerista ikää.
+
+Ratifioidut sarjojen ja epookkien alajaot on lyhennetty Y/M (ylä-/myöhäis-), K (keski) ja A/V (ala-/varhais-). Kvartääriä, yläpaleogeenia, liitua, triasta, permiä ja prekambria lukuun ottamatta numeeriset iät on esitetty Gradstein et al. (2012) julkaisussa ”A Geologic Time Scale 2012”; kvartäärin, yläpaleogeenin, liidun, jura, triaksen, permin ja prekambrin iät on saatu asianomaisilta ICS:n alakomiteoilta.
+
+Väritys noudattaa Maailman geologisen karttakomission Geological Map of World (http://www.ccgm.org) värejä
+
+Taulun ovat laatineet K.M. Cohen, D.A.T. Harper, P.L. Gibbard, N. Car
+
+(c) International Commission on Stratigraphy, Syyskuu 2024.
+
+Viittausohje: Cohen, K.M., Finney, S.C., Gibbard, P.L. & Fan, J.-X. (2013; updated) The ICS International Chronostratigraphic Chart. Episodes 36: 199-204."""@fi ,
+
+    """La définition de la limite inférieure de chaque unité formelle par un point précis dans la coupe d’un stratotype de limite global (GSSP-Global Boundary Stratotype Section and Points) est encore en cours, y compris celle des unités de l’Archéen et du Protérozoïque, auparavant définie par des âges absolus (GSSA-Global Standard Stratigraphic Ages). Les noms en italique indiquent des unités informelles et l’espace pour des unités à nommer. Les chartes et des informations plus détaillées sur les GSSP sont disponibles sur le site web de l’International Commission on Stratigraphy (ICS) www.stratigraphy.org.
+
+Les âges numériques sont sujets à révision et ne définissent pas les unités du Phanérozoïque et de l’Édicarien; seuls les GSSP le font. Pour les limites du Phanérozoïque qui n’ont pas de GSSP ratifiés ou des âges numériques calibrés, un âge numérique approximatif (~) est indiqué. Les sous-séries/-sous-époques ratifiées sont abbrégées par S (Supérieur), M (Moyen) et I (Inférieur). Les âges numériques de tous les systèmes à l’exception du Précambrien, Cambrien, Permien, Trias, Jurassique, Crétacé, Paléogène supérieur et Quaternaire sont tirés du livre A Geologic Time Scale 2012 par Gradstein et al. (2012); ceux Précambrien, Cambrien, Permien, Trias, Jurassique, Crétacé, Paléogène supérieur et Quaternaire ont été définis par les subcommissions de l’ICS.
+
+Les couleurs suivent les recommendations de la Commission de la Carte Géologique du Monde (www.ccgm.org)
+
+Chart faite par K.M. Cohen, D.A.T. Harper, P.L. Gibbard, N. Car
+
+(c) Commission Internationale de Stratigraphie, Septembre 2024.
+
+Citation: Cohen, K.M., Finney, S.C., Gibbard, P..L. & Fan, J.X. (2013; updated) The ICS International Chronostratigraphic Chart. Episodes 36:199-204"""@fr ,
+
+    """Bármely rendű egység alsó határának kijelölése globális határsztratotípus-szelvény és pont (GSSP) alapján történik, beleértve az archaikum és proterozoikum egységeit is, bár ezeket sokáig globális standard rétegtani korok (GSSA) útján definiálták. Az informális, valamint a még elnevezésre váró egységeket dőlt betű jelzi. A táblázat különböző verziói és a ratifikált GSSP-kre vonatkozó részletes információk a http://www.stratigraphy.org honlapról érhetők el. E táblázat webcímét lásd alább.
+
+A számszerű korok új kormeghatározási eredmények alapján változhatnak, de a fanerozoikum egységeinek és az ediacarainak a definíciójában nincs szerepük. A ratifikált GSSP-vel vagy megbízhatóan meghatározott számszerű korral nem rendelkező fanerozoikumi egységeknél közelítő számszerű kor (~) szerepel.
+
+A ratifikált alsorozatok/alkorok rövidítése f/k (felső/késő), k (középső) és a/k (alsó/kora). A számszerű korok forrása Gradstein et al. (2012) „A Geologic Time Scale 2012” c. műve, kivéve a kvarter, felső paleogén, kréta, jura, triász, perm és prekambrium egységeit, melyekhez a Nemzetközi Rétegtani Bizottság illetékes albizottságai szolgáltattak adatot.
+
+A színek a Földtani Világtérkép Bizottság (CGMW) rendszerét követik. ( www.ccgm.org )
+
+A táblázat kidolgozói: K.M. Cohen, D.A.T. Harper, P.L. Gibbard, N. Car
+
+(c) Nemzetközi Rétegtani Bizottság (ICS), 2024. szeptember
+
+Javasolt idézés: Cohen, K.M., Finney, S.C., Gibbard, P.L. & Fan, J.-X. (2013; frissítve) The ICS International Chronostratigraphic Chart. Episodes 36: 199-204."""@hu ,
+
+    """Le unità stratigrafiche del Fanerozoico e dell'Ediacarano, sono state o sono in procinto di essere definite da GSSP (Global Boundary Stratotype Section and Points) tramite il loro limite inferiore. Le unità con età ≥ 1000 Ma, ovvero quelle dell'Archeano e del Proterozoico, sono al momento definite da GSSA (Global Stratigraphic Standard Ages). I nomi in corsivo identificano le unità informali, mentre le unità non ancora definite sono indicate con il nome generico del proprio rango. Schemi aggiornati e informazioni dettagliate sui GSSP ratificati sono disponibili sul sito web http://www.stratigraphy.org. Le datazioni numeriche sono oggetto di revisione e, a differenza dei GSSP, non definiscono unità nel Fanerozoico e nell’Ediacarano. Per le unità del Fanerozoico non definite da GSSP o senza un’età precisa, viene indicata un’età numerica approssimata (~). Le età numeriche per tutti i sistemi eccetto che per il Quaternario, il Paleogene superiore, il Cretacico, il Triassico, il Permiano, il Cambriano e il Precambriano sono prese da “A Geologic Time Scale 2012” di Gradstein et al. (2012), quelle per il Quaternario, il Paleogene superiore, il Cretacico, il Giurassico, il Triassico, il Permiano, il Cambriano e il Precambriano sono state fornite dalle relative sottocommissioni della ICS.
+
+I colori seguono le indicazioni della Commission for the Geological Map of the World (www.ccgm.org)
+
+Carta redatta da K.M. Cohen, D.A.T. Harper, P.L. Gibbard, N. Car
+
+(c) International Commission on Stratigraphy, settembre 2024.
+
+Da citare: Cohen, K.M., Finney, S.C., Gibbard, P.L. & Fan, J.-X. (2013; aggiornato)
+The ICS International Chronostratigraphic Chart. Episodes 36: 199-204
+
+Traduzione a cura della Commissione Italiana di Stratigrafia"""@it ,
+
+    """すべての階層の層序区分単位に対して，その下限をGSSPs（国際境界模式層断面とポイント）によって定義する作業が進行中である．これは，長らくGSSA（国際標準層序年代）によって定義されてきた太古（累）界および原生（累）界の下限に対しても同様である．GSSPsに関する図および詳細な情報は，ウェブサイト http://www.stratigraphy.org に掲載されている．
+
+本表に掲載されている年代値は見直されることがあるが，それは顕生（累）界およびエディアカラン系の層序区分単位の定義の変更を伴うものではない．そのような定義の変更は，GSSPsによってのみ可能である．GSSPsにより定義されていない境界や確定した年代値がない顕生（累）界の層序区分単位境界に対しては，おおよその年代値を「~」を付して示した．
+
+第四系，上部古第三系，白亜系，三畳系，ペルム系，カンブリア系，先カンブリア（累）界を除く全ての界の年代値は，Gradstein et al.（2012） の‘The Geologic Time Scale 2012’による．第四系，上部古第三系，白亜系，三畳系，ペルム系，カンブリア系，先カンブリア（累）界の年代値に関しては，当該問題を扱う国際層序委員会の小委員会による．
+
+この日本語版ISC Chart（2024年6月版）は，IUGS（国際地質科学 連合）の許諾を得て，日本地質学会が作成した．表の色は，国際地質図委員会（Commission for the Geological Map of the World (www.cgmw.org）の 推奨に従う
+
+図案 (オリジナル): K.M. Cohen, D.A.T. Harper, P.L. Gibbard, N. Car
+
+(c) 国際層序委員会，2024年12月
+
+引用: Cohen, K.M., Finney, S.C., Gibbard, P.L. & Fan, J.-X. (2013; updated) The ICS International Chronostratigraphic Chart. Episodes 36: 199-204."""@ja ,
+
+    """오 랫 동 안 국 제 표 준 층 서 연 령 ( G S S A ) 으 로 지 정 된 시 생 누 대 와 원생누대의 하부경계를 포함하여, 모든 지질시대의 하부경계에 대한 국제표준층서구역(GSSP)을 지정하고 있는 중이다. 이탤릭체는 비공식적인 지질시대나 이름이 붙여지지 않은 지질시대를 나타낸다. 이 표 의 모 든 버 전 과 승 인 된 G S S P 에 대 한 자 세 한 정 보 는 http://www.stratigraphy.org에서 찾아볼 수 있다. 이 표의 URL은 아래에 적어 놓았다.
+
+수 치 연 령 은 수 정 될 수 있 으 며 , 현 생 누 대 의 지 질 시 대 와 에디아카리기는 수치연령이 아니라 GSSP에 의해서만 정의된다. GSSP가 승인되지 않았거나 범위가 제한된 수치연령이 주어지지 않은 현생누대 지질시대의 경계에는 수치연령의 근사값(~)을 적어 놓았다. 승인된 아세/아통은 후기, 중기, 전기로 표기하였다. 제4기, 상부 고진기, 백악기, 트라이아스기, 쥐라기, 페름기, 캄브리아기 그리고 선 캄 브 리 아 시 대 의 수 치 연 령 은 국 제 층 서 위 원 회 의 해 당 지질시대위원회에서 제공하였으며, 이를 제외한 모든 지질시대 경계의 수치연령은 ‘Gradstein et al. (2012)의 ‘A Geologic Time Scale 2012’로 부터 인용하였다.
+
+표의 색채는 세계지질도위원회 (www.ccgm.org) 를 따랐다.
+
+표의 초안은 2024년 06월 (c) 국제층서위원회의 K.M. Cohen, D.A.T. Harper, P.L. Gibbard, N. Car가 만들었다.
+
+인용: Cohen, K.M., Finney, S.C., Gibbard, P.L. & Fan, J.-X. (2013; updated) The ICS International Chronostratigraphic Chart. Episodes 36: 199-204."""@ko ,
+
+    """Visų rangų padaliniai yra apibrėžti Globalinio stratotipo pjūvio apatinės ribos tašku (GSPT), o archejaus ir proterozojaus padaliniai nusakomi Globalinio stratigrafinio amžiaus standartu (GSAS). Patvirtintu GSPT lentelėje detali informacija yra tikra tinklalapyje http://www.stratigraphy.org
+
+Fanerozojaus ir ediakaro GSPT padalinių amžiaus skaičiai yra neapibrėžti ir gali būti tikslinami toms fanerozojaus riboms, kurioms nėra GSPT patvirtinimo arba jos negalutinės, skaičiai rodo apytikrį amžių (~), yra sąlyginiai.
+
+Visų sistemų amžius, išskyrus apatinį pleistoceną, permą, triasą, kreidą ir prekambrą yra paimti iš Geologinės laiko skalės 2012 (Gradstein ir kt., 2012), o toms apatinio pleistoceno, permo, triaso ir kreidos, sąlygiškai pagal pakomisių duomenis. Spalvos suderintos su pasaulinio geologinio žemėlapio spalvomis (http://www.ccgm.org).
+
+Lentelė sudaryta: K.M. Cohen, S.C. Finney, P.L. Gibbard
+
+(c) Tarptautinė stratigrafijos komisija, 2024 sausis.
+
+Cituoti: Cohen, K.M., Finney, S.C., Gibbard, P.L., ir Fan, J.-X. (2013; papildyta) The ICS International Chronostratigraphic Chart. Episodes 36: 199-204."""@lt ,
+
+    """De ondergrens van eenheden van verschillende rang, wordt momenteel stapsgewijs gedefinieerd op basis van Global Boundary Stratotype Section and Points (GSSPs), ook die in het Archeïcum en het Proterozoïcum welke vooralsnog als Global Standard Stratigraphic Age (GSSA) vastgesteld zijn. Tabellen en nadere informatie over geratificeerde GSSPs zijn te vinden op www.stratigraphy.org. De URL van deze tabel is hieronder gegeven.
+
+Van eenheden met hun door een GSSP gedefinieerde ondergrens, wordt de veronderstelde ouderdom in Ma van tijd tot tijd herzien (naar nieuw inzicht bijgesteld). Voor Fanerozoïsche eenheden waarvoor nog geen GSSP en/of numerieke ouderdom is vastgesteld, is een ouderdom bij benadering gegeven (~).
+
+De ouderdommen in Ma zijn overgenomen uit ‘A Geological Time Scale 2012’ door Gradstein et al. (2012), met uitzondering van die voor het Precambrium, Cambrium, Perm, Trias, Jura, Krijt, boven Paleogeen en Kwartair, die afkomstig zijn van de betreffende ICS subcommissies.
+
+De kleuren volgen deze van de Commissie voor de Geologische Kaart van de Wereld www.ccgm.org
+
+Tabel opgesteld door K.M. Cohen, D.A.T. Harper, P.L. Gibbard & N. Car
+
+(c) International Commission on Stratigraphy, September 2024.
+
+Citeren: Cohen, K.M., Finney, S.C., Gibbard, P.L. & Fan, J.-X. (2013; updated). The ICS International Chronostratigraphic Chart. Episodes 36: 199-204.
+"""@nl ,
+
+    """Det pågår nå en prosess der de nedre grensene for alle enhetene i tabellen defineres med Global Boundary Stratotype Section and Points (GSSP). Dette gjelder også for grensene i arkeikum og proterozoikum som lenge har vært definert med Global Standard Stratigraphical Ages (GSSA). Tabeller og detaljert informasjon om ratifiserte GSSP er tilgjengelig på websiden www.stratigraphy.org. Denne tabellens URL finnes nedenfor.
+
+Numeriske aldre underkastes revisjon og definerer ikke enheter i fanerozoikum og ediacara; kun ratifiserte GSSP gjelder. For grenser i fanerozoikum uten ratifisert GSSP eller kalibrerte numeriske aldere, er bare tilnærmete aldre (~) oppgitt.
+
+Numeriske aldre for alle systemer unntatt prekambrium, perm, trias, jura, kritt, øvre paleogen og kvartær er hentet fra ‘A Geological Time Scale 2012’ av Gradstein et al. (2012), mens de fra prekambrium, perm, trias, jura, kritt, øvre paleogen og kvartær er fremskaffet av de relevante underkomiteer i ICS.
+
+Fargeskalaen følger retningslinjene til The Commission for the Geological Map of the World www.ccgm.org
+
+Tabellen er tegnet av K.M. Cohen, D.A.T. Harper, P.L. Gibbard & J.-X. Fan
+
+(c) International Commission on Stratigraphy, Septemebr 2024.
+
+Referanse: Cohen, K.M., Finney, S.C., Gibbard, P.L. & Fan, J.-X. (2013; updated). The ICS International Chronostratigraphic Chart. Episodes 36: 199-204."""@no ,
+
+    """A definição do Estratotipo Global de Limite (GSSP - Global Boundary Stratotype Section and Point) para a base dos diversos andares, séries, sistemas e eratemas, é um processo ainda incompleto. O mesmo ocorre A Tabela original e os detalhes sobre os GSSP (critério de definição de cada um, localização geográfica e geológica, correlação, etc.), atualizam-se regularmente na web page: http://www.stratigraphy.org.
+
+As Subséries e Subépocas ratificadas estão abreviadas como S (Superior), M (Médio) e I (Inferior). A datação absoluta em milhões de anos (Ma) para a base do Ediacárico e das restantes unidades do Fanerozoico é apenas orientadora, em especial para os limites sem GSSP formal (~Ma). Estes valores poderão ser revistos no futuro ou serem recalibrados geocronometricamente. Os valores indicados são provenientes de Gradstein et al. (A Geologic Time Scale 2012), excetuando as datações do Quaternário, Paleogénico Superior, Cretácico, Jurássico, Triássico, Pérmico, Câmbrico e Precâmbrico, fornecidas pelas subcomissões respetivas da ICS-IUGS.
+
+Tabela desenhada por K.M. Cohen, D.A.T. Harper, P.L. Gibbard e N. Car Setembro de 2024 © International Commission on Stratigraphy (IUGS)
+
+Citar: Cohen, K.M., Finney, S.C., Gibbard, P.L. & Fan, J.-X. (2013; atualizada) The ICS International chronostratigraphic Chart. Episodes 36: 199-204."""@pt ,
+
+    """Нижние границы всех подразделений, определяемые Точкой глобального стратотипа границ (ТГСГ) постоянно уточняются, в том числе подразделения архея и протерозоя, давно определяемые геохронологическими данными (ГССВ /GSSA).
+
+Шкалы и подробная информация о ратифицированных GSSP доступна на сайте: http://www.stratigraphy.org. URL-адрес данной шкалы приводится ниже.
+
+Геохронологические возрасты границ постоянно уточняются и не определяют поразделения фанерозоя и эдиакария, которые фиксируются только через GSSP. Для границ в фанерозое, которые не имеют ратифицированных GSSP или рассчитанных геохронологических оценок, указано приблизительное значение (~).
+
+Оценки возрастов для всех систем, за исключением раннего плейстоцена, мелового, триасового, пермского периодов и докембрия приведены по «A Geologic Time Scale 2012» (Gradstein et al., 2012); а для указанных выше систем представлены соответствующими подкомиссиями ICS.
+
+Цвета шкалы соответствуют требованиям Комиссии по геологической карте Мира (http://ccgm.org/)
+
+Шкала представлена K.M. Cohen, D.A.T. Harper, P.L. Gibbard
+
+(с) Международная комиссия по стратиграфии, февраль 2024 г.
+
+Цитировать: Cohen, K.M., Finney, S.C., Gibbard, P.L. & Fan, J.-X. (2013; с дополнениями) The ICS International Chronostratigraphic Chart. Episodes 36: 199-204."""@ru ,
+
+    """Spodné hranice všetkých rádov sú definované na základe stratotypových profilov a bodov globálnych hraníc (GSSP) vrátane archaických a peroterozoických, ktoré sú definované na základe globálnych štandardných Numerické veky sú predmetom revízie a na rozdiel od GSSP nedefinujú jednotky fanerozoika a ediakaru. Pre hranice fanerozoických stupňov bez ratifikovaných GSSP alebo bez definovaného numerického veku, je použitý približný numerický vek (~).
+
+Ratifikované pododdelenia/podepochy sú skrátene označené v./m. (vrchný/mladší), str. (stredný) a sp./st. (spodný/starší). Numerické veky pri všetkých útvaroch okrem kvartéru, vrchného paleogénu, kriedy, triasu, permu a predkambria sú prevzaté z práce Gradstein et al. (2012)A Geologic Time Scale 2012. Kvartérne, vrchnopaleogénne, kriedové, jurský, triasové, permské a predkambrické veky poskytli príslušné subkomisie ICS.
+
+Farby podľa Komisie pre geologickú mapu sveta (www.ccgm.org)
+
+Anglickú tabuľku nakreslili K.M. Cohen, D.A.T. Harper, P.L. Gibbard a N. Car
+
+(c) Medzinárodná stratigrafická komisia, septembra 2024.
+
+Citovať ako: Cohen, K.M., Finney, S.C., Gibbard, P.L. & Fan, J.-X. (2013; updated) The ICS International Chronostratigraphic Chart. Episodes 36"""@sk ,
+
+    """Bütün kademelerin birimlerinin alt sınırları Küresel Stratotip Kesit ve Noktaların Sınırları (GSSP) kapsamında tanımlanmıştır ve buna Küresel Standart Stratigrafik Yaşlar (GSSA) tarafından uzun zamandır tanımlanan Arkeen ile Proterozoyik de dâhildir. Çizelgeler ve tasdikli GSSP’ler hakkında daha detaylı bilgiler http://www.stratigraphy.org sayfasından temin edilebilir. Bu çizelgenin URL’si aşağıda verilmiştir.
+
+Sayısal yaş değerleri gözden geçirilmeye açıktır ve Fanerozoyik ile Ediyakaran içindeki birimlerin sınırlanmasını sağlamaz; sadece GSSP ile elde edilmiştir. Tasdikli GSSP’den veya sınırlandırılmış sayısal yaş değerlerinden yoksun Fanerozoyikteki sınırlar için, yaklaşık sayısal değer (~) verilmiştir.
+
+Tasdikli Alt Seri/Devreler Ü/G (Üst/Geç), O (Orta) ve A/E (Alt/Erken) olarak kısaltılmıştır. Kuvaterner, Üst Paleojen, Kretase, Jura, Triyas, Permiyen ve Pre-Kambriyen dışında tüm sistemlerin sayısal yaş değerleri “Jeolojik Zaman Tablosu 2012”den alınmıştır (Gradstein vd. 2012); Kuvaterner, Üst Paleojen, Kretase, Jura, Triyas, Permiyen ve Pre-Kambriyen için olan yaşlar, Uluslararası Stratigrafi Komisyonu’nun ilgili alt komisyonları tarafından sağlanmıştır.
+
+Renklendirme kodları için Dünya Jeoloji Haritası Komisyonu (http://www.ccgm.org) temel alınmıştır.
+
+Çizelge tasarımı: K.M. Cohen, D.A.T. Harper, P.L. Gibbard
+
+(c) International Commission on Stratigraphy, Eylül 2024.
+
+Kaynak gösterimi: Cohen, K.M., Finney, S.C., Gibbard, P.L. & Fan, J.-X. (2013; updated) The ICS International Chronostratigraphic Chart. Episodes 36: 199-204."""@tr ,
+
+    """所有全球年代地层单位均由其底界的全球界线层型剖面和点位（GSSP）界定，包括长期由全球标准地层年龄（GSSA）界定的太古宇和元古宇各单位。斜体代表非正式名称或尚未命名单位的临时名称。图件及已批准GSSP的详情参见国际地层委员会官网。本图件的网址见右下角。
+
+年龄值仍在不断修订；显生宇和埃迪卡拉系的单位不能由 年龄界定，而只能由GSSP界定。显生宇中没有确定GSSP或精 确年龄值的单位，则标注了近似年龄值（～）。
+
+已批准的亚统/亚世简写为上/晚、中、下/早；第四系、古 近系上部、白垩系、侏罗系、三叠系、二叠系、寒武系和前寒 武系的年龄值由各分会提供；其他年龄值引自Gradstein等主 编的《地质年代表2012》一书。
+
+所图中各单位的颜色参照了世界地质图委员会 发布的色谱(http://www.ccgm.org)。
+
+本图件由K.M. Cohen、D.A.T. Harper、P.L. Gibbard和N. Car绘制
+
+(c)国际地层委员会，2024年12月（英文版)
+
+(c)国际地层委员会，2024年12月（中文版)
+
+引用：Cohen, K.M., Finney, S.C., Gibbard, P.L. & Fan, J.-X. (2013; updated) The ICS International Chronostratigraphic Chart. Episodes 36: 199-204.
+"""@zh ;
+.
+
+<https://linked.data.gov.au/org/ics>
+    a sdo:Organization ;
+    sdo:name "International Commission on Stratigraphy" ;
+    sdo:alternateName
+        "Comissió Internacional d’Estratigrafia"@ca ,
+        "国 际 地 层 委 员 会"@zh ,
+        "Mezinárodní stratigrafická komise"@cz ,
+        "Kansainvälinen stratigrafian komitea"@fi ,
+        "Commission Internationale de Stratigraphie"@fr ,
+        "Internationale Stratigraphische Kommission"@de ,
+        "Nemzetközi Rétegtani Bizottság"@hu ,
+        "Commissione Internazionale di Stratigrafia"@it ,
+        "国際層序委員会"@jp ,
+        "국 제 층 서 위 원 회"@ko ,
+        "Internationale Commissie voor Stratigrafie"@nl ,
+        "Den internasjonale stratigrafiske kommisjon"@no ,
+        "Comissão Internacional de Estratigrafia"@pt ,
+        "Medzinárodná stratigrafická komisia"@sk ,
+        "Comisión Internacional de Estratigrafía"@es ,
+        "Uluslararası Stratigrafi Komisyonu"@tr ,
+        "Международная комиссия по стратиграфии"@ru ,
+        "Estratigrafiako Nazioarteko Batzordea"@eu ,
+        "Tarptautinė stratigrafijos komisija"@lt ;
+    sdo:url "https://stratigraphy.org"^^xsd:anyURI ;
 .


### PR DESCRIPTION
I've updated the Chart to the latest version - 2024-12 - and removed the version marker from the file name so the Chart can be updated in place more easily from now on.